### PR TITLE
normalize algorithm_name to lowercase in LocalScratchManager

### DIFF
--- a/utils/optimization/local_scratch_manager.py
+++ b/utils/optimization/local_scratch_manager.py
@@ -72,7 +72,7 @@ class LocalScratchManager:
         self.config = config
         self.logger = logger
         self.project_dir = project_dir
-        self.algorithm_name = algorithm_name
+        self.algorithm_name = algorithm_name.lower()
         self.domain_name = config.get('DOMAIN_NAME')
         self.experiment_id = config.get('EXPERIMENT_ID')
         self.mpi_rank = mpi_rank if mpi_rank is not None else 0


### PR DESCRIPTION
This PR changes one line to adjust the algorithm_name on localscratch to be lower case.

This led to issues when staging the results back to the /project folder on HPCs.
