### PR TITLE
Fix: use SLURM_TMPDIR for MPI worker files and adjust imports

### DIFF
--- a/utils/optimization/local_scratch_manager.py
+++ b/utils/optimization/local_scratch_manager.py
@@ -72,7 +72,7 @@ class LocalScratchManager:
         self.config = config
         self.logger = logger
         self.project_dir = project_dir
-        self.algorithm_name = algorithm_name
+        self.algorithm_name = algorithm_name.lower()
         self.domain_name = config.get('DOMAIN_NAME')
         self.experiment_id = config.get('EXPERIMENT_ID')
         self.mpi_rank = mpi_rank if mpi_rank is not None else 0


### PR DESCRIPTION
This PR updates the MPI batch evaluation in `iterative_optimizer.py`:

- Writes `mpi_tasks_*.pkl` and `mpi_worker_*.py` into `$SLURM_TMPDIR`
  (node-local scratch) instead of the project directory.
- Ensures the generated MPI worker script has a correct `sys.path` so
  `iterative_optimizer` and `utils` can be imported reliably.
- Keeps detailed MPI worker logs optional and only written when `LOG_LEVEL=DEBUG`.

**Motivation:**  
On Fir, writing all MPI worker files into `/project` is suspected to contribute to higher metadata load on the Lustre MDT.  
A previous fix (dc103bc7e87a3e655b7997e2dd349ecdd580cd8e) by @DarriEy added MPI worker logging functionality.  
This PR moves additional MPI-related files to node-local scratch to further reduce metadata activity on `/project`.