### PR TITLE
Add RTI International Corporate CLA and Designated Employees

### DIFF
--- a/CLA_SIGNATURES
+++ b/CLA_SIGNATURES
@@ -27,3 +27,20 @@ Name: Befekadu Taddesse Woldegiorgis
 GitHub: befekadu2023
 Email: befekadutaddesse.wol@ucalgary.ca
 Date: 2026-03-30
+---
+
+Organization: Research Triangle Institute (d/b/a RTI International)
+Authorized Signatory: Dean T. Woodward
+Title: Assistant General Counsel, IP & Licensing
+Email: dtw@rti.org
+GitHub Username of Signatory: <dean-woodward-rti>
+Date: 2026-04-14
+Designated Employees:
+Anthony Preucil (apreucil)
+Florian Kluibenschaedl (fkluibenschaedl_rtiintl) 
+Kaylyn Lemons (Sinisgalli) (ksinisgalli-ghpub)
+Paul Micheletty (pdmich)
+Lindsay Parker (lparker-rti)
+Sam Lamont (slamont_rtiintl)
+Katie van Werkhoven (kvanwerkhoven)
+Matthew Denno (mgdenno)


### PR DESCRIPTION
This pull request adds the corporate CLA signature for Research Triangle Institute (d/b/a RTI International).

I am submitting this PR as an authorized signatory on behalf of RTI International.

# Pull Request

## Summary
Briefly describe what this PR does.

## Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Docs / workflow improvement

## Checklist
- [ ] CI and Docs build pass
- [ ] Code style follows project guidelines
- [ ] Tests (if applicable) added or updated
- [ ] Documentation updated
- [ ] [CLA](../blob/main/CLA.md) signed (external contributors)

Closes #<issue-number>
