### PR TITLE
fix(06_decision_ensemble): pin random_seed for DDS reproducibility

### DIFF
--- a/examples/paper_case_studies/configs/configs_nested/06_decision_ensemble/config_fuse_decisions.yaml
+++ b/examples/paper_case_studies/configs/configs_nested/06_decision_ensemble/config_fuse_decisions.yaml
@@ -5,6 +5,7 @@
 system:
   data_dir: ./data/
   code_dir: ./
+  random_seed: 42
 domain:
   name: Bow_at_Banff_lumped_era5
   experiment_id: fuse_decision_ensemble

--- a/tests/unit/config/test_paper_configs.py
+++ b/tests/unit/config/test_paper_configs.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""
+Unit tests for paper case study configuration files.
+
+Pins reproducibility-critical properties in
+examples/paper_case_studies/configs/configs_nested/* so that accidental
+removal of required fields (e.g. random_seed on stochastic experiments)
+is caught in CI rather than in downstream reproducibility runs.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from symfluence.core.config.models import SymfluenceConfig
+
+pytestmark = [pytest.mark.unit, pytest.mark.quick]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONFIGS_NESTED = REPO_ROOT / "examples" / "paper_case_studies" / "configs" / "configs_nested"
+
+
+def _load(path: Path) -> SymfluenceConfig:
+    with path.open() as fh:
+        data = yaml.safe_load(fh)
+    return SymfluenceConfig.model_validate(data)
+
+
+def test_decision_ensemble_sets_random_seed():
+    """Decision ensemble must pin a random_seed for paper reproducibility.
+
+    PW reported best-run performance diverging from the paper (0.89 vs 0.86)
+    with three different decision choices. Root cause: DDS initialized with
+    unseeded RNG. This test prevents the seed from being silently dropped.
+    """
+    cfg = _load(CONFIGS_NESTED / "06_decision_ensemble" / "config_fuse_decisions.yaml")
+    assert cfg.system.random_seed is not None, (
+        "06_decision_ensemble config must set system.random_seed for "
+        "reproducibility of DDS-driven decision enumeration."
+    )
+    assert isinstance(cfg.system.random_seed, int)


### PR DESCRIPTION
## Summary
- `06_decision_ensemble/config_fuse_decisions.yaml` did not set `system.random_seed`, leaving DDS initialized with an unseeded RNG.
- This caused reproducibility divergence from the paper: best run 0.89 vs 0.86, with three different decision choices (perc_lower vs perc_f2sat, onestate_1 vs tens2pll_2, sequential vs rootweight), reported by PW.
- Adds `random_seed: 42` and a unit test that pins the property so it cannot be silently removed.

Addresses co-author feedback item **6.1** in the experiments summary.

## Root cause
`core/config/models/system.py:35` defaults `random_seed` to `None`. Without a value, `base_model_optimizer.py:161-165` skips `_set_random_seeds()` and DDS starts from OS entropy.

## Test plan
- [x] `python -m pytest tests/unit/config/test_paper_configs.py -x -q` — passes
- [x] Config parses and `cfg.system.random_seed == 42`
- [x] Seeded `np.random.random(3)` reproducible across runs
- [ ] Co-author PW re-runs 06_decision_ensemble end-to-end to confirm match with paper (~8h, out of scope for this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)