### PR TITLE
fix(taudem): pin clone to release tag v5.4.0 to prevent HEAD drift

### DIFF
--- a/src/symfluence/cli/external_tools_config.py
+++ b/src/symfluence/cli/external_tools_config.py
@@ -97,7 +97,10 @@ def _register_taudem(common_env: str) -> None:
         'default_path_suffix': 'installs/TauDEM/bin',
         'default_exe': 'pitremove',
         'repository': 'https://github.com/dtarb/TauDEM.git',
-        'branch': None,
+        # Pin to a tagged release so that upstream HEAD drift cannot break
+        # installs. v5.4.0 (Dec 2025) is the most recent tagged release and
+        # ships the CMakeLists layout the TAUDEM_BUILD_COMMAND expects.
+        'branch': 'v5.4.0',
         'install_dir': 'TauDEM',
         'build_commands': [
             common_env,

--- a/tests/unit/cli/test_external_tools_config.py
+++ b/tests/unit/cli/test_external_tools_config.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""
+Regression tests for external build-tool registrations.
+
+Pins reproducibility-critical properties (e.g. TauDEM pinned to a tagged
+release) so that accidental reversions to floating HEAD are caught in CI.
+"""
+
+import pytest
+
+from symfluence.cli.external_tools_config import get_external_tools_definitions
+
+pytestmark = [pytest.mark.unit, pytest.mark.quick]
+
+
+def test_taudem_pinned_to_release_tag():
+    """TauDEM must be pinned to a tagged release, not HEAD.
+
+    AI/IA/AP reported TauDEM build failing intermittently with 'pitremove'
+    missing. Root cause: upstream HEAD drift. Pinning to a tag (git clone -b
+    works for both branches and tags) freezes the install against a known-good
+    version. Dropping the pin would regress to floating HEAD.
+    """
+    tools = get_external_tools_definitions()
+    assert 'taudem' in tools, "TauDEM build instructions must be registered"
+    spec = tools['taudem']
+    assert spec.get('branch'), (
+        "TauDEM must pin 'branch' to a tagged release (e.g. 'v5.4.0'); "
+        "a None branch lets upstream HEAD drift break installs."
+    )
+    # Must look like a release tag, not a moving branch name
+    branch = str(spec['branch'])
+    assert branch.startswith('v') and any(c.isdigit() for c in branch), (
+        f"TauDEM branch '{branch}' does not look like a release tag. "
+        "Pin to something like 'v5.4.0'."
+    )

--- a/tools/quality/broad_exception_allowlist.txt
+++ b/tools/quality/broad_exception_allowlist.txt
@@ -43,8 +43,8 @@ src/symfluence/cli/commands/data_commands.py:86:except Exception as exc:  # noqa
 src/symfluence/cli/commands/fews_commands.py:152:except Exception as exc:  # noqa: BLE001 — wrap-and-raise to domain error
 src/symfluence/cli/commands/fews_commands.py:54:except Exception as exc:  # noqa: BLE001 — wrap-and-raise to domain error
 src/symfluence/cli/commands/fews_commands.py:87:except Exception as exc:  # noqa: BLE001 — wrap-and-raise to domain error
-src/symfluence/cli/external_tools_config.py:431:except Exception:  # noqa: BLE001
-src/symfluence/cli/external_tools_config.py:436:except Exception as exc:  # noqa: BLE001
+src/symfluence/cli/external_tools_config.py:434:except Exception:  # noqa: BLE001
+src/symfluence/cli/external_tools_config.py:439:except Exception as exc:  # noqa: BLE001
 src/symfluence/cli/preset_registry.py:163:except Exception:  # noqa: BLE001
 src/symfluence/cli/preset_registry.py:173:except Exception:  # noqa: BLE001
 src/symfluence/cli/services/tool_installer.py:1019:except Exception:  # noqa: BLE001 — top-level fallback


### PR DESCRIPTION
## Summary
- TauDEM clone used `branch=None`, checking out upstream HEAD at install time. Intermittent build failures (missing `pitremove`) traced to dtarb/TauDEM HEAD drift, reported by AI/IA/AP.
- Pin to tag `v5.4.0` (Dec 2025 release). `git clone -b` accepts tags as well as branches.
- Adds regression test that fails if the pin is dropped.

Addresses co-author feedback item **0.3** in the experiments summary.

## Verification (local, macOS, brew toolchain)
```
$ git clone --depth 1 -b v5.4.0 https://github.com/dtarb/TauDEM.git taudem-verify
$ cd taudem-verify && git describe --tags
v5.4.0
$ mkdir -p build && cd build
$ CC=mpicc CXX=mpicxx cmake -S .. -B . -DCMAKE_BUILD_TYPE=Release  # OK
$ cmake --build . --target pitremove -j 2                          # OK
$ ./src/pitremove
PitRemove version 5.4.0
```

## Test plan
- [x] `python -m pytest tests/unit/cli/test_external_tools_config.py -x -q` — passes
- [x] Tag clone + CMake configure + `pitremove` target build on macOS (above)
- [ ] Smoke test on Linux (co-authors running Ubuntu / Compute Canada)

🤖 Generated with [Claude Code](https://claude.com/claude-code)