### PR TITLE
fix(discretization): actionable error + config fix for missing BYO HRU shp

### DIFF
--- a/examples/paper_case_studies/configs/configs_orig/01_domain_definition/config_Bow_lumped_elev_sd_routing_era5.yaml
+++ b/examples/paper_case_studies/configs/configs_orig/01_domain_definition/config_Bow_lumped_elev_sd_routing_era5.yaml
@@ -56,7 +56,11 @@ ASPECT_PATH: default
 
 # Shapefile settings - Catchment shape (elevation-band HRUs within lumped GRU)
 CATCHMENT_PATH: default
-CATCHMENT_SHP_NAME: Bow_at_Banff_lumped_era5_HRUs_elevation.shp  # Use elevation-band HRU shapefile
+# CATCHMENT_SHP_NAME must be 'default' here so the discretization step
+# generates the HRU shapefile. Setting it to a filename tells the code to
+# skip generation and load that filename as a BYO shapefile — which then
+# fails at step 5 because the file does not yet exist.
+CATCHMENT_SHP_NAME: default  # Auto-named {DOMAIN_NAME}_HRUs_{SUB_GRID_DISCRETIZATION}.shp
 CATCHMENT_SHP_LAT: center_lat
 CATCHMENT_SHP_LON: center_lon
 CATCHMENT_SHP_AREA: HRU_area

--- a/src/symfluence/geospatial/discretization/core.py
+++ b/src/symfluence/geospatial/discretization/core.py
@@ -244,6 +244,32 @@ class DomainDiscretizer(PathResolverMixin):
                 dict_key='CATCHMENT_SHP_NAME'
             )
             if catchment_name != "default":
+                # Non-default name means the user is bringing their own HRU
+                # shapefile — we skip discretization and just sort it. Fail
+                # early with an actionable message if that file doesn't
+                # actually exist, rather than letting sort_catchment_shape()
+                # raise a bare FileNotFoundError from deep inside geopandas.
+                catchment_path_cfg = self._get_config_value(
+                    lambda: self.config.paths.catchment_path,
+                    default='default',
+                    dict_key='CATCHMENT_PATH'
+                )
+                if catchment_path_cfg == "default":
+                    catchment_subpath = self._get_catchment_subpath(catchment_name)
+                    expected_path = self.project_dir / catchment_subpath / catchment_name
+                else:
+                    expected_path = Path(catchment_path_cfg) / catchment_name
+
+                if not expected_path.exists():
+                    raise FileNotFoundError(
+                        f"CATCHMENT_SHP_NAME='{catchment_name}' is set, so SYMFLUENCE "
+                        f"expects a user-provided HRU shapefile at:\n  {expected_path}\n"
+                        f"but that file does not exist. Either:\n"
+                        f"  (a) set CATCHMENT_SHP_NAME: default so the discretization "
+                        f"step generates it, or\n"
+                        f"  (b) place your custom HRU shapefile at the path above."
+                    )
+
                 self.logger.debug(f"Using provided catchment shapefile: {catchment_name}")
 
                 # Just sort the existing shapefile

--- a/tests/unit/geospatial/test_discretization_dispatch.py
+++ b/tests/unit/geospatial/test_discretization_dispatch.py
@@ -84,3 +84,79 @@ def test_discretize_domain_rejects_unknown_method(tmp_path):
 
     with pytest.raises(ValueError):
         discretizer.discretize_domain()
+
+
+def _base_config_with_shp(tmp_path, discretization, shp_name):
+    """Variant of _base_config that sets a custom CATCHMENT_SHP_NAME at construction.
+
+    `SymfluenceConfig.paths` is a frozen pydantic model, so we must pass the
+    non-default value through the constructor rather than mutate post-hoc.
+    """
+    config_dict = {
+        "SYMFLUENCE_DATA_DIR": str(tmp_path),
+        "SYMFLUENCE_CODE_DIR": str(tmp_path / "code"),
+        "DOMAIN_NAME": "test_domain",
+        "DEM_NAME": "default",
+        "DEM_PATH": "default",
+        "DOMAIN_DEFINITION_METHOD": "delineate",
+        "CATCHMENT_PATH": "default",
+        "CATCHMENT_SHP_NAME": shp_name,
+        "CATCHMENT_SHP_GRUID": "GRU_ID",
+        "CATCHMENT_SHP_HRUID": "HRU_ID",
+        "SUB_GRID_DISCRETIZATION": discretization,
+        "EXPERIMENT_ID": "test",
+        "EXPERIMENT_TIME_START": "2020-01-01 00:00",
+        "EXPERIMENT_TIME_END": "2020-01-02 00:00",
+        "FORCING_DATASET": "ERA5",
+        "HYDROLOGICAL_MODEL": "SUMMA",
+    }
+    return SymfluenceConfig(**config_dict)
+
+
+def test_discretize_domain_errors_when_byo_shapefile_missing(tmp_path):
+    """Custom CATCHMENT_SHP_NAME pointing at a non-existent file must fail
+    with an actionable message, not a deep FileNotFoundError from geopandas.
+
+    Reported by NB: setting CATCHMENT_SHP_NAME to the file that the
+    discretization step was supposed to produce caused the code to skip
+    generation and then crash inside sort_catchment_shape() reading the
+    missing file. This test pins the improved diagnostic at discretize_domain
+    boundary so users see the cause and the two ways to fix it.
+    """
+    config = _base_config_with_shp(
+        tmp_path, "elevation", "test_domain_HRUs_elevation.shp"
+    )
+    logger = logging.getLogger("test_discretize_domain_errors_when_byo_shapefile_missing")
+
+    discretizer = DomainDiscretizer(config, logger)
+
+    with pytest.raises(FileNotFoundError) as exc:
+        discretizer.discretize_domain()
+
+    msg = str(exc.value)
+    assert "test_domain_HRUs_elevation.shp" in msg
+    assert "CATCHMENT_SHP_NAME" in msg
+    assert "default" in msg
+
+
+def test_discretize_domain_uses_byo_shapefile_when_it_exists(tmp_path, monkeypatch):
+    """When CATCHMENT_SHP_NAME points at an existing file, skip discretization
+    and just call sort_catchment_shape — that is the legitimate BYO path."""
+    byo_name = "my_custom_hrus.shp"
+    config = _base_config_with_shp(tmp_path, "elevation", byo_name)
+
+    discretizer = DomainDiscretizer(
+        config, logging.getLogger("test_discretize_domain_uses_byo_shapefile_when_it_exists")
+    )
+    byo_subpath = discretizer._get_catchment_subpath(byo_name)
+    byo_path = discretizer.project_dir / byo_subpath / byo_name
+    byo_path.parent.mkdir(parents=True, exist_ok=True)
+    byo_path.write_text("dummy")
+
+    sentinel = Path(tmp_path / "sorted_byo.shp")
+    monkeypatch.setattr(
+        DomainDiscretizer, "sort_catchment_shape", lambda self: sentinel
+    )
+
+    result = discretizer.discretize_domain()
+    assert result == sentinel


### PR DESCRIPTION
## Summary
NB reported `01_domain_definition` failing at step 5 with a bare `FileNotFoundError` from geopandas when running `config_Bow_lumped_elev_sd_routing_era5.yaml`. Root cause was a config/code semantics mismatch, not a missing code path — so this PR fixes both halves:

1. **Config fix** — `configs_orig/01_domain_definition/config_Bow_lumped_elev_sd_routing_era5.yaml:59` set `CATCHMENT_SHP_NAME` to the filename the discretization step was supposed to *produce*. The code reads that as "user is bringing their own HRU shapefile — skip generation". Set it back to `default` and added a comment explaining the semantics. The `10_multivariate_evaluation` configs that reference a pre-generated shapefile from the uncalibrated run are intentional and **unchanged**.

2. **Code fix (diagnostics)** — `src/symfluence/geospatial/discretization/core.py` silently fell through to `sort_catchment_shape()` when `CATCHMENT_SHP_NAME != "default"`, even if that file did not yet exist. The resulting error surfaced deep inside geopandas. Now `discretize_domain()` checks existence up front and raises an actionable `FileNotFoundError` that names the expected path, the config key, and both resolutions. This is a pure diagnostic improvement — no behaviour change for the BYO path that already worked.

Addresses co-author feedback item **1.6**.

## Test plan
- [x] `python -m pytest tests/unit/geospatial/test_discretization_dispatch.py -x -q` — 5/5 passing
- [x] New: `test_discretize_domain_errors_when_byo_shapefile_missing` — asserts the new error message names the path, the config key, and the "default" resolution
- [x] New: `test_discretize_domain_uses_byo_shapefile_when_it_exists` — asserts the legitimate BYO path still works when the file is present
- [ ] Co-author NB re-runs the fixed config end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)