### PR TITLE
fix(acquisition): auto-derive bbox from POUR_POINT_COORDS for point domains

### DIFF
--- a/src/symfluence/data/acquisition/acquisition_service.py
+++ b/src/symfluence/data/acquisition/acquisition_service.py
@@ -231,6 +231,78 @@ class AcquisitionService(ConfigurableMixin):
         self.domain_name = self._get_config_value(lambda: self.config.domain.name)
         self.project_dir = self.data_dir / f"domain_{self.domain_name}"
         self.variable_handler = VariableHandler(self.config, self.logger, 'ERA5', 'SUMMA')
+        self._auto_bbox_logged = False
+
+    def _resolve_bounding_box(self, purpose: str) -> str:
+        """Resolve BOUNDING_BOX_COORDS with auto-derivation for point domains.
+
+        If the user set ``BOUNDING_BOX_COORDS`` explicitly, that value wins.
+        Otherwise, for point domains (``DOMAIN_DEFINITION_METHOD: point``) with
+        ``POUR_POINT_COORDS`` set, a small square bbox is derived from the
+        point using ``POINT_BUFFER_DISTANCE`` (defaults to 0.01°, ~1 km).
+
+        Args:
+            purpose: Short label ("attributes" or "forcing") used in error
+                and log messages so users know which call site failed.
+
+        Returns:
+            The resolved bbox string in "north/west/south/east" order.
+
+        Raises:
+            ValueError: If no bbox is provided and auto-derivation does not
+                apply (non-point domain, or point domain without coords).
+        """
+        bbox_str = self._get_config_value(
+            lambda: self.config.domain.bounding_box_coords, default=None
+        )
+        if bbox_str:
+            return bbox_str
+
+        definition_method = str(self._get_config_value(
+            lambda: self.config.domain.definition_method, default=''
+        )).lower()
+        pour_point = self._get_config_value(
+            lambda: self.config.domain.pour_point_coords, default=None
+        )
+
+        if definition_method == 'point' and pour_point:
+            try:
+                lat_str, lon_str = str(pour_point).split('/')
+                lat, lon = float(lat_str), float(lon_str)
+            except (ValueError, AttributeError) as exc:
+                raise ValueError(
+                    f"Cannot auto-derive BOUNDING_BOX_COORDS for {purpose}: "
+                    f"POUR_POINT_COORDS='{pour_point}' is not in 'lat/lon' format."
+                ) from exc
+
+            buffer = self._get_config_value(
+                lambda: self.config.domain.delineation.point_buffer_distance,
+                default=None,
+                dict_key='POINT_BUFFER_DISTANCE',
+            )
+            if buffer is None:
+                buffer = 0.01  # ~1 km at the equator
+            buffer = float(buffer)
+
+            derived = f"{lat + buffer}/{lon - buffer}/{lat - buffer}/{lon + buffer}"
+            if not self._auto_bbox_logged:
+                self.logger.info(
+                    f"BOUNDING_BOX_COORDS not set; auto-derived {derived} "
+                    f"from POUR_POINT_COORDS={pour_point} with buffer={buffer}° "
+                    f"(point domain). Override by setting BOUNDING_BOX_COORDS "
+                    f"explicitly or POINT_BUFFER_DISTANCE."
+                )
+                self._auto_bbox_logged = True
+            return derived
+
+        raise ValueError(
+            f"BOUNDING_BOX_COORDS is required for cloud-based {purpose} "
+            f"acquisition (DATA_ACCESS: CLOUD) but was not set. Add "
+            f"BOUNDING_BOX_COORDS: 'north/west/south/east' to your "
+            f"configuration file (e.g. '44.5/-87.9/44.2/-87.5'). "
+            f"For point domains, setting POUR_POINT_COORDS alone is enough — "
+            f"the bbox is auto-derived using POINT_BUFFER_DISTANCE (default 0.01°)."
+        )
 
     def _run_parallel_tasks(
         self,
@@ -314,15 +386,7 @@ class AcquisitionService(ConfigurableMixin):
         if data_access == 'CLOUD':
             self.logger.info(f"Cloud data access enabled for attributes (DEM_SOURCE: {dem_source})")
 
-            bbox_str = self._get_config_value(
-                lambda: self.config.domain.bounding_box_coords, default=None)
-            if not bbox_str:
-                raise ValueError(
-                    "BOUNDING_BOX_COORDS is required for cloud-based attribute "
-                    "acquisition (DATA_ACCESS: CLOUD) but was not set. Add "
-                    "BOUNDING_BOX_COORDS: 'north/west/south/east' to your "
-                    "configuration file (e.g. '44.5/-87.9/44.2/-87.5')."
-                )
+            bbox_str = self._resolve_bounding_box("attributes")
 
             try:
                 downloader = CloudForcingDownloader(self.config, self.logger)
@@ -351,7 +415,7 @@ class AcquisitionService(ConfigurableMixin):
                             return downloader.download_alos_dem()
                         elif dem_source == 'merit_hydro':
                             gr = gistoolRunner(self.config, self.logger)
-                            bbox = self._get_config_value(lambda: self.config.domain.bounding_box_coords).split('/')
+                            bbox = bbox_str.split('/')
                             latlims = f"{bbox[0]},{bbox[2]}"
                             lonlims = f"{bbox[1]},{bbox[3]}"
                             self._acquire_elevation_data(gr, dem_dir, latlims, lonlims)
@@ -571,14 +635,7 @@ class AcquisitionService(ConfigurableMixin):
             if not check_cloud_access_availability(forcing_dataset, self.logger):
                 raise ValueError(f"Dataset '{forcing_dataset}' does not support DATA_ACCESS: cloud.")
 
-            if not self._get_config_value(
-                lambda: self.config.domain.bounding_box_coords, default=None):
-                raise ValueError(
-                    "BOUNDING_BOX_COORDS is required for cloud-based forcing "
-                    "acquisition (DATA_ACCESS: CLOUD) but was not set. Add "
-                    "BOUNDING_BOX_COORDS: 'north/west/south/east' to your "
-                    "configuration file."
-                )
+            bbox = self._resolve_bounding_box("forcing")
 
             raw_data_dir = resolve_data_subdir(self.project_dir, 'forcing') / 'raw_data'
             raw_data_dir.mkdir(parents=True, exist_ok=True)
@@ -592,8 +649,8 @@ class AcquisitionService(ConfigurableMixin):
                 enable_checksum=self._get_config_value(lambda: self.config.data.forcing_cache_checksum, default=True, dict_key='FORCING_CACHE_CHECKSUM')
             )
 
-            # Generate cache key
-            bbox = self._get_config_value(lambda: self.config.domain.bounding_box_coords)
+            # Generate cache key (reuse the bbox resolved above so a point
+            # domain's auto-derived bbox ends up in the cache key too).
             time_start = self._get_config_value(lambda: self.config.domain.time_start)
             time_end = self._get_config_value(lambda: self.config.domain.time_end)
 

--- a/tests/unit/data/acquisition/test_bbox_resolution.py
+++ b/tests/unit/data/acquisition/test_bbox_resolution.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""
+Unit tests for AcquisitionService._resolve_bounding_box.
+
+NB reported that point-domain configs (e.g. config_paradise_point.yaml)
+fail data acquisition with 'BOUNDING_BOX_COORDS is required ...' even
+though POUR_POINT_COORDS is set. The resolver auto-derives a small
+square bbox around the pour point for point domains so these configs
+work out of the box.
+"""
+
+import logging
+
+import pytest
+
+from symfluence.core.config.models import SymfluenceConfig
+from symfluence.data.acquisition.acquisition_service import AcquisitionService
+
+pytestmark = [pytest.mark.unit, pytest.mark.quick]
+
+
+def _service(tmp_path, **overrides):
+    """Build an AcquisitionService bound to a minimal config under tmp_path."""
+    config_dict = {
+        "SYMFLUENCE_DATA_DIR": str(tmp_path),
+        "SYMFLUENCE_CODE_DIR": str(tmp_path / "code"),
+        "DOMAIN_NAME": "bbox_test",
+        "EXPERIMENT_ID": "test",
+        "EXPERIMENT_TIME_START": "2020-01-01 00:00",
+        "EXPERIMENT_TIME_END": "2020-01-02 00:00",
+        "FORCING_DATASET": "ERA5",
+        "HYDROLOGICAL_MODEL": "SUMMA",
+        "DOMAIN_DEFINITION_METHOD": "lumped",
+        "SUB_GRID_DISCRETIZATION": "GRUs",
+    }
+    config_dict.update(overrides)
+    config = SymfluenceConfig(**config_dict)
+    return AcquisitionService(
+        config, logging.getLogger("test_bbox_resolution")
+    )
+
+
+def test_explicit_bbox_wins(tmp_path):
+    """Explicit BOUNDING_BOX_COORDS must always take precedence."""
+    svc = _service(
+        tmp_path,
+        DOMAIN_DEFINITION_METHOD="point",
+        POUR_POINT_COORDS="46.78/-121.75",
+        BOUNDING_BOX_COORDS="44.5/-87.9/44.2/-87.5",
+    )
+    assert svc._resolve_bounding_box("attributes") == "44.5/-87.9/44.2/-87.5"
+
+
+def test_point_domain_auto_derives_bbox_with_default_buffer(tmp_path):
+    """Point domain + pour_point_coords + no bbox + no buffer → 0.01° square."""
+    svc = _service(
+        tmp_path,
+        DOMAIN_DEFINITION_METHOD="point",
+        POUR_POINT_COORDS="46.78/-121.75",
+    )
+    bbox = svc._resolve_bounding_box("attributes")
+    parts = [float(p) for p in bbox.split("/")]
+    # Order is north/west/south/east
+    assert parts[0] == pytest.approx(46.79)   # lat + 0.01
+    assert parts[1] == pytest.approx(-121.76)  # lon - 0.01
+    assert parts[2] == pytest.approx(46.77)   # lat - 0.01
+    assert parts[3] == pytest.approx(-121.74)  # lon + 0.01
+
+
+def test_point_domain_auto_derives_with_custom_buffer(tmp_path):
+    """POINT_BUFFER_DISTANCE must be honored when set."""
+    svc = _service(
+        tmp_path,
+        DOMAIN_DEFINITION_METHOD="point",
+        POUR_POINT_COORDS="50.0/-120.0",
+        POINT_BUFFER_DISTANCE=0.05,
+    )
+    bbox = svc._resolve_bounding_box("forcing")
+    parts = [float(p) for p in bbox.split("/")]
+    assert parts[0] == pytest.approx(50.05)
+    assert parts[1] == pytest.approx(-120.05)
+    assert parts[2] == pytest.approx(49.95)
+    assert parts[3] == pytest.approx(-119.95)
+
+
+def test_lumped_domain_without_bbox_raises_actionable_error(tmp_path):
+    """Non-point domains still require an explicit bbox; the error must
+    name the call site (purpose) and point at how to fix it."""
+    svc = _service(
+        tmp_path,
+        DOMAIN_DEFINITION_METHOD="lumped",
+        POUR_POINT_COORDS="50.0/-120.0",
+    )
+    with pytest.raises(ValueError) as exc:
+        svc._resolve_bounding_box("attributes")
+    msg = str(exc.value)
+    assert "BOUNDING_BOX_COORDS" in msg
+    assert "attributes" in msg
+    assert "POUR_POINT_COORDS" in msg  # mentions the point-domain shortcut
+
+
+def test_point_domain_without_pour_point_raises(tmp_path):
+    """A point domain config that forgets POUR_POINT_COORDS must fail
+    cleanly rather than silently auto-deriving from nothing."""
+    svc = _service(
+        tmp_path,
+        DOMAIN_DEFINITION_METHOD="point",
+    )
+    with pytest.raises(ValueError) as exc:
+        svc._resolve_bounding_box("forcing")
+    assert "BOUNDING_BOX_COORDS" in str(exc.value)
+
+
+def test_paradise_point_config_resolves_bbox(tmp_path):
+    """End-to-end: load configs_nested/01_domain_definition/config_paradise_point.yaml
+    (which intentionally omits BOUNDING_BOX_COORDS) and confirm the resolver
+    produces a bbox without raising."""
+    from pathlib import Path
+
+    import yaml
+
+    repo_root = Path(__file__).resolve().parents[4]
+    cfg_path = (
+        repo_root
+        / "examples/paper_case_studies/configs/configs_nested"
+        / "01_domain_definition/config_paradise_point.yaml"
+    )
+    with cfg_path.open() as fh:
+        data = yaml.safe_load(fh)
+    # Override data_dir to keep the test hermetic
+    data.setdefault("system", {})["data_dir"] = str(tmp_path)
+    config = SymfluenceConfig.model_validate(data)
+    assert config.domain.bounding_box_coords is None  # confirms the gap exists
+
+    svc = AcquisitionService(config, logging.getLogger("test_paradise_point"))
+    bbox = svc._resolve_bounding_box("attributes")
+    parts = [float(p) for p in bbox.split("/")]
+    # pour_point_coords: 46.78/-121.75 + default buffer 0.01°
+    assert parts[0] == pytest.approx(46.79)
+    assert parts[2] == pytest.approx(46.77)


### PR DESCRIPTION
## Summary
NB reported `config_paradise_point.yaml` failing data acquisition with `BOUNDING_BOX_COORDS is required for cloud-based attribute/forcing acquisition` even though `POUR_POINT_COORDS` is set. Asking the user to restate a single-point domain as a bbox is redundant — the schema already exposes `POINT_BUFFER_DISTANCE` for exactly this purpose, used by `coastal_delineator.py`.

Add `AcquisitionService._resolve_bounding_box(purpose)` that:
1. **Returns the user-provided `BOUNDING_BOX_COORDS` if set** — no behavior change for existing configs.
2. **For `definition_method='point'` with `pour_point_coords` set**, auto-derives a square bbox of ±`POINT_BUFFER_DISTANCE` (default 0.01°, ~1 km) and logs the derivation once per service instance.
3. **Otherwise raises an actionable error** naming the call site (`attributes` / `forcing`) and pointing at both fixes.

Replace the two CLOUD-path validation sites + the post-validation bbox reads in CLOUD attribute and CLOUD forcing paths. Non-cloud (MAF / datatool) paths unchanged — NB's failure was on the CLOUD path (default for point configs).

`config_paradise_point.yaml` is unchanged (already omits bbox) and now works out of the box.

Addresses co-author feedback item **1.1**.

## Test plan
- [x] `python -m pytest tests/unit/data/acquisition/test_bbox_resolution.py -x -q` — 6/6 passing
- [x] `python -m pytest tests/unit/data/acquisition/ -x -q` — 1846/1846 passing (no regressions)
- [x] End-to-end: paradise_point YAML loads + resolver yields bbox `46.79/-121.76/46.77/-121.74` from `POUR_POINT_COORDS: 46.78/-121.75`
- [ ] NB re-runs `01_domain_definition` end-to-end with the unchanged paradise_point config

🤖 Generated with [Claude Code](https://claude.com/claude-code)