### PR TITLE
feat(05_benchmarking): add FUSE/HBV/GR4J/HYPE benchmark configs

### DIFF
--- a/examples/paper_case_studies/configs/configs_nested/05_benchmarking/README.md
+++ b/examples/paper_case_studies/configs/configs_nested/05_benchmarking/README.md
@@ -4,12 +4,25 @@
 How do calibrated hydrological models compare against simple statistical
 benchmarks (persistence, climatology)?
 
-## Config
-- `config_bow_benchmark.yaml` — Benchmark evaluation at Bow at Banff
+## Configs
+Each config calibrates one model on Bow at Banff and evaluates it against
+the persistence / climatology / long-term-mean benchmarks. Run them
+independently to reproduce one point on Figure 8 each.
+
+- `config_bow_benchmark.yaml` — SUMMA (reference / paper match)
+- `config_bow_benchmark_fuse.yaml` — FUSE
+- `config_bow_benchmark_hbv.yaml` — HBV
+- `config_bow_benchmark_gr4j.yaml` — GR4J (requires R + rpy2 — see top-level README)
+- `config_bow_benchmark_hype.yaml` — HYPE
+
+For other models on Figure 8, copy any of the variants above and replace
+the `model:` block with the corresponding entry from
+`02_model_ensemble/models/config_<model>.yaml`. Keep
+`evaluation.analyses: [benchmarking]` so the benchmarks run.
 
 ## Key Configuration Choices
 - Uses same domain/period as model ensemble (Experiment 2)
-- `ANALYSES: [benchmarking]` triggers benchmark computation
+- `evaluation.analyses: [benchmarking]` triggers benchmark computation
 - Benchmarks: persistence (lag-1), daily/monthly climatology, long-term mean
 
 ## Paper Figures

--- a/examples/paper_case_studies/configs/configs_nested/05_benchmarking/config_bow_benchmark_fuse.yaml
+++ b/examples/paper_case_studies/configs/configs_nested/05_benchmarking/config_bow_benchmark_fuse.yaml
@@ -1,0 +1,48 @@
+# Experiment 5: Benchmarking with FUSE (Section 3.4)
+# Calibrates FUSE on Bow at Banff and evaluates against persistence /
+# climatology / long-term mean baselines. Mirrors config_bow_benchmark.yaml
+# (SUMMA) so users can reproduce Figure 8's FUSE point.
+#
+# To benchmark another model, copy this file and replace the model block
+# with the corresponding entry from
+# 02_model_ensemble/models/config_<model>.yaml, then keep
+# `analyses: [benchmarking]` below.
+
+system:
+  data_dir: ./data/
+  code_dir: ./
+domain:
+  name: Bow_at_Banff_lumped_era5
+  experiment_id: benchmark_fuse
+  time_start: 2002-01-01 01:00
+  time_end: 2009-12-31 23:00
+  calibration_period: 2004-01-01, 2007-12-31
+  evaluation_period: 2008-01-01, 2009-12-31
+  spinup_period: 2002-01-01, 2003-12-31
+  pour_point_coords: 51.1722/-115.5717
+  bounding_box_coords: 51.76/-116.55/50.95/-115.5
+  definition_method: lumped
+  delineation:
+    routing: lumped
+  discretization: GRUs
+data:
+  streamflow_data_provider: WSC
+forcing:
+  dataset: ERA5
+model:
+  hydrological_model: FUSE
+  routing_model: none
+  fuse:
+    spatial_mode: lumped
+    params_to_calibrate: MAXWATR_1,MAXWATR_2,BASERTE,QB_POWR,TIMEDELAY,PERCRTE,FRACTEN,RTFRAC1,MBASE,MFMAX,MFMIN,PXTEMP,LAPSE
+optimization:
+  methods:
+  - iteration
+  algorithm: DDS
+  iterations: 1000
+  metric: KGE
+evaluation:
+  streamflow:
+    station_id: 05BB001
+  analyses:
+  - benchmarking

--- a/examples/paper_case_studies/configs/configs_nested/05_benchmarking/config_bow_benchmark_gr4j.yaml
+++ b/examples/paper_case_studies/configs/configs_nested/05_benchmarking/config_bow_benchmark_gr4j.yaml
@@ -1,0 +1,45 @@
+# Experiment 5: Benchmarking with GR4J (Section 3.4)
+# Calibrates GR4J on Bow at Banff and evaluates against persistence /
+# climatology / long-term mean baselines. Mirrors config_bow_benchmark.yaml
+# (SUMMA) so users can reproduce Figure 8's GR4J point.
+#
+# Requires R + rpy2 (the bootstrap installer attempts rpy2 by default;
+# if R is not on the system, GR4J will not run — see other variants).
+
+system:
+  data_dir: ./data/
+  code_dir: ./
+domain:
+  name: Bow_at_Banff_lumped_era5
+  experiment_id: benchmark_gr4j
+  time_start: 2002-01-01 01:00
+  time_end: 2009-12-31 23:00
+  calibration_period: 2004-01-01, 2007-12-31
+  evaluation_period: 2008-01-01, 2009-12-31
+  spinup_period: 2002-01-01, 2003-12-31
+  pour_point_coords: 51.1722/-115.5717
+  bounding_box_coords: 51.76/-116.55/50.95/-115.5
+  definition_method: lumped
+  delineation:
+    routing: lumped
+  discretization: GRUs
+data:
+  streamflow_data_provider: WSC
+forcing:
+  dataset: ERA5
+model:
+  hydrological_model: GR4J
+  routing_model: none
+  gr:
+    params_to_calibrate: X1,X2,X3,X4,CTG,Kf,Gratio,Albedo_diff
+optimization:
+  methods:
+  - iteration
+  algorithm: DDS
+  iterations: 1000
+  metric: KGE
+evaluation:
+  streamflow:
+    station_id: 05BB001
+  analyses:
+  - benchmarking

--- a/examples/paper_case_studies/configs/configs_nested/05_benchmarking/config_bow_benchmark_hbv.yaml
+++ b/examples/paper_case_studies/configs/configs_nested/05_benchmarking/config_bow_benchmark_hbv.yaml
@@ -1,0 +1,44 @@
+# Experiment 5: Benchmarking with HBV (Section 3.4)
+# Calibrates HBV on Bow at Banff and evaluates against persistence /
+# climatology / long-term mean baselines. Mirrors config_bow_benchmark.yaml
+# (SUMMA) so users can reproduce Figure 8's HBV point.
+
+system:
+  data_dir: ./data/
+  code_dir: ./
+domain:
+  name: Bow_at_Banff_lumped_era5
+  experiment_id: benchmark_hbv
+  time_start: 2002-01-01 01:00
+  time_end: 2009-12-31 23:00
+  calibration_period: 2004-01-01, 2007-12-31
+  evaluation_period: 2008-01-01, 2009-12-31
+  spinup_period: 2002-01-01, 2003-12-31
+  pour_point_coords: 51.1722/-115.5717
+  bounding_box_coords: 51.76/-116.55/50.95/-115.5
+  definition_method: lumped
+  delineation:
+    routing: lumped
+  discretization: GRUs
+data:
+  streamflow_data_provider: WSC
+forcing:
+  dataset: ERA5
+model:
+  hydrological_model: HBV
+  routing_model: none
+  hbv:
+    backend: jax
+    timestep_hours: 24
+    params_to_calibrate: tt,cfmax,sfcf,cfr,cwh,fc,lp,beta,k0,k1,k2,uzl,perc,maxbas
+optimization:
+  methods:
+  - iteration
+  algorithm: DDS
+  iterations: 1000
+  metric: KGE
+evaluation:
+  streamflow:
+    station_id: 05BB001
+  analyses:
+  - benchmarking

--- a/examples/paper_case_studies/configs/configs_nested/05_benchmarking/config_bow_benchmark_hype.yaml
+++ b/examples/paper_case_studies/configs/configs_nested/05_benchmarking/config_bow_benchmark_hype.yaml
@@ -1,0 +1,42 @@
+# Experiment 5: Benchmarking with HYPE (Section 3.4)
+# Calibrates HYPE on Bow at Banff and evaluates against persistence /
+# climatology / long-term mean baselines. Mirrors config_bow_benchmark.yaml
+# (SUMMA) so users can reproduce Figure 8's HYPE point.
+
+system:
+  data_dir: ./data/
+  code_dir: ./
+domain:
+  name: Bow_at_Banff_lumped_era5
+  experiment_id: benchmark_hype
+  time_start: 2002-01-01 01:00
+  time_end: 2009-12-31 23:00
+  calibration_period: 2004-01-01, 2007-12-31
+  evaluation_period: 2008-01-01, 2009-12-31
+  spinup_period: 2002-01-01, 2003-12-31
+  pour_point_coords: 51.1722/-115.5717
+  bounding_box_coords: 51.76/-116.55/50.95/-115.5
+  definition_method: lumped
+  delineation:
+    routing: lumped
+  discretization: GRUs
+data:
+  streamflow_data_provider: WSC
+forcing:
+  dataset: ERA5
+model:
+  hydrological_model: HYPE
+  routing_model: none
+  hype:
+    params_to_calibrate: ttmp,cmlt,cevp,lp,epotdist,rrcs1,rrcs2,rcgrw,rivvel,damp,wcwp,wcfc,wcep,srrcs
+optimization:
+  methods:
+  - iteration
+  algorithm: DDS
+  iterations: 1000
+  metric: KGE
+evaluation:
+  streamflow:
+    station_id: 05BB001
+  analyses:
+  - benchmarking

--- a/tests/unit/config/test_paper_configs.py
+++ b/tests/unit/config/test_paper_configs.py
@@ -42,3 +42,32 @@ def test_decision_ensemble_sets_random_seed():
         "reproducibility of DDS-driven decision enumeration."
     )
     assert isinstance(cfg.system.random_seed, int)
+
+
+# Benchmark configs — one per model family. PW reported that 05_benchmarking
+# only shipped a SUMMA config, making it impossible to reproduce Figure 8's
+# other model points without copy-paste. The variants below close that gap.
+BENCHMARK_CONFIGS = [
+    ("config_bow_benchmark.yaml",       "SUMMA"),
+    ("config_bow_benchmark_fuse.yaml",  "FUSE"),
+    ("config_bow_benchmark_hbv.yaml",   "HBV"),
+    ("config_bow_benchmark_gr4j.yaml",  "GR4J"),
+    ("config_bow_benchmark_hype.yaml",  "HYPE"),
+]
+
+
+@pytest.mark.parametrize("filename,expected_model", BENCHMARK_CONFIGS)
+def test_benchmark_config_loads(filename, expected_model):
+    """Each 05_benchmarking variant must parse, target the right model, and
+    enable the benchmarking analysis. Removing the analysis or swapping the
+    model field would silently invalidate the experiment."""
+    cfg = _load(CONFIGS_NESTED / "05_benchmarking" / filename)
+    assert str(cfg.model.hydrological_model).upper() == expected_model.upper(), (
+        f"{filename} must target {expected_model}; got {cfg.model.hydrological_model}"
+    )
+    analyses = cfg.evaluation.analyses or []
+    analyses_lower = [str(a).lower() for a in analyses]
+    assert "benchmarking" in analyses_lower, (
+        f"{filename} must include 'benchmarking' in evaluation.analyses; "
+        f"got {analyses}"
+    )


### PR DESCRIPTION
## Summary
PW reported that `05_benchmarking` shipped only a SUMMA config, making it impossible to reproduce Figure 8's other model points without copy-paste from `02_model_ensemble`. Investigation confirmed `configs_orig/05_benchmarking/` also had only SUMMA — the multi-model Figure 8 results were never published as configs.

This PR adds four variants mirroring `config_bow_benchmark.yaml` (SUMMA) with the model block swapped from the corresponding `02_model_ensemble/models/config_<model>.yaml`, and `evaluation.analyses: [benchmarking]`:

- `config_bow_benchmark_fuse.yaml`
- `config_bow_benchmark_hbv.yaml`
- `config_bow_benchmark_gr4j.yaml` — requires R + rpy2 (see top-level README)
- `config_bow_benchmark_hype.yaml`

README updated to list the variants and document the recipe for adding more models (copy variant + replace model block from `02_model_ensemble/models/`).

Addresses co-author feedback item **5.2**.

## Test plan
- [x] `python -m pytest tests/unit/config/test_paper_configs.py -x -q` — 6/6 passing (1 random_seed test + 5 parametrized benchmark tests).
- [x] Each new variant parses via `SymfluenceConfig.model_validate(...)`.
- [x] Each variant's `model.hydrological_model` matches the filename and `evaluation.analyses` contains `benchmarking`.
- [ ] Co-author PW reruns one of the new variants end-to-end against the paper's Figure 8 expectations.

## Open question for reviewers
The `02_model_ensemble/models/` directory has 26 model configs. I added benchmark variants for the four PW explicitly named (FUSE/HBV/GR4J/HYPE). Happy to extend to all 26 if useful, but the README now documents the copy-paste recipe so users can self-serve the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)