### PR TITLE
fix(remap): defensive CFIF fallback in EASYMORE weight applier

### DIFF
--- a/src/symfluence/data/preprocessing/resampling/weight_applier.py
+++ b/src/symfluence/data/preprocessing/resampling/weight_applier.py
@@ -237,7 +237,22 @@ class RemappingWeightApplier(ConfigMixin):
         return esmr
 
     def _detect_file_variables(self, file: Path, worker_str: str) -> list:
-        """Detect forcing variables in the file (CFIF or legacy SUMMA names)."""
+        """Detect forcing variables in the file.
+
+        Tries, in order:
+          1. CFIF standard names (e.g. 'air_temperature') — the post-merge
+             expectation.
+          2. Legacy SUMMA-style names (e.g. 'airtemp') — older intermediate
+             format kept for back-compat.
+          3. Raw dataset names from the active dataset handler's rename
+             map (e.g. 'tas' for NEX-GDDP, 'pr' for RDRS-projection,
+             'RDRS_v2.1_P_TT_1.5m' for native RDRS). When matches are
+             found here it means the per-handler ``process_dataset`` step
+             was bypassed; we materialise a renamed copy in-place so
+             EASYMORE produces a CFIF-named output and SUMMA's forcing
+             processor can read it. This is the defensive guard described
+             in feedback item 3.1.
+        """
         try:
             with xr.open_dataset(file, engine="h5netcdf") as ds:
                 # CFIF standard variable names (primary)
@@ -258,9 +273,19 @@ class RemappingWeightApplier(ConfigMixin):
                     available_vars = [v for v in all_legacy_vars if v in ds]
 
                 if not available_vars:
+                    # Defensive guard: try the dataset handler's rename map.
+                    # If raw dataset names are present, the per-handler
+                    # process_dataset step was bypassed somewhere upstream;
+                    # materialise a CFIF-renamed copy in-place so EASYMORE
+                    # gets standardised names.
+                    handler_vars = self._maybe_rename_with_handler(file, ds, worker_str)
+                    if handler_vars:
+                        return handler_vars
+
+                if not available_vars:
                     self.logger.error(
                         f"{worker_str}No forcing variables found in {file.name} "
-                        f"(checked CFIF and legacy SUMMA names). "
+                        f"(checked CFIF, legacy SUMMA, and dataset-handler rename map). "
                         f"Available variables: {list(ds.variables.keys())}"
                     )
                     return []
@@ -279,6 +304,72 @@ class RemappingWeightApplier(ConfigMixin):
             return []
         finally:
             gc.collect()
+
+    def _maybe_rename_with_handler(
+        self,
+        file: Path,
+        ds: xr.Dataset,
+        worker_str: str,
+    ) -> list:
+        """Apply dataset-handler standardisation in-place if raw names are present.
+
+        Returns the list of CFIF variable names now in the file, or [] if
+        nothing matched. Reopens the file because xr does not allow
+        in-place rewrite of the dataset that's currently open.
+        """
+        if self.dataset_handler is None:
+            return []
+        # Discover the rename map for this handler. Older handlers expose
+        # ``get_variable_mapping``; newer ones use ``process_dataset``.
+        rename_map = {}
+        if hasattr(self.dataset_handler, 'get_variable_mapping'):
+            try:
+                full_map = self.dataset_handler.get_variable_mapping() or {}
+                rename_map = {k: v for k, v in full_map.items() if k in ds.variables}
+            except Exception as e:  # noqa: BLE001 — defensive guard, don't kill remap
+                self.logger.debug(f"{worker_str}get_variable_mapping failed: {e}")
+
+        if not rename_map:
+            return []
+
+        self.logger.warning(
+            f"{worker_str}{file.name} has raw dataset variables "
+            f"({sorted(rename_map.keys())}); the per-handler standardisation "
+            f"step appears to have been skipped. Materialising a CFIF-renamed "
+            f"copy in-place so remapping can proceed. "
+            f"This indicates an upstream wiring gap — see feedback item 3.1."
+        )
+        try:
+            ds_load = xr.open_dataset(file, engine="h5netcdf").load()
+            try:
+                ds_proc = self.dataset_handler.process_dataset(ds_load)
+                tmp = file.with_suffix(file.suffix + '.cfif_tmp')
+                ds_proc.to_netcdf(tmp)
+            finally:
+                ds_load.close()
+            tmp.replace(file)
+        except Exception as e:  # noqa: BLE001 — defensive guard, don't kill remap
+            self.logger.error(
+                f"{worker_str}Failed to materialise CFIF-renamed copy of "
+                f"{file.name}: {e}"
+            )
+            return []
+
+        # Re-detect on the rewritten file
+        with xr.open_dataset(file, engine="h5netcdf") as ds2:
+            cfif_now = [
+                v for v in (
+                    'surface_air_pressure', 'surface_downwelling_longwave_flux',
+                    'surface_downwelling_shortwave_flux', 'precipitation_flux',
+                    'air_temperature', 'specific_humidity', 'wind_speed',
+                    'relative_humidity', 'eastward_wind', 'northward_wind',
+                )
+                if v in ds2
+            ]
+        self.logger.info(
+            f"{worker_str}{file.name} now contains CFIF variables: {cfif_now}"
+        )
+        return cfif_now
 
     def _move_output_file(
         self,

--- a/tests/unit/data/test_weight_applier_cfif_fallback.py
+++ b/tests/unit/data/test_weight_applier_cfif_fallback.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""
+Defensive standardisation in the EASYMORE weight applier.
+
+NB reported that 03_forcing_ensemble produced a remap output containing
+raw RDRS / NEX-GDDP variable names ('orog', 'tas', 'pr', 'huss', ...)
+that SUMMA's forcing processor could not consume. Root cause: somewhere
+upstream the per-handler ``process_dataset`` standardisation was
+bypassed, so EASYMORE remapped raw-named variables and propagated them.
+
+The fix in weight_applier._maybe_rename_with_handler is a defensive
+guard: when EASYMORE's input has no CFIF or legacy SUMMA names, fall
+back to the active dataset handler's rename map and materialise a
+CFIF-renamed copy in-place before remapping. This test pins that
+behaviour on a synthetic raw-RDRS file.
+"""
+
+import logging
+from pathlib import Path
+
+import pandas as pd
+import pytest
+import xarray as xr
+
+from symfluence.data.preprocessing.dataset_handlers.rdrs_utils import RDRSHandler
+from symfluence.data.preprocessing.resampling.weight_applier import (
+    RemappingWeightApplier,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.quick]
+
+
+def _write_raw_rdrs_file(path: Path) -> None:
+    """Create a tiny NetCDF with native RDRS v2.1 variable names."""
+    times = pd.date_range("2015-01-01", periods=3, freq="h")
+    ds = xr.Dataset(
+        data_vars={
+            "RDRS_v2.1_P_TT_1.5m": (("time",), [10.0, 11.0, 12.0]),    # Celsius
+            "RDRS_v2.1_P_P0_SFC":  (("time",), [1013.0, 1012.0, 1011.0]),  # mb
+            "RDRS_v2.1_A_PR0_SFC": (("time",), [1.0, 0.0, 2.0]),       # mm/hr
+            "RDRS_v2.1_P_HU_09975": (("time",), [0.005, 0.006, 0.005]),  # spec hum
+            "RDRS_v2.1_P_UVC_10m": (("time",), [3.0, 4.0, 5.0]),       # knots
+            "RDRS_v2.1_P_FB_SFC":  (("time",), [200.0, 250.0, 300.0]),
+            "RDRS_v2.1_P_FI_SFC":  (("time",), [300.0, 320.0, 340.0]),
+        },
+        coords={"time": times},
+    )
+    ds.to_netcdf(path)
+
+
+def test_weight_applier_falls_back_to_handler_rename(tmp_path):
+    """File with raw RDRS names must be standardised in-place to CFIF
+    so EASYMORE produces a CFIF-named output. Without this guard the
+    file would be rejected with 'No forcing variables found'."""
+    raw_file = tmp_path / "test_RDRS_raw.nc"
+    _write_raw_rdrs_file(raw_file)
+
+    # Sanity check: the file truly has no CFIF / SUMMA-legacy names yet
+    with xr.open_dataset(raw_file, engine="h5netcdf") as ds_pre:
+        assert "air_temperature" not in ds_pre
+        assert "airtemp" not in ds_pre
+        assert "RDRS_v2.1_P_TT_1.5m" in ds_pre
+
+    handler = RDRSHandler(
+        {"DOMAIN_NAME": "test", "FORCING_DATASET": "RDRS"},
+        logging.getLogger("test_handler"),
+        tmp_path,
+    )
+    applier = RemappingWeightApplier(
+        config={"DOMAIN_NAME": "test"},
+        project_dir=tmp_path,
+        output_dir=tmp_path,
+        dataset_handler=handler,
+        logger=logging.getLogger("test_applier"),
+    )
+
+    detected = applier._detect_file_variables(raw_file, worker_str="")
+    # Must return a non-empty CFIF-named list — fallback succeeded
+    assert detected, (
+        "Expected the defensive fallback to materialise a CFIF-renamed copy "
+        "and return CFIF variable names; got an empty list."
+    )
+    expected_subset = {
+        "air_temperature",
+        "surface_air_pressure",
+        "precipitation_flux",
+    }
+    assert expected_subset.issubset(set(detected)), (
+        f"Detected variables {detected} missing expected CFIF names {expected_subset}"
+    )
+
+    # Confirm the file on disk was rewritten with CFIF names
+    with xr.open_dataset(raw_file, engine="h5netcdf") as ds_post:
+        assert "air_temperature" in ds_post
+        assert "surface_air_pressure" in ds_post
+        assert "precipitation_flux" in ds_post
+        # Original raw names should be gone
+        assert "RDRS_v2.1_P_TT_1.5m" not in ds_post
+
+
+def test_weight_applier_passes_through_already_cfif_files(tmp_path):
+    """When the file already has CFIF names, the fallback must NOT fire
+    (no spurious rewrite, no warning)."""
+    times = pd.date_range("2015-01-01", periods=3, freq="h")
+    pre = xr.Dataset(
+        data_vars={
+            "air_temperature":      (("time",), [283.0, 284.0, 285.0]),
+            "surface_air_pressure": (("time",), [101300.0, 101200.0, 101100.0]),
+            "precipitation_flux":   (("time",), [0.0003, 0.0, 0.0006]),
+        },
+        coords={"time": times},
+    )
+    cfif_file = tmp_path / "test_cfif.nc"
+    pre.to_netcdf(cfif_file)
+    pre_mtime = cfif_file.stat().st_mtime
+
+    handler = RDRSHandler(
+        {"DOMAIN_NAME": "test", "FORCING_DATASET": "RDRS"},
+        logging.getLogger("test_handler"),
+        tmp_path,
+    )
+    applier = RemappingWeightApplier(
+        config={"DOMAIN_NAME": "test"},
+        project_dir=tmp_path,
+        output_dir=tmp_path,
+        dataset_handler=handler,
+        logger=logging.getLogger("test_applier"),
+    )
+
+    detected = applier._detect_file_variables(cfif_file, worker_str="")
+    assert "air_temperature" in detected
+    assert "surface_air_pressure" in detected
+    assert "precipitation_flux" in detected
+    # File mtime unchanged — no rewrite happened
+    assert cfif_file.stat().st_mtime == pre_mtime, (
+        "Fallback wrongly rewrote a file that already had CFIF names"
+    )

--- a/tools/quality/broad_exception_allowlist.txt
+++ b/tools/quality/broad_exception_allowlist.txt
@@ -363,7 +363,9 @@ src/symfluence/data/preprocessing/resampling/shapefile_processor.py:269:except E
 src/symfluence/data/preprocessing/resampling/shapefile_processor.py:288:except Exception as e:  # noqa: BLE001 — wrap-and-raise to domain error
 src/symfluence/data/preprocessing/resampling/shapefile_processor.py:76:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/preprocessing/resampling/weight_applier.py:160:except Exception as e:  # noqa: BLE001 — preprocessing resilience
-src/symfluence/data/preprocessing/resampling/weight_applier.py:277:except Exception as e:  # noqa: BLE001 — preprocessing resilience
+src/symfluence/data/preprocessing/resampling/weight_applier.py:302:except Exception as e:  # noqa: BLE001 — preprocessing resilience
+src/symfluence/data/preprocessing/resampling/weight_applier.py:329:except Exception as e:  # noqa: BLE001 — defensive guard, don't kill remap
+src/symfluence/data/preprocessing/resampling/weight_applier.py:351:except Exception as e:  # noqa: BLE001 — defensive guard, don't kill remap
 src/symfluence/data/preprocessing/resampling/weight_generator.py:255:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/preprocessing/resampling/weight_generator.py:398:except Exception as e:  # noqa: BLE001 — wrap-and-raise to domain error
 src/symfluence/data/preprocessing/resampling/weight_generator.py:424:except Exception as e:  # noqa: BLE001 — preprocessing resilience


### PR DESCRIPTION
## Summary
NB reported that `03_forcing_ensemble` produced a remap output containing raw RDRS / NEX-GDDP variable names (`orog`, `tas`, `pr`, `huss`, ...) that SUMMA's forcing processor could not consume. Root cause: somewhere upstream the per-handler `process_dataset` standardisation was bypassed, so EASYMORE ran on raw-named files and propagated them.

Defensive guard in `RemappingWeightApplier._detect_file_variables`: when the input file has neither CFIF nor legacy SUMMA names, fall back to the active dataset handler's rename map. If raw dataset names match, materialise a CFIF-renamed copy in-place (using the handler's own `process_dataset`) before EASYMORE runs. Output is then guaranteed CFIF regardless of upstream wiring gaps.

This is the **less-invasive option B** discussed with @DarriEy: keep the per-handler `process_dataset` as the primary path; add a single fail-safe at the EASYMORE boundary that catches the bypass. The bigger model-ready-store refactor (option A) is left for a future PR.

Addresses co-author feedback item **3.1**.

## Behaviour
| Input | Old | New |
|---|---|---|
| CFIF names already present | ✓ pass through | ✓ pass through (mtime unchanged) |
| Legacy SUMMA names already present | ✓ pass through | ✓ pass through |
| Raw dataset names present | ✗ rejected, "No forcing variables found" | ⚠ warn + rewrite to CFIF in-place + proceed |
| Truly no matching variable | ✗ same error | ✗ same error (now mentions handler rename-map check) |

## Test plan
- [x] `python -m pytest tests/unit/data/test_weight_applier_cfif_fallback.py -x -q` — 2/2 passing.
- [x] `python -m pytest tests/unit/data/test_rdrs_processing.py tests/unit/data/test_weight_applier_cfif_fallback.py -x -q` — 4/4 passing (no regressions to existing RDRS handler tests).
- [ ] **End-to-end verification in progress**: Bow at Banff with RDRS forcing + SUMMA run on this Mac (per Darri's request). Will follow up here with the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)