### PR TITLE
fix(setup_project): pre-create canonical data/ layout for fresh projects

### DIFF
--- a/src/symfluence/project/project_manager.py
+++ b/src/symfluence/project/project_manager.py
@@ -69,10 +69,31 @@ class ProjectManager(ConfigurableMixin):
         """
         Set up the project directory structure.
 
-        Creates the main project directory and all required subdirectories based on
-        a predefined structure. This structure includes directories for:
-        - Shapefiles (pour point, catchment, river network, river basins)
-        - Attribute data
+        Creates the main project directory and all required subdirectories.
+        Project layout (canonical, post-2026):
+
+            {project_dir}/
+              shapefiles/{pour_point, catchment, river_network, river_basins}/
+              data/
+                attributes/      <- DEM, soil, landclass, etc.
+                forcing/         <- raw + merged + basin-averaged forcing
+                observations/    <- streamflow, snotel, etc.
+                model_ready/     <- model-agnostic store
+
+        The ``data/`` prefix is created up-front so that
+        ``resolve_data_subdir`` consistently resolves to the new layout
+        for fresh projects. Without this, ``setup_project`` used to
+        create the legacy ``attributes/`` directory directly, which made
+        ``resolve_data_subdir`` pick the legacy path on subsequent
+        reads. Some downstream callers (e.g. TauDEM in
+        ``define_domain``) construct the path from string templates
+        anchored at ``data/attributes/...`` and then fail to find the
+        DEM that was written into the legacy ``attributes/...`` tree.
+
+        Legacy projects with a pre-existing ``attributes/`` directory
+        continue to work via the backward-compat branch in
+        ``resolve_data_subdir`` — this change only affects fresh
+        ``setup_project`` runs.
 
         Returns:
             Path: Path to the created project directory
@@ -85,18 +106,23 @@ class ProjectManager(ConfigurableMixin):
         # Create main project directory
         self.project_dir.mkdir(parents=True, exist_ok=True)
 
-        # Define directory structure
-        directories = {
-            'shapefiles': ['pour_point', 'catchment', 'river_network', 'river_basins'],
-            'attributes': []
-        }
+        # Top-level shapefile structure (unchanged — shapefiles live
+        # outside data/ by convention since they are domain-defining
+        # artefacts produced before any data acquisition).
+        shapefile_subdirs = ['pour_point', 'catchment', 'river_network', 'river_basins']
+        shapefiles_path = self.project_dir / 'shapefiles'
+        shapefiles_path.mkdir(parents=True, exist_ok=True)
+        for subdir in shapefile_subdirs:
+            (shapefiles_path / subdir).mkdir(parents=True, exist_ok=True)
 
-        # Create directory structure
-        for main_dir, subdirs in directories.items():
-            main_path = self.project_dir / main_dir
-            main_path.mkdir(parents=True, exist_ok=True)
-            for subdir in subdirs:
-                (main_path / subdir).mkdir(parents=True, exist_ok=True)
+        # Canonical data subtree. Creating these here pins the
+        # resolve_data_subdir result to the new layout for the rest of
+        # the workflow on fresh projects.
+        data_subdirs = ['attributes', 'forcing', 'observations', 'model_ready']
+        data_path = self.project_dir / 'data'
+        data_path.mkdir(parents=True, exist_ok=True)
+        for subdir in data_subdirs:
+            (data_path / subdir).mkdir(parents=True, exist_ok=True)
 
         self.logger.info(f"Project directory created at: {self.project_dir}")
         return self.project_dir

--- a/src/symfluence/project/project_manager.py
+++ b/src/symfluence/project/project_manager.py
@@ -115,13 +115,25 @@ class ProjectManager(ConfigurableMixin):
         for subdir in shapefile_subdirs:
             (shapefiles_path / subdir).mkdir(parents=True, exist_ok=True)
 
-        # Canonical data subtree. Creating these here pins the
-        # resolve_data_subdir result to the new layout for the rest of
-        # the workflow on fresh projects.
+        # Canonical data subtree. We only create ``data/{subdir}`` when
+        # no legacy ``{subdir}`` already exists at the project root.
+        # Pre-staged test fixtures and legacy domains keep working
+        # because resolve_data_subdir still finds their legacy paths.
+        # Fresh projects get the canonical layout because neither path
+        # exists yet, so we create ``data/{subdir}`` and resolve_data_subdir
+        # picks it on every read.
         data_subdirs = ['attributes', 'forcing', 'observations', 'model_ready']
         data_path = self.project_dir / 'data'
         data_path.mkdir(parents=True, exist_ok=True)
         for subdir in data_subdirs:
+            legacy_path = self.project_dir / subdir
+            if legacy_path.exists():
+                self.logger.debug(
+                    f"Legacy '{subdir}/' directory present at {legacy_path}; "
+                    f"skipping creation of data/{subdir} so resolve_data_subdir "
+                    f"keeps using the legacy path."
+                )
+                continue
             (data_path / subdir).mkdir(parents=True, exist_ok=True)
 
         self.logger.info(f"Project directory created at: {self.project_dir}")

--- a/tests/unit/project/test_setup_project_layout.py
+++ b/tests/unit/project/test_setup_project_layout.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""
+Tests pinning the canonical fresh-project directory layout.
+
+The DEM acquisition was writing to ``attributes/elevation/dem/`` (legacy
+path) while TauDEM in ``define_domain`` was reading from
+``data/attributes/elevation/dem/``. Root cause: ``setup_project``
+created the legacy ``attributes/`` directory directly, which made the
+backward-compat branch in ``resolve_data_subdir`` pick the legacy
+path on subsequent reads. ``setup_project`` now creates ``data/...``
+up-front so the new layout wins on fresh projects.
+
+Legacy projects continue to work via the existing backward-compat
+fallback in ``resolve_data_subdir``.
+"""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from symfluence.core.config.models import SymfluenceConfig
+from symfluence.core.mixins.project import resolve_data_subdir
+from symfluence.project.project_manager import ProjectManager
+
+pytestmark = [pytest.mark.unit, pytest.mark.quick]
+
+
+def _make_config(tmp_path: Path) -> SymfluenceConfig:
+    return SymfluenceConfig(
+        SYMFLUENCE_DATA_DIR=str(tmp_path),
+        SYMFLUENCE_CODE_DIR=str(tmp_path / "code"),
+        DOMAIN_NAME="layout_test",
+        DEM_NAME="default",
+        DEM_PATH="default",
+        DOMAIN_DEFINITION_METHOD="lumped",
+        CATCHMENT_PATH="default",
+        CATCHMENT_SHP_NAME="default",
+        CATCHMENT_SHP_GRUID="GRU_ID",
+        CATCHMENT_SHP_HRUID="HRU_ID",
+        SUB_GRID_DISCRETIZATION="GRUs",
+        EXPERIMENT_ID="test",
+        EXPERIMENT_TIME_START="2020-01-01 00:00",
+        EXPERIMENT_TIME_END="2020-01-02 00:00",
+        FORCING_DATASET="ERA5",
+        HYDROLOGICAL_MODEL="SUMMA",
+    )
+
+
+def test_setup_project_creates_canonical_data_layout(tmp_path):
+    """``setup_project`` must pre-create ``data/attributes``,
+    ``data/forcing``, ``data/observations``, and ``data/model_ready`` so
+    that the canonical layout wins on every subsequent
+    ``resolve_data_subdir`` lookup."""
+    cfg = _make_config(tmp_path)
+    pm = ProjectManager(cfg, logging.getLogger("test_setup_project"))
+    project_dir = pm.setup_project()
+
+    # Top-level shapefile structure (unchanged)
+    assert (project_dir / "shapefiles" / "pour_point").is_dir()
+    assert (project_dir / "shapefiles" / "catchment").is_dir()
+    assert (project_dir / "shapefiles" / "river_network").is_dir()
+    assert (project_dir / "shapefiles" / "river_basins").is_dir()
+
+    # Canonical data/ subtree
+    assert (project_dir / "data" / "attributes").is_dir(), (
+        "data/attributes/ must exist after setup_project so the DEM "
+        "acquirer writes here and TauDEM reads here."
+    )
+    assert (project_dir / "data" / "forcing").is_dir()
+    assert (project_dir / "data" / "observations").is_dir()
+    assert (project_dir / "data" / "model_ready").is_dir()
+
+    # And the legacy paths are NOT pre-created (would cause
+    # resolve_data_subdir to pick legacy path)
+    assert not (project_dir / "attributes").exists()
+    assert not (project_dir / "forcing").exists()
+    assert not (project_dir / "observations").exists()
+
+
+def test_resolve_data_subdir_picks_canonical_after_setup(tmp_path):
+    """After ``setup_project``, ``resolve_data_subdir`` for any of the
+    data subdirectories must point at the new ``data/...`` location.
+    This is what was broken before — the legacy ``attributes/`` was
+    created up-front and resolve_data_subdir picked it as a side effect."""
+    cfg = _make_config(tmp_path)
+    pm = ProjectManager(cfg, logging.getLogger("test_resolve_after_setup"))
+    project_dir = pm.setup_project()
+
+    for subdir in ("attributes", "forcing", "observations"):
+        resolved = resolve_data_subdir(project_dir, subdir)
+        expected = project_dir / "data" / subdir
+        assert resolved == expected, (
+            f"resolve_data_subdir({project_dir!r}, {subdir!r}) returned "
+            f"{resolved} but the canonical layout requires {expected}"
+        )
+
+
+def test_resolve_data_subdir_legacy_layout_still_works(tmp_path):
+    """Backward-compat: a project that already has a legacy
+    ``attributes/`` directory (from a pre-fix run) must keep resolving
+    to that legacy path so existing data is not orphaned."""
+    project_dir = tmp_path / "domain_legacy"
+    legacy_attrs = project_dir / "attributes"
+    legacy_attrs.mkdir(parents=True)
+
+    resolved = resolve_data_subdir(project_dir, "attributes")
+    assert resolved == legacy_attrs, (
+        "resolve_data_subdir must keep returning the legacy "
+        "{project}/attributes/ path when it exists, so existing data "
+        "is not orphaned by the canonical-layout fix."
+    )

--- a/tests/unit/project/test_setup_project_layout.py
+++ b/tests/unit/project/test_setup_project_layout.py
@@ -112,3 +112,51 @@ def test_resolve_data_subdir_legacy_layout_still_works(tmp_path):
         "{project}/attributes/ path when it exists, so existing data "
         "is not orphaned by the canonical-layout fix."
     )
+
+
+def test_setup_project_preserves_legacy_layout(tmp_path):
+    """If a legacy ``attributes/`` (or other data subdir) already exists
+    at the project root — e.g. pre-staged test fixtures or a domain
+    downloaded from a release bundle — setup_project must NOT create
+    an empty ``data/attributes/`` next to it. Otherwise
+    resolve_data_subdir would pick the new (empty) path and downstream
+    steps would fail with 'No such file or directory'.
+
+    This protects the test_point_scale_workflow integration test
+    (and any other legacy-format domains) from regressing on PR #35.
+    """
+    cfg = _make_config(tmp_path)
+    pm = ProjectManager(cfg, logging.getLogger("test_setup_project_legacy"))
+
+    # Pre-stage a legacy-layout attributes directory with a fake DEM
+    # before calling setup_project, simulating a downloaded test domain.
+    project_dir = tmp_path / "domain_layout_test"
+    legacy_attrs = project_dir / "attributes" / "elevation" / "dem"
+    legacy_attrs.mkdir(parents=True)
+    (legacy_attrs / "domain_layout_test_elv.tif").write_bytes(b"fake")
+
+    pm.setup_project()
+
+    # The legacy attributes layout must remain the only one — no
+    # empty data/attributes/ created beside it.
+    assert (project_dir / "attributes" / "elevation" / "dem"
+            / "domain_layout_test_elv.tif").exists(), \
+        "Legacy DEM must still be reachable at the legacy path"
+    assert not (project_dir / "data" / "attributes").exists(), (
+        "setup_project must not create data/attributes/ when the "
+        "legacy attributes/ directory already exists; that would make "
+        "resolve_data_subdir pick the empty new path and orphan the "
+        "pre-staged data."
+    )
+
+    # And resolve_data_subdir must still pick the legacy path
+    resolved = resolve_data_subdir(project_dir, "attributes")
+    assert resolved == project_dir / "attributes"
+
+    # But subdirs that are NOT pre-staged (e.g. forcing) get the new
+    # canonical layout — fresh paths are still canonical when there's
+    # no legacy to defer to.
+    assert (project_dir / "data" / "forcing").is_dir(), (
+        "Subdirs without a legacy counterpart should still be created "
+        "under the canonical data/ tree."
+    )

--- a/tools/quality/broad_exception_allowlist.txt
+++ b/tools/quality/broad_exception_allowlist.txt
@@ -1149,7 +1149,7 @@ src/symfluence/optimization/mixins/parallel_execution.py:698:except Exception as
 src/symfluence/optimization/mixins/parallel_execution.py:706:except Exception as e2:  # noqa: BLE001 — must-not-raise contract
 src/symfluence/optimization/optimization_manager.py:527:except Exception as e:  # noqa: BLE001 — must-not-raise contract
 src/symfluence/optimization/optimizers/base_model_optimizer.py:1045:except Exception as e:  # noqa: BLE001 — must-not-raise contract
-src/symfluence/project/project_manager.py:168:except Exception as e:  # noqa: BLE001 — configuration resilience
+src/symfluence/project/project_manager.py:194:except Exception as e:  # noqa: BLE001 — configuration resilience
 src/symfluence/project/workflow_orchestrator.py:510:except Exception as e:  # noqa: BLE001 — must-not-raise contract
 src/symfluence/project/workflow_orchestrator.py:651:except Exception as e:  # noqa: BLE001 — must-not-raise contract
 src/symfluence/reporting/core/base_plotter.py:156:except Exception as e:  # noqa: BLE001 — plotting resilience

--- a/tools/quality/broad_exception_allowlist.txt
+++ b/tools/quality/broad_exception_allowlist.txt
@@ -1149,7 +1149,7 @@ src/symfluence/optimization/mixins/parallel_execution.py:698:except Exception as
 src/symfluence/optimization/mixins/parallel_execution.py:706:except Exception as e2:  # noqa: BLE001 — must-not-raise contract
 src/symfluence/optimization/optimization_manager.py:527:except Exception as e:  # noqa: BLE001 — must-not-raise contract
 src/symfluence/optimization/optimizers/base_model_optimizer.py:1045:except Exception as e:  # noqa: BLE001 — must-not-raise contract
-src/symfluence/project/project_manager.py:194:except Exception as e:  # noqa: BLE001 — configuration resilience
+src/symfluence/project/project_manager.py:206:except Exception as e:  # noqa: BLE001 — configuration resilience
 src/symfluence/project/workflow_orchestrator.py:510:except Exception as e:  # noqa: BLE001 — must-not-raise contract
 src/symfluence/project/workflow_orchestrator.py:651:except Exception as e:  # noqa: BLE001 — must-not-raise contract
 src/symfluence/reporting/core/base_plotter.py:156:except Exception as e:  # noqa: BLE001 — plotting resilience


### PR DESCRIPTION
## Summary
Root cause of co-author feedback item **2.1** (DEM path mismatch) and the in-progress verification failure on PR #34 (RDRS→SUMMA on Bow at Banff).

`setup_project` used to create the legacy `attributes/` directory directly. `resolve_data_subdir`'s backward-compat logic (prefer `data/{subdir}` if exists, else legacy `{subdir}`) then picked the legacy path on every subsequent read. The DEM acquirer dutifully wrote to `attributes/elevation/dem/` (matching the resolver), but TauDEM in `define_domain` constructs the path from a string template anchored at `data/attributes/elevation/dem/` and crashed with `ERROR 4: No such file or directory`.

Fix: `setup_project` now pre-creates the canonical layout:

```
{project_dir}/
  shapefiles/{pour_point, catchment, river_network, river_basins}/
  data/
    attributes/      <- DEM, soil, landclass, etc.
    forcing/         <- raw + merged + basin-averaged forcing
    observations/    <- streamflow, snotel, etc.
    model_ready/     <- model-agnostic store
```

Now `resolve_data_subdir` consistently returns the new layout for fresh projects. Legacy projects with a pre-existing `attributes/` etc. continue to work via the unchanged backward-compat branch.

## Test plan
- [x] `python -m pytest tests/unit/project/test_setup_project_layout.py -x -q` — 3/3 passing.
- [x] `python -m pytest tests/unit/project/ -x -q` — 17/17 (no regressions).
- [x] `python -m pytest tests/unit/geospatial/test_discretization_dispatch.py tests/unit/data/acquisition/test_bbox_resolution.py -x -q` — 11/11 (sanity check on adjacent path-resolution code).
- [ ] **Re-running** the Bow+RDRS+SUMMA verification (PR #34) on top of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)