### PR TITLE
Enable post-calibration SUMMA SWE visualization with correct unit conversions

### DIFF
--- a/CLA_SIGNATURES
+++ b/CLA_SIGNATURES
@@ -27,3 +27,9 @@ Name: Befekadu Taddesse Woldegiorgis
 GitHub: befekadu2023
 Email: befekadutaddesse.wol@ucalgary.ca
 Date: 2026-03-30
+---
+
+Name: Tristan Montoya
+GitHub: tristanmontoya
+Email: montoya.tristan@gmail.com
+Date: 2026-04-21

--- a/src/symfluence/reporting/orchestrators/calibration_orchestrator.py
+++ b/src/symfluence/reporting/orchestrators/calibration_orchestrator.py
@@ -47,6 +47,27 @@ class CalibrationOrchestrator(ConfigMixin):
         self.analysis_plotter = analysis_plotter
         self.model_output_orchestrator = model_output_orchestrator
 
+    def _find_summa_final_evaluation_file(self, experiment_id: str) -> Optional[Path]:
+        """Find calibrated SUMMA daily output from the final evaluation run."""
+        algorithm = str(self._get_config_value(
+            lambda: self.config.optimization.algorithm,
+            default='optimization',
+            dict_key='ITERATIVE_OPTIMIZATION_ALGORITHM',
+        )).lower()
+        final_eval_file = (
+            self.project_dir / "optimization" / "SUMMA" /
+            f"{algorithm}_{experiment_id}" / "final_evaluation" /
+            f"{experiment_id}_day.nc"
+        )
+        if final_eval_file.exists():
+            return final_eval_file
+
+        optimization_dir = self.project_dir / "optimization" / "SUMMA"
+        candidates = list(optimization_dir.glob(f"*/final_evaluation/{experiment_id}_day.nc"))
+        if not candidates:
+            return None
+        return max(candidates, key=lambda path: path.stat().st_mtime)
+
     @skip_if_not_visualizing()
     def generate_model_comparison_overview(
         self,
@@ -201,7 +222,17 @@ class CalibrationOrchestrator(ConfigMixin):
 
             elif calibration_target in ('swe', 'snow', 'snow_water_equivalent'):
                 # SWE calibration -> SUMMA outputs with SWE observations
-                summa_plots = self.model_output_orchestrator.visualize_summa_outputs(experiment_id)
+                final_eval_file = self._find_summa_final_evaluation_file(experiment_id)
+                if final_eval_file is not None:
+                    self.logger.info(f"Loading calibrated SUMMA output from: {final_eval_file}")
+                    summa_plots = self.analysis_plotter.plot_summa_outputs(
+                        experiment_id,
+                        summa_file=final_eval_file,
+                        output_suffix="calibrated",
+                    )
+                else:
+                    self.logger.info("No calibrated SUMMA final-evaluation output found; using standard simulation output")
+                    summa_plots = self.model_output_orchestrator.visualize_summa_outputs(experiment_id)
                 if 'scalarSWE' in summa_plots:
                     plot_paths['scalarSWE'] = summa_plots['scalarSWE']
                     plot_paths['model_comparison'] = summa_plots['scalarSWE']

--- a/src/symfluence/reporting/orchestrators/calibration_orchestrator.py
+++ b/src/symfluence/reporting/orchestrators/calibration_orchestrator.py
@@ -231,7 +231,7 @@ class CalibrationOrchestrator(ConfigMixin):
                         output_suffix="calibrated",
                     )
                 else:
-                    self.logger.info("No calibrated SUMMA final-evaluation output found; using standard simulation output")
+                    self.logger.info("No calibrated SUMMA final evaluation output found; using standard simulation output")
                     summa_plots = self.model_output_orchestrator.visualize_summa_outputs(experiment_id)
                 if 'scalarSWE' in summa_plots:
                     plot_paths['scalarSWE'] = summa_plots['scalarSWE']

--- a/src/symfluence/reporting/plotters/analysis_plotter.py
+++ b/src/symfluence/reporting/plotters/analysis_plotter.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 import pandas as pd
 
-from symfluence.core.constants import ConfigKeys, UnitConversion
+from symfluence.core.constants import ConfigKeys, UnitConversion, UnitConverter
 from symfluence.reporting.core.base_plotter import BasePlotter
 from symfluence.reporting.panels import (
     FDCPanel,
@@ -669,15 +669,11 @@ class AnalysisPlotter(BasePlotter):
 
         obs_series = df[swe_col].astype(float)
 
-        # Auto-detect units: if max < 50, likely inches; convert to mm
-        if obs_series.max() < 50:
-            obs_series = obs_series * 25.4  # inches to mm
-        elif obs_series.max() < 500:
-            # Could be cm, convert to mm
-            if obs_series.max() < 100:
-                obs_series = obs_series * 10  # cm to mm
-
-        return obs_series
+        return UnitConverter.swe_inches_to_mm(
+            obs_series,
+            auto_detect=True,
+            logger=self.logger,
+        )
 
     @BasePlotter._plot_safe("loading energy flux observations")
     def _load_energy_flux_observations(self, flux_type: str = 'LE') -> Optional[pd.Series]:
@@ -819,7 +815,13 @@ class AnalysisPlotter(BasePlotter):
         })
 
     @BasePlotter._plot_safe("plot_summa_outputs")
-    def plot_summa_outputs(self, experiment_id: str) -> Dict[str, str]:
+    def plot_summa_outputs(
+        self,
+        experiment_id: str,
+        *,
+        summa_file: Optional[Path] = None,
+        output_suffix: str = "",
+    ) -> Dict[str, str]:
         """
         Create professional visualizations for SUMMA output variables.
 
@@ -858,7 +860,8 @@ class AnalysisPlotter(BasePlotter):
             'scalarSenHeatTotal': lambda: self._load_energy_flux_observations('H'),
         }
 
-        summa_file = self.project_dir / "simulations" / experiment_id / "SUMMA" / f"{experiment_id}_day.nc"
+        if summa_file is None:
+            summa_file = self.project_dir / "simulations" / experiment_id / "SUMMA" / f"{experiment_id}_day.nc"
         if not summa_file.exists():
             return {}
 
@@ -1191,7 +1194,8 @@ class AnalysisPlotter(BasePlotter):
                 # Layout adjustment not critical - may fail with complex GridSpec
                 pass
 
-            plot_file = plot_dir / f'{var_name}.png'
+            suffix = f"_{output_suffix}" if output_suffix else ""
+            plot_file = plot_dir / f'{var_name}{suffix}.png'
             self._save_and_close(fig, plot_file)
             plot_paths[str(var_name)] = str(plot_file)
         ds.close()


### PR DESCRIPTION
## Summary of the issue

Previously, the snow-water equivalent (SWE) plots in [01a_point_scale_snotel.ipynb](https://github.com/symfluence-org/SYMFLUENCE/blob/main/examples/01_point_vertical_flux_estimation/01a_point_scale_snotel.ipynb) did not actually visualize the post-calibration run, with `visualize_calibration_results` calling the standard `visualize_summa_outputs` instead. This meant that the post-calibration visualization of SWE was simply a repeat of the plot from the pre-calibration run. 

A second thing I found was that the `AnalysisPlotter`'s `_load_swe_observations` method used an ad-hoc unit conversion that ran as follows:

```
# Auto-detect units: if max < 50, likely inches; convert to mm
        if obs_series.max() < 50:
            obs_series = obs_series * 25.4  # inches to mm
        elif obs_series.max() < 500:
            # Could be cm, convert to mm
            if obs_series.max() < 100:
                obs_series = obs_series * 10  # cm to mm
```

Because the Paradise SNOTEL SWE data, which I understand to be in inches, had a maximum value of 123.1, none of the above conversions were triggered, and thus the plots incorrectly (as far as I understand) used the values in inches, not mm.

## Changes made

1. Added the optional arguments `summa_file` and `output_suffix` to `plot_summa_outputs` which default to the previously hard-coded summa file `self.project_dir / "simulations" / experiment_id / "SUMMA" / f"{experiment_id}_day.nc"` and no output suffix.
2. Added the helper method `_find_summa_final_evaluation_file`, which finds the final evaluation file.
3. Made `visualize_calibration_results` pass the path given by `_find_summa_final_evaluation_file` into `plot_summa_outputs`, so that the final evaluation results get plotted.
4. Revised `_load_swe_observations` in `AnalysisPlotter` to reuse SYMFLUENCE's existing `UnitConverter.swe_inches_to_mm(..., auto_detect=True)`. With this conversion, the maximum observed SWE value lies below the default `SWE_UNIT_THRESHOLD` of 250 inches, and thus the auto-conversion takes place. The resulting post-calibration plot then looks correct to my non-hydrologist eyes, at least:

<img width="4672" height="3216" alt="scalarSWE_calibrated" src="https://private-user-images.githubusercontent.com/19731734/581681234-1f5c6929-2d1c-40d9-907a-dde4cc100802.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzY4MTU0NTEsIm5iZiI6MTc3NjgxNTE1MSwicGF0aCI6Ii8xOTczMTczNC81ODE2ODEyMzQtMWY1YzY5MjktMmQxYy00MGQ5LTkwN2EtZGRlNGNjMTAwODAyLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjA0MjElMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwNDIxVDIzNDU1MVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTgzYTgzMTkxMTcyYmRmYmEzOTFhYTRkMmY5MDYxMTgyOThlNGEyOTViM2U2YzVmM2FlNDg5ODIzOWVlOGVlMTUmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JnJlc3BvbnNlLWNvbnRlbnQtdHlwZT1pbWFnZSUyRnBuZyJ9.Pl1xngBt3i7uHZWo-bZQhtcGjqLDMEpAYg5ADtBQJsg" />

5. Added my information to the CLA file.

Please let me know if there's anything I've missed or misunderstood :)