### PR TITLE
Use correct optimization algorithm key in notebooks

### DIFF
--- a/CLA_SIGNATURES
+++ b/CLA_SIGNATURES
@@ -27,3 +27,9 @@ Name: Befekadu Taddesse Woldegiorgis
 GitHub: befekadu2023
 Email: befekadutaddesse.wol@ucalgary.ca
 Date: 2026-03-30
+---
+
+Name: Tristan Montoya
+GitHub: tristanmontoya
+Email: montoya.tristan@gmail.com
+Date: 2026-04-21

--- a/examples/01_point_vertical_flux_estimation/01a_point_scale_snotel.ipynb
+++ b/examples/01_point_vertical_flux_estimation/01a_point_scale_snotel.ipynb
@@ -134,7 +134,7 @@
     "    # iteration, making it robust to occasional model failures from poor\n",
     "    # parameter combinations — unlike DDS which starts from a single point.\n",
     "    OPTIMIZATION_METHODS=['iteration'],\n",
-    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DE',\n",
+    "    iterative_optimization_algorithm='DE',\n",
     "    optimization_metric='KGE',\n",
     "    optimization_target='swe',\n",
     "    calibration_timestep='daily',\n",

--- a/examples/01_point_vertical_flux_estimation/01a_point_scale_snotel.ipynb
+++ b/examples/01_point_vertical_flux_estimation/01a_point_scale_snotel.ipynb
@@ -134,7 +134,7 @@
     "    # iteration, making it robust to occasional model failures from poor\n",
     "    # parameter combinations — unlike DDS which starts from a single point.\n",
     "    OPTIMIZATION_METHODS=['iteration'],\n",
-    "    optimization_algorithm='DE',\n",
+    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DE',\n",
     "    optimization_metric='KGE',\n",
     "    optimization_target='swe',\n",
     "    calibration_timestep='daily',\n",

--- a/examples/01_point_vertical_flux_estimation/01b_point_scale_fluxnet.ipynb
+++ b/examples/01_point_vertical_flux_estimation/01b_point_scale_fluxnet.ipynb
@@ -133,7 +133,7 @@
     "    # iteration, making it robust to occasional model failures from poor\n",
     "    # parameter combinations.\n",
     "    OPTIMIZATION_METHODS=['iteration'],\n",
-    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DE',\n",
+    "    iterative_optimization_algorithm='DE',\n",
     "    optimization_metric='KGE',\n",
     "    optimization_target='et',\n",
     "    calibration_timestep='daily',\n",

--- a/examples/01_point_vertical_flux_estimation/01b_point_scale_fluxnet.ipynb
+++ b/examples/01_point_vertical_flux_estimation/01b_point_scale_fluxnet.ipynb
@@ -133,7 +133,7 @@
     "    # iteration, making it robust to occasional model failures from poor\n",
     "    # parameter combinations.\n",
     "    OPTIMIZATION_METHODS=['iteration'],\n",
-    "    optimization_algorithm='DE',\n",
+    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DE',\n",
     "    optimization_metric='KGE',\n",
     "    optimization_target='et',\n",
     "    calibration_timestep='daily',\n",

--- a/examples/02_watershed_modelling/02a_basin_lumped.ipynb
+++ b/examples/02_watershed_modelling/02a_basin_lumped.ipynb
@@ -69,7 +69,7 @@
     "    params_to_calibrate='k_soil,theta_sat,aquiferBaseflowExp,aquiferBaseflowRate,qSurfScale,summerLAI,frozenPrecipMultip,Fcapil,tempCritRain,heightCanopyTop,heightCanopyBottom,windReductionParam,vGn_n',\n",
     "    basin_params_to_calibrate='routingGammaScale,routingGammaShape',\n",
     "    optimization_target='streamflow',\n",
-    "    optimization_algorithm='DDS',\n",
+    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',\n",
     "    iterations=100,\n",
     "    optimization_metric='KGE',\n",
     "    calibration_timestep='hourly',\n",

--- a/examples/02_watershed_modelling/02a_basin_lumped.ipynb
+++ b/examples/02_watershed_modelling/02a_basin_lumped.ipynb
@@ -69,7 +69,7 @@
     "    params_to_calibrate='k_soil,theta_sat,aquiferBaseflowExp,aquiferBaseflowRate,qSurfScale,summerLAI,frozenPrecipMultip,Fcapil,tempCritRain,heightCanopyTop,heightCanopyBottom,windReductionParam,vGn_n',\n",
     "    basin_params_to_calibrate='routingGammaScale,routingGammaShape',\n",
     "    optimization_target='streamflow',\n",
-    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',\n",
+    "    iterative_optimization_algorithm='DDS',\n",
     "    iterations=100,\n",
     "    optimization_metric='KGE',\n",
     "    calibration_timestep='hourly',\n",

--- a/examples/02_watershed_modelling/02b_basin_semi_distributed.ipynb
+++ b/examples/02_watershed_modelling/02b_basin_semi_distributed.ipynb
@@ -79,7 +79,7 @@
     "    OPTIMIZATION_METHODS=['iteration'],\n",
     "    params_to_calibrate='minStomatalResistance,cond2photo_slope,vcmax25_canopyTop,jmax25_scale,summerLAI,rootingDepth,soilStressParam,z0Canopy,windReductionParam',\n",
     "    optimization_target='streamflow',\n",
-    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',\n",
+    "    iterative_optimization_algorithm='DDS',\n",
     "    optimization_metric='KGE',\n",
     "    calibration_timestep='hourly',\n",
     ")\n",

--- a/examples/02_watershed_modelling/02b_basin_semi_distributed.ipynb
+++ b/examples/02_watershed_modelling/02b_basin_semi_distributed.ipynb
@@ -79,7 +79,7 @@
     "    OPTIMIZATION_METHODS=['iteration'],\n",
     "    params_to_calibrate='minStomatalResistance,cond2photo_slope,vcmax25_canopyTop,jmax25_scale,summerLAI,rootingDepth,soilStressParam,z0Canopy,windReductionParam',\n",
     "    optimization_target='streamflow',\n",
-    "    optimization_algorithm='DDS',\n",
+    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',\n",
     "    optimization_metric='KGE',\n",
     "    calibration_timestep='hourly',\n",
     ")\n",

--- a/examples/02_watershed_modelling/02c_basin_distributed.ipynb
+++ b/examples/02_watershed_modelling/02c_basin_distributed.ipynb
@@ -80,7 +80,7 @@
     "    OPTIMIZATION_METHODS=['iteration'],\n",
     "    params_to_calibrate='minStomatalResistance,cond2photo_slope,vcmax25_canopyTop,jmax25_scale,summerLAI,rootingDepth,soilStressParam,z0Canopy,windReductionParam',\n",
     "    optimization_target='streamflow',\n",
-    "    optimization_algorithm='DDS',\n",
+    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',\n",
     "    optimization_metric='KGE',\n",
     "    calibration_timestep='hourly',\n",
     ")\n",

--- a/examples/02_watershed_modelling/02c_basin_distributed.ipynb
+++ b/examples/02_watershed_modelling/02c_basin_distributed.ipynb
@@ -80,7 +80,7 @@
     "    OPTIMIZATION_METHODS=['iteration'],\n",
     "    params_to_calibrate='minStomatalResistance,cond2photo_slope,vcmax25_canopyTop,jmax25_scale,summerLAI,rootingDepth,soilStressParam,z0Canopy,windReductionParam',\n",
     "    optimization_target='streamflow',\n",
-    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',\n",
+    "    iterative_optimization_algorithm='DDS',\n",
     "    optimization_metric='KGE',\n",
     "    calibration_timestep='hourly',\n",
     ")\n",

--- a/examples/04_workshop_notebooks/04a_logan_river_workshop.ipynb
+++ b/examples/04_workshop_notebooks/04a_logan_river_workshop.ipynb
@@ -194,7 +194,7 @@
     "    # Calibration (applies to all models)\n",
     "    OPTIMIZATION_METHODS=['iteration'],\n",
     "    optimization_target='streamflow',\n",
-    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',\n",
+    "    iterative_optimization_algorithm='DDS',\n",
     "    optimization_metric='KGE',\n",
     "    calibration_timestep='hourly',\n",
     "    iterations=100,\n",

--- a/examples/04_workshop_notebooks/04a_logan_river_workshop.ipynb
+++ b/examples/04_workshop_notebooks/04a_logan_river_workshop.ipynb
@@ -194,7 +194,7 @@
     "    # Calibration (applies to all models)\n",
     "    OPTIMIZATION_METHODS=['iteration'],\n",
     "    optimization_target='streamflow',\n",
-    "    optimization_algorithm='DDS',\n",
+    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',\n",
     "    optimization_metric='KGE',\n",
     "    calibration_timestep='hourly',\n",
     "    iterations=100,\n",

--- a/examples/04_workshop_notebooks/04b_provo_river_workshop.ipynb
+++ b/examples/04_workshop_notebooks/04b_provo_river_workshop.ipynb
@@ -208,7 +208,7 @@
     "    \n",
     "    # Optimization configuration\n",
     "    optimization_target='streamflow',\n",
-    "    optimization_algorithm='DDS',               # Dynamically Dimensioned Search\n",
+    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',               # Dynamically Dimensioned Search\n",
     "    optimization_metric='KGE',                  # Kling-Gupta Efficiency\n",
     "    calibration_timestep='hourly',\n",
     "    iterations=5000,                             # Number of calibration iterations\n",

--- a/examples/04_workshop_notebooks/04b_provo_river_workshop.ipynb
+++ b/examples/04_workshop_notebooks/04b_provo_river_workshop.ipynb
@@ -208,7 +208,7 @@
     "    \n",
     "    # Optimization configuration\n",
     "    optimization_target='streamflow',\n",
-    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',               # Dynamically Dimensioned Search\n",
+    "    iterative_optimization_algorithm='DDS',               # Dynamically Dimensioned Search\n",
     "    optimization_metric='KGE',                  # Kling-Gupta Efficiency\n",
     "    calibration_timestep='hourly',\n",
     "    iterations=5000,                             # Number of calibration iterations\n",

--- a/examples/04_workshop_notebooks/04b_provo_river_workshop.ipynb
+++ b/examples/04_workshop_notebooks/04b_provo_river_workshop.ipynb
@@ -208,7 +208,7 @@
     "    \n",
     "    # Optimization configuration\n",
     "    optimization_target='streamflow',\n",
-    "    iterative_optimization_algorithm='DDS',  # Dynamically Dimensioned Search\n",
+    "    iterative_optimization_algorithm='DDS',     # Dynamically Dimensioned Search\n",
     "    optimization_metric='KGE',                  # Kling-Gupta Efficiency\n",
     "    calibration_timestep='hourly',\n",
     "    iterations=5000,                             # Number of calibration iterations\n",

--- a/examples/04_workshop_notebooks/04b_provo_river_workshop.ipynb
+++ b/examples/04_workshop_notebooks/04b_provo_river_workshop.ipynb
@@ -208,7 +208,7 @@
     "    \n",
     "    # Optimization configuration\n",
     "    optimization_target='streamflow',\n",
-    "    iterative_optimization_algorithm='DDS',               # Dynamically Dimensioned Search\n",
+    "    iterative_optimization_algorithm='DDS',  # Dynamically Dimensioned Search\n",
     "    optimization_metric='KGE',                  # Kling-Gupta Efficiency\n",
     "    calibration_timestep='hourly',\n",
     "    iterations=5000,                             # Number of calibration iterations\n",

--- a/examples/04_workshop_notebooks/04c_sagehen_creek_workshop.ipynb
+++ b/examples/04_workshop_notebooks/04c_sagehen_creek_workshop.ipynb
@@ -273,7 +273,7 @@
     "\n",
     "    # Optimization configuration\n",
     "    optimization_target='streamflow',\n",
-    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',\n",
+    "    iterative_optimization_algorithm='DDS',\n",
     "    optimization_metric='KGE',\n",
     "    calibration_timestep='daily',\n",
     "    iterations=300,\n",

--- a/examples/04_workshop_notebooks/04c_sagehen_creek_workshop.ipynb
+++ b/examples/04_workshop_notebooks/04c_sagehen_creek_workshop.ipynb
@@ -273,7 +273,7 @@
     "\n",
     "    # Optimization configuration\n",
     "    optimization_target='streamflow',\n",
-    "    optimization_algorithm='DDS',\n",
+    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',\n",
     "    optimization_metric='KGE',\n",
     "    calibration_timestep='daily',\n",
     "    iterations=300,\n",

--- a/examples/04_workshop_notebooks/04d_diguillin_river_chile.ipynb
+++ b/examples/04_workshop_notebooks/04d_diguillin_river_chile.ipynb
@@ -128,7 +128,7 @@
     "    # Calibration\n",
     "    OPTIMIZATION_METHODS=['iteration'],\n",
     "    optimization_target='streamflow',\n",
-    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',\n",
+    "    iterative_optimization_algorithm='DDS',\n",
     "    optimization_metric='KGE',\n",
     "    iterations=100,\n",
     ")\n",

--- a/examples/04_workshop_notebooks/04d_diguillin_river_chile.ipynb
+++ b/examples/04_workshop_notebooks/04d_diguillin_river_chile.ipynb
@@ -128,7 +128,7 @@
     "    # Calibration\n",
     "    OPTIMIZATION_METHODS=['iteration'],\n",
     "    optimization_target='streamflow',\n",
-    "    optimization_algorithm='DDS',\n",
+    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',\n",
     "    optimization_metric='KGE',\n",
     "    iterations=100,\n",
     ")\n",


### PR DESCRIPTION
## Summary of the issue
The notebooks used the keyword `optimization_algorithm` keyword, which is _not_ aliased to `ITERATIVE_OPTIMIZATION_ALGORITHM` in `SymfluenceConfig.from_minimal` and thus does not override the default PSO algorithm with the specified one. 

## Changes made
This PR replaces the `optimization_algorithm` keyword with `iterative_optimization_algorithm` (keeping the previous keyword's lowercase convention), thereby using the specified algorithm. For example, in [01a_point_scale_snotel.ipynb](https://github.com/symfluence-org/SYMFLUENCE/blob/main/examples/01_point_vertical_flux_estimation/01a_point_scale_snotel.ipynb), the notebook specified `optimization_algorithm='DE'` but the resulting calibration run actually used `PSO`. With the changes here, `DE` is actually used.

Optionally, we could decide to use the standard `NORMALIZATION_ALIASES` in `SymfluenceConfig.from_minimal`, but I did not make this change (please let me know if you think this should be done).

**Note:** I added my name to the CLA signatures as with the other PR to try to calm down the github-actions bot, but the check still fails for some reason (maybe I had to do it in the initial commit?). 