### PR TITLE
fix(dem): align cloud paper configs to copernicus + actionable MERIT error

### DIFF
--- a/examples/paper_case_studies/configs/configs_orig/11_data_pipeline/config_Bow_pipeline_distributed.yaml
+++ b/examples/paper_case_studies/configs/configs_orig/11_data_pipeline/config_Bow_pipeline_distributed.yaml
@@ -33,7 +33,7 @@ ELEVATION_BAND_SIZE: 200  # metres
 MIN_HRU_SIZE: 4.0         # km²
 
 # DEM and geospatial attributes
-DEM_SOURCE: MERIT
+DEM_SOURCE: copernicus   # Cloud-reachable default (Copernicus GLO-30). Use 'merit_hydro' only with DATA_ACCESS: hpc via MAF gistool.
 DEM_PATH: default
 SOIL_CLASS_PATH: default
 LAND_CLASS_PATH: default

--- a/examples/paper_case_studies/configs/configs_orig/11_data_pipeline/config_Bow_pipeline_era5.yaml
+++ b/examples/paper_case_studies/configs/configs_orig/11_data_pipeline/config_Bow_pipeline_era5.yaml
@@ -33,7 +33,7 @@ CATCHMENT_SHP_PATH: default
 RIVER_NETWORK_SHP_PATH: default
 
 # DEM and geospatial attributes
-DEM_SOURCE: MERIT
+DEM_SOURCE: copernicus   # Cloud-reachable default (Copernicus GLO-30). Use 'merit_hydro' only with DATA_ACCESS: hpc via MAF gistool.
 DEM_PATH: default
 SOIL_CLASS_PATH: default
 LAND_CLASS_PATH: default

--- a/examples/paper_case_studies/configs/configs_orig/11_data_pipeline/config_Iceland_pipeline_era5.yaml
+++ b/examples/paper_case_studies/configs/configs_orig/11_data_pipeline/config_Iceland_pipeline_era5.yaml
@@ -34,7 +34,7 @@ ELEVATION_BAND_SIZE: 200  # metres
 MIN_HRU_SIZE: 10.0        # km² (larger minimum for regional domain)
 
 # DEM and geospatial attributes
-DEM_SOURCE: MERIT
+DEM_SOURCE: copernicus   # Cloud-reachable default (Copernicus GLO-30). Use 'merit_hydro' only with DATA_ACCESS: hpc via MAF gistool.
 DEM_PATH: default
 SOIL_CLASS_PATH: default
 LAND_CLASS_PATH: default

--- a/examples/paper_case_studies/configs/configs_orig/11_data_pipeline/config_Paradise_pipeline_era5.yaml
+++ b/examples/paper_case_studies/configs/configs_orig/11_data_pipeline/config_Paradise_pipeline_era5.yaml
@@ -32,7 +32,7 @@ CATCHMENT_SHP_PATH: default
 RIVER_NETWORK_SHP_PATH: none
 
 # DEM and geospatial attributes
-DEM_SOURCE: MERIT
+DEM_SOURCE: copernicus   # Cloud-reachable default (Copernicus GLO-30). Use 'merit_hydro' only with DATA_ACCESS: hpc via MAF gistool.
 DEM_PATH: default
 SOIL_CLASS_PATH: default
 LAND_CLASS_PATH: default

--- a/src/symfluence/data/acquisition/acquisition_service.py
+++ b/src/symfluence/data/acquisition/acquisition_service.py
@@ -421,7 +421,37 @@ class AcquisitionService(ConfigurableMixin):
                             self._acquire_elevation_data(gr, dem_dir, latlims, lonlims)
                             return dem_dir / f"domain_{self.domain_name}_elv.tif"
                         else:
-                            raise ValueError(f"Unsupported DEM_SOURCE: '{dem_source}'.")
+                            # Surface common misconfigurations with an actionable
+                            # hint instead of just "unsupported". MERIT-Hydro in
+                            # particular looks superficially right — it's in many
+                            # of our HPC paper configs — but it's only reachable
+                            # via the MAF gistool path, not cloud. If the user
+                            # set it with DATA_ACCESS=cloud they need a
+                            # cloud-reachable source.
+                            lower = str(dem_source).lower()
+                            accepted_cloud = [
+                                'copernicus', 'copdem90', 'copernicus_90',
+                                'fabdem', 'nasadem', 'srtm', 'etopo',
+                                'mapzen', 'alos',
+                            ]
+                            hint = ""
+                            if 'merit' in lower:
+                                hint = (
+                                    " MERIT-Hydro is only available via the MAF "
+                                    "gistool path (DATA_ACCESS: hpc). For "
+                                    "DATA_ACCESS: cloud, use 'copernicus' "
+                                    "(the default) or one of: "
+                                    f"{', '.join(accepted_cloud)}."
+                                )
+                            else:
+                                hint = (
+                                    f" Accepted cloud DEM sources: "
+                                    f"{', '.join(accepted_cloud)}."
+                                )
+                            raise ValueError(
+                                f"Unsupported DEM_SOURCE: '{dem_source}' for "
+                                f"DATA_ACCESS: cloud.{hint}"
+                            )
                     attr_tasks.append(('DEM', _acquire_dem))
                 else:
                     self.logger.info("Skipping DEM acquisition (DOWNLOAD_DEM is False)")

--- a/tests/unit/data/acquisition/test_dem_source_error_hints.py
+++ b/tests/unit/data/acquisition/test_dem_source_error_hints.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""
+Regression tests for the DEM_SOURCE error message.
+
+SH reported that paper configs using ``DEM_SOURCE: MERIT`` failed with a
+bare "unsupported" message and the fix was discovered by trial and error
+(switching to ``copernicus``). MERIT-Hydro is only reachable via the MAF
+gistool (``DATA_ACCESS: hpc``) path; with ``DATA_ACCESS: cloud`` the
+request cannot succeed. Rather than silently aliasing ``MERIT`` to
+something the cloud dispatcher could not serve, we surface a specific
+actionable hint in the error so users understand the underlying
+constraint.
+
+The four paper configs in ``configs_orig/11_data_pipeline/`` that
+previously said ``DEM_SOURCE: MERIT`` were also updated to
+``copernicus`` in the same PR; this test only pins the error-message
+contract on the code side.
+"""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from symfluence.core.config.models import SymfluenceConfig
+from symfluence.data.acquisition.acquisition_service import AcquisitionService
+
+pytestmark = [pytest.mark.unit, pytest.mark.quick]
+
+
+def _service(tmp_path, **overrides):
+    cfg = {
+        "SYMFLUENCE_DATA_DIR": str(tmp_path),
+        "SYMFLUENCE_CODE_DIR": str(tmp_path / "code"),
+        "DOMAIN_NAME": "dem_err_test",
+        "EXPERIMENT_ID": "test",
+        "EXPERIMENT_TIME_START": "2020-01-01 00:00",
+        "EXPERIMENT_TIME_END": "2020-01-02 00:00",
+        "FORCING_DATASET": "ERA5",
+        "HYDROLOGICAL_MODEL": "SUMMA",
+        "DOMAIN_DEFINITION_METHOD": "lumped",
+        "SUB_GRID_DISCRETIZATION": "GRUs",
+        "BOUNDING_BOX_COORDS": "44.5/-87.9/44.2/-87.5",
+        "DATA_ACCESS": "cloud",
+    }
+    cfg.update(overrides)
+    return AcquisitionService(
+        SymfluenceConfig(**cfg), logging.getLogger("dem_err_test")
+    )
+
+
+def _trigger_dem_dispatch(svc):
+    """Drive acquire_attributes far enough to hit the DEM-source branch.
+
+    The cloud path reaches the unsupported-DEM_SOURCE raise inside a
+    task appended to a parallel executor. We run the single task inline
+    to bubble the raise directly.
+    """
+    # The raise lives in the cloud branch only; stub out the downloader
+    # so we don't actually hit Copernicus etc.
+    with patch(
+        "symfluence.data.acquisition.acquisition_service.CloudForcingDownloader"
+    ), patch.object(
+        AcquisitionService, "_run_parallel_tasks",
+        side_effect=lambda tasks, desc="": {
+            name: (fn() if callable(fn) else None)  # actually execute the closure
+            for name, fn in tasks
+        },
+    ):
+        svc.acquire_attributes()
+
+
+def test_merit_on_cloud_gives_actionable_error(tmp_path):
+    """DEM_SOURCE=MERIT with DATA_ACCESS=cloud must name MERIT
+    specifically, explain that it needs hpc + gistool, and list cloud
+    alternatives."""
+    svc = _service(tmp_path, DEM_SOURCE="MERIT")
+    with pytest.raises(Exception) as exc:
+        _trigger_dem_dispatch(svc)
+    msg = str(exc.value)
+    # Specific to MERIT → name the cloud/hpc distinction
+    assert "MERIT" in msg or "merit" in msg.lower()
+    assert "hpc" in msg.lower() or "MAF" in msg or "gistool" in msg
+    assert "copernicus" in msg.lower()
+
+
+def test_generic_unsupported_dem_lists_cloud_alternatives(tmp_path):
+    """For any other unsupported DEM_SOURCE, the error lists the cloud
+    alternatives so the user can pick one without spelunking."""
+    svc = _service(tmp_path, DEM_SOURCE="not_a_real_source")
+    with pytest.raises(Exception) as exc:
+        _trigger_dem_dispatch(svc)
+    msg = str(exc.value)
+    assert "not_a_real_source" in msg
+    # Must list at least the default and one alternative
+    assert "copernicus" in msg.lower()
+    assert "fabdem" in msg.lower() or "nasadem" in msg.lower()


### PR DESCRIPTION
## Summary
SH reported ``DEM_SOURCE: MERIT`` rejected as unsupported in v0.8.2, forcing a manual switch to ``copernicus`` to proceed. Investigation found:

- All four ``configs_orig/11_data_pipeline/`` paper configs declare ``DEM_SOURCE: MERIT`` and none of them set ``DATA_ACCESS`` → they default to cloud.
- MERIT-Hydro is only reachable via the MAF gistool path (``DATA_ACCESS: hpc``). It cannot be served on the cloud path. So those configs have been broken-as-written for any reviewer following the cloud install path.
- The dispatcher error was a bare "unsupported" that didn't name the cloud/hpc mismatch, so the fix was discovered by trial and error.

Deliberately **not** adding a silent alias from ``MERIT → merit_hydro`` — that would let a cloud user believe they're using MERIT-Hydro when the cloud path can't actually serve it. Fail-loud with a useful hint is the right contract.

## Changes
- Swap ``DEM_SOURCE: MERIT → copernicus`` in the 4 paper configs (cloud-reachable default, 30m Copernicus GLO-30). Inline comment documents the HPC alternative.
- ``acquisition_service.py`` cloud-DEM dispatcher raises with a specific hint when the user set ``MERIT`` (names the hpc/MAF/gistool constraint) and a generic list of accepted cloud sources otherwise.
- Regression test pins both hint paths.

Addresses co-author feedback item **11.14**.

## Test plan
- [x] ``python -m pytest tests/unit/data/acquisition/test_dem_source_error_hints.py -x -q`` — 2/2
- [x] All four paper configs still parse via ``SymfluenceConfig.model_validate(...)``
- [ ] Co-author SH re-runs one of the 11_data_pipeline configs end-to-end with the new default

🤖 Generated with [Claude Code](https://claude.com/claude-code)