### PR TITLE
fix(templates): align scaffold time windows to paper Figure 4

### DIFF
--- a/src/symfluence/resources/config_templates/config_template_comprehensive.yaml
+++ b/src/symfluence/resources/config_templates/config_template_comprehensive.yaml
@@ -2731,14 +2731,14 @@ SIMULATIONS_PATH: default
 # ================================================================================
 
 # CALIBRATION_PERIOD
-#   Type:        str
-#   Default:     None
-#   Source:      DomainConfig (domain.py)
-#   Usage:      14
 # The default below mirrors the paper Figure 4 calibration window for
 # the Bow at Banff case study (Eythorsson et al. 2026b). Replace with
 # your own domain's window when adapting this template. The calibration
 # window must lie inside EXPERIMENT_TIME_START..EXPERIMENT_TIME_END.
+#   Type:        str
+#   Default:     None
+#   Source:      DomainConfig (domain.py)
+#   Usage:      14
 CALIBRATION_PERIOD: "2004-01-01, 2007-12-31"
 
 # CALIBRATION_START_DATE
@@ -2802,13 +2802,13 @@ DOMAIN_NAME: "example_basin"
 BOUNDING_BOX_COORDS: null
 
 # EVALUATION_PERIOD
+# Mirrors the paper Figure 4 evaluation window for the Bow at Banff
+# case study. Must lie inside EXPERIMENT_TIME_START..EXPERIMENT_TIME_END
+# and must not overlap CALIBRATION_PERIOD.
 #   Type:        str
 #   Default:     None
 #   Source:      DomainConfig (domain.py)
 #   Usage:      7
-# Mirrors the paper Figure 4 evaluation window for the Bow at Banff
-# case study. Must lie inside EXPERIMENT_TIME_START..EXPERIMENT_TIME_END
-# and must not overlap CALIBRATION_PERIOD.
 EVALUATION_PERIOD: "2008-01-01, 2009-12-31"
 
 # EXPERIMENT_ID
@@ -2819,14 +2819,14 @@ EVALUATION_PERIOD: "2008-01-01, 2009-12-31"
 EXPERIMENT_ID: "run_1"
 
 # EXPERIMENT_TIME_END
-#   Type:        str
-#   Default:     None
-#   Source:      DomainConfig (domain.py)
-#   Usage:      54
 # The default below mirrors the paper Figure 4 simulation window for
 # the Bow at Banff case study (2002-01-01 through 2009-12-31, with a
 # 2002–2003 spin-up, 2004–2007 calibration, 2008–2009 evaluation).
 # Replace with your own simulation window when adapting this template.
+#   Type:        str
+#   Default:     None
+#   Source:      DomainConfig (domain.py)
+#   Usage:      54
 EXPERIMENT_TIME_END: "2009-12-31 23:00"
 
 # EXPERIMENT_TIME_START

--- a/src/symfluence/resources/config_templates/config_template_comprehensive.yaml
+++ b/src/symfluence/resources/config_templates/config_template_comprehensive.yaml
@@ -2735,7 +2735,11 @@ SIMULATIONS_PATH: default
 #   Default:     None
 #   Source:      DomainConfig (domain.py)
 #   Usage:      14
-CALIBRATION_PERIOD: null
+# The default below mirrors the paper Figure 4 calibration window for
+# the Bow at Banff case study (Eythorsson et al. 2026b). Replace with
+# your own domain's window when adapting this template. The calibration
+# window must lie inside EXPERIMENT_TIME_START..EXPERIMENT_TIME_END.
+CALIBRATION_PERIOD: "2004-01-01, 2007-12-31"
 
 # CALIBRATION_START_DATE
 #   Type:        str
@@ -2802,7 +2806,10 @@ BOUNDING_BOX_COORDS: null
 #   Default:     None
 #   Source:      DomainConfig (domain.py)
 #   Usage:      7
-EVALUATION_PERIOD: null
+# Mirrors the paper Figure 4 evaluation window for the Bow at Banff
+# case study. Must lie inside EXPERIMENT_TIME_START..EXPERIMENT_TIME_END
+# and must not overlap CALIBRATION_PERIOD.
+EVALUATION_PERIOD: "2008-01-01, 2009-12-31"
 
 # EXPERIMENT_ID
 #   Type:        str
@@ -2816,14 +2823,18 @@ EXPERIMENT_ID: "run_1"
 #   Default:     None
 #   Source:      DomainConfig (domain.py)
 #   Usage:      54
-EXPERIMENT_TIME_END: "2020-12-31 23:00"
+# The default below mirrors the paper Figure 4 simulation window for
+# the Bow at Banff case study (2002-01-01 through 2009-12-31, with a
+# 2002–2003 spin-up, 2004–2007 calibration, 2008–2009 evaluation).
+# Replace with your own simulation window when adapting this template.
+EXPERIMENT_TIME_END: "2009-12-31 23:00"
 
 # EXPERIMENT_TIME_START
 #   Type:        str
 #   Default:     None
 #   Source:      DomainConfig (domain.py)
 #   Usage:      59
-EXPERIMENT_TIME_START: "2010-01-01 01:00"
+EXPERIMENT_TIME_START: "2002-01-01 01:00"
 
 # SPINUP_PERIOD
 #   Type:        str

--- a/src/symfluence/resources/config_templates/config_template_comprehensive_nested.yaml
+++ b/src/symfluence/resources/config_templates/config_template_comprehensive_nested.yaml
@@ -108,20 +108,26 @@ domain:
   # ---------------------------------------------------------------------------
   # Simulation time period (must include spin-up if needed)
   # Format: "YYYY-MM-DD HH:MM"
-  time_start: "2010-01-01 00:00"
-  time_end: "2020-12-31 23:00"
+  #
+  # The defaults below mirror the paper Figure 4 simulation window for
+  # the Bow at Banff case study (Eythorsson et al. 2026b): 2002-01-01
+  # through 2009-12-31, with a 2002–2003 spin-up, 2004–2007 calibration,
+  # 2008–2009 evaluation. Replace all four fields when adapting this
+  # template to your own domain.
+  time_start: "2002-01-01 00:00"
+  time_end: "2009-12-31 23:00"
 
   # Calibration period for parameter optimization
   # Format: "YYYY-MM-DD, YYYY-MM-DD" (start, end)
-  calibration_period: null
+  calibration_period: "2004-01-01, 2007-12-31"
   calibration_start_date: null
   calibration_end_date: null
 
   # Independent validation period
-  evaluation_period: null
+  evaluation_period: "2008-01-01, 2009-12-31"
 
   # Model warm-up period (excluded from evaluation)
-  spinup_period: null
+  spinup_period: "2002-01-01, 2003-12-31"
 
   # ---------------------------------------------------------------------------
   # Spatial Definition Method (REQUIRED)


### PR DESCRIPTION
## Summary
SH reported the ERA5 time-window mismatch: the scaffold templates (``config_template_comprehensive*.yaml``, used when ``symfluence`` generates a new project config) defaulted to ``2010-01-01 .. 2020-12-31`` with null calibration/evaluation periods. A reviewer initialising a config from the template to reproduce paper Figure 4 inherits the wrong simulation window, downloads the wrong data, and gets results that look like a reproducibility failure.

Align both scaffold templates to the Bow at Banff Fig 4 window from Eythorsson et al. 2026b:
- `time_start`: 2002-01-01
- `time_end`: 2009-12-31
- `spinup_period`: 2002-01-01 .. 2003-12-31
- `calibration_period`: 2004-01-01 .. 2007-12-31
- `evaluation_period`: 2008-01-01 .. 2009-12-31

Inline comments on each field identify this as the paper Fig 4 window for the Bow case study and instruct users to replace the values when adapting to their own domain.

Addresses co-author feedback item **11.15**.

## Test plan
- [x] Both templates parse via `yaml.safe_load` and show correct windows
- [x] No test in `tests/` pins the old 2010-2020 template defaults (verified by grep — tests that reference `2020-12-31` build their own configs independently)
- [ ] SH re-scaffolds a config from template and confirms Fig 4 reproduction window is inherited

🤖 Generated with [Claude Code](https://claude.com/claude-code)