### PR TITLE
CLM: MODIS PFT mapping, DEM elevation, ANA streamflow handler

### DIFF
--- a/CLA_SIGNATURES
+++ b/CLA_SIGNATURES
@@ -29,6 +29,23 @@ Email: befekadutaddesse.wol@ucalgary.ca
 Date: 2026-03-30
 ---
 
+Organization: Research Triangle Institute (d/b/a RTI International)
+Authorized Signatory: Dean T. Woodward
+Title: Assistant General Counsel, IP & Licensing
+Email: dtw@rti.org
+GitHub Username of Signatory: <dean-woodward-rti>
+Date: 2026-04-14
+Designated Employees:
+Anthony Preucil (apreucil)
+Florian Kluibenschaedl (fkluibenschaedl_rtiintl)
+Kaylyn Lemons (Sinisgalli) (ksinisgalli-ghpub)
+Paul Micheletty (pdmich)
+Lindsay Parker (lparker-rti)
+Sam Lamont (slamont_rtiintl)
+Katie van Werkhoven (kvanwerkhoven)
+Matthew Denno (mgdenno)
+---
+
 Name: Tristan Montoya
 GitHub: tristanmontoya
 Email: montoya.tristan@gmail.com

--- a/CLA_SIGNATURES
+++ b/CLA_SIGNATURES
@@ -27,3 +27,9 @@ Name: Befekadu Taddesse Woldegiorgis
 GitHub: befekadu2023
 Email: befekadutaddesse.wol@ucalgary.ca
 Date: 2026-03-30
+---
+
+Name: Tristan Montoya
+GitHub: tristanmontoya
+Email: montoya.tristan@gmail.com
+Date: 2026-04-21

--- a/examples/01_point_vertical_flux_estimation/01a_point_scale_snotel.ipynb
+++ b/examples/01_point_vertical_flux_estimation/01a_point_scale_snotel.ipynb
@@ -134,7 +134,7 @@
     "    # iteration, making it robust to occasional model failures from poor\n",
     "    # parameter combinations — unlike DDS which starts from a single point.\n",
     "    OPTIMIZATION_METHODS=['iteration'],\n",
-    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DE',\n",
+    "    iterative_optimization_algorithm='DE',\n",
     "    optimization_metric='KGE',\n",
     "    optimization_target='swe',\n",
     "    calibration_timestep='daily',\n",

--- a/examples/01_point_vertical_flux_estimation/01a_point_scale_snotel.ipynb
+++ b/examples/01_point_vertical_flux_estimation/01a_point_scale_snotel.ipynb
@@ -134,7 +134,7 @@
     "    # iteration, making it robust to occasional model failures from poor\n",
     "    # parameter combinations — unlike DDS which starts from a single point.\n",
     "    OPTIMIZATION_METHODS=['iteration'],\n",
-    "    optimization_algorithm='DE',\n",
+    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DE',\n",
     "    optimization_metric='KGE',\n",
     "    optimization_target='swe',\n",
     "    calibration_timestep='daily',\n",

--- a/examples/01_point_vertical_flux_estimation/01b_point_scale_fluxnet.ipynb
+++ b/examples/01_point_vertical_flux_estimation/01b_point_scale_fluxnet.ipynb
@@ -133,7 +133,7 @@
     "    # iteration, making it robust to occasional model failures from poor\n",
     "    # parameter combinations.\n",
     "    OPTIMIZATION_METHODS=['iteration'],\n",
-    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DE',\n",
+    "    iterative_optimization_algorithm='DE',\n",
     "    optimization_metric='KGE',\n",
     "    optimization_target='et',\n",
     "    calibration_timestep='daily',\n",

--- a/examples/01_point_vertical_flux_estimation/01b_point_scale_fluxnet.ipynb
+++ b/examples/01_point_vertical_flux_estimation/01b_point_scale_fluxnet.ipynb
@@ -133,7 +133,7 @@
     "    # iteration, making it robust to occasional model failures from poor\n",
     "    # parameter combinations.\n",
     "    OPTIMIZATION_METHODS=['iteration'],\n",
-    "    optimization_algorithm='DE',\n",
+    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DE',\n",
     "    optimization_metric='KGE',\n",
     "    optimization_target='et',\n",
     "    calibration_timestep='daily',\n",

--- a/examples/02_watershed_modelling/02a_basin_lumped.ipynb
+++ b/examples/02_watershed_modelling/02a_basin_lumped.ipynb
@@ -69,7 +69,7 @@
     "    params_to_calibrate='k_soil,theta_sat,aquiferBaseflowExp,aquiferBaseflowRate,qSurfScale,summerLAI,frozenPrecipMultip,Fcapil,tempCritRain,heightCanopyTop,heightCanopyBottom,windReductionParam,vGn_n',\n",
     "    basin_params_to_calibrate='routingGammaScale,routingGammaShape',\n",
     "    optimization_target='streamflow',\n",
-    "    optimization_algorithm='DDS',\n",
+    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',\n",
     "    iterations=100,\n",
     "    optimization_metric='KGE',\n",
     "    calibration_timestep='hourly',\n",

--- a/examples/02_watershed_modelling/02a_basin_lumped.ipynb
+++ b/examples/02_watershed_modelling/02a_basin_lumped.ipynb
@@ -69,7 +69,7 @@
     "    params_to_calibrate='k_soil,theta_sat,aquiferBaseflowExp,aquiferBaseflowRate,qSurfScale,summerLAI,frozenPrecipMultip,Fcapil,tempCritRain,heightCanopyTop,heightCanopyBottom,windReductionParam,vGn_n',\n",
     "    basin_params_to_calibrate='routingGammaScale,routingGammaShape',\n",
     "    optimization_target='streamflow',\n",
-    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',\n",
+    "    iterative_optimization_algorithm='DDS',\n",
     "    iterations=100,\n",
     "    optimization_metric='KGE',\n",
     "    calibration_timestep='hourly',\n",

--- a/examples/02_watershed_modelling/02b_basin_semi_distributed.ipynb
+++ b/examples/02_watershed_modelling/02b_basin_semi_distributed.ipynb
@@ -79,7 +79,7 @@
     "    OPTIMIZATION_METHODS=['iteration'],\n",
     "    params_to_calibrate='minStomatalResistance,cond2photo_slope,vcmax25_canopyTop,jmax25_scale,summerLAI,rootingDepth,soilStressParam,z0Canopy,windReductionParam',\n",
     "    optimization_target='streamflow',\n",
-    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',\n",
+    "    iterative_optimization_algorithm='DDS',\n",
     "    optimization_metric='KGE',\n",
     "    calibration_timestep='hourly',\n",
     ")\n",

--- a/examples/02_watershed_modelling/02b_basin_semi_distributed.ipynb
+++ b/examples/02_watershed_modelling/02b_basin_semi_distributed.ipynb
@@ -79,7 +79,7 @@
     "    OPTIMIZATION_METHODS=['iteration'],\n",
     "    params_to_calibrate='minStomatalResistance,cond2photo_slope,vcmax25_canopyTop,jmax25_scale,summerLAI,rootingDepth,soilStressParam,z0Canopy,windReductionParam',\n",
     "    optimization_target='streamflow',\n",
-    "    optimization_algorithm='DDS',\n",
+    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',\n",
     "    optimization_metric='KGE',\n",
     "    calibration_timestep='hourly',\n",
     ")\n",

--- a/examples/02_watershed_modelling/02c_basin_distributed.ipynb
+++ b/examples/02_watershed_modelling/02c_basin_distributed.ipynb
@@ -80,7 +80,7 @@
     "    OPTIMIZATION_METHODS=['iteration'],\n",
     "    params_to_calibrate='minStomatalResistance,cond2photo_slope,vcmax25_canopyTop,jmax25_scale,summerLAI,rootingDepth,soilStressParam,z0Canopy,windReductionParam',\n",
     "    optimization_target='streamflow',\n",
-    "    optimization_algorithm='DDS',\n",
+    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',\n",
     "    optimization_metric='KGE',\n",
     "    calibration_timestep='hourly',\n",
     ")\n",

--- a/examples/02_watershed_modelling/02c_basin_distributed.ipynb
+++ b/examples/02_watershed_modelling/02c_basin_distributed.ipynb
@@ -80,7 +80,7 @@
     "    OPTIMIZATION_METHODS=['iteration'],\n",
     "    params_to_calibrate='minStomatalResistance,cond2photo_slope,vcmax25_canopyTop,jmax25_scale,summerLAI,rootingDepth,soilStressParam,z0Canopy,windReductionParam',\n",
     "    optimization_target='streamflow',\n",
-    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',\n",
+    "    iterative_optimization_algorithm='DDS',\n",
     "    optimization_metric='KGE',\n",
     "    calibration_timestep='hourly',\n",
     ")\n",

--- a/examples/04_workshop_notebooks/04a_logan_river_workshop.ipynb
+++ b/examples/04_workshop_notebooks/04a_logan_river_workshop.ipynb
@@ -194,7 +194,7 @@
     "    # Calibration (applies to all models)\n",
     "    OPTIMIZATION_METHODS=['iteration'],\n",
     "    optimization_target='streamflow',\n",
-    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',\n",
+    "    iterative_optimization_algorithm='DDS',\n",
     "    optimization_metric='KGE',\n",
     "    calibration_timestep='hourly',\n",
     "    iterations=100,\n",

--- a/examples/04_workshop_notebooks/04a_logan_river_workshop.ipynb
+++ b/examples/04_workshop_notebooks/04a_logan_river_workshop.ipynb
@@ -194,7 +194,7 @@
     "    # Calibration (applies to all models)\n",
     "    OPTIMIZATION_METHODS=['iteration'],\n",
     "    optimization_target='streamflow',\n",
-    "    optimization_algorithm='DDS',\n",
+    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',\n",
     "    optimization_metric='KGE',\n",
     "    calibration_timestep='hourly',\n",
     "    iterations=100,\n",

--- a/examples/04_workshop_notebooks/04b_provo_river_workshop.ipynb
+++ b/examples/04_workshop_notebooks/04b_provo_river_workshop.ipynb
@@ -208,7 +208,7 @@
     "    \n",
     "    # Optimization configuration\n",
     "    optimization_target='streamflow',\n",
-    "    optimization_algorithm='DDS',               # Dynamically Dimensioned Search\n",
+    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',               # Dynamically Dimensioned Search\n",
     "    optimization_metric='KGE',                  # Kling-Gupta Efficiency\n",
     "    calibration_timestep='hourly',\n",
     "    iterations=5000,                             # Number of calibration iterations\n",

--- a/examples/04_workshop_notebooks/04b_provo_river_workshop.ipynb
+++ b/examples/04_workshop_notebooks/04b_provo_river_workshop.ipynb
@@ -208,7 +208,7 @@
     "    \n",
     "    # Optimization configuration\n",
     "    optimization_target='streamflow',\n",
-    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',               # Dynamically Dimensioned Search\n",
+    "    iterative_optimization_algorithm='DDS',               # Dynamically Dimensioned Search\n",
     "    optimization_metric='KGE',                  # Kling-Gupta Efficiency\n",
     "    calibration_timestep='hourly',\n",
     "    iterations=5000,                             # Number of calibration iterations\n",

--- a/examples/04_workshop_notebooks/04b_provo_river_workshop.ipynb
+++ b/examples/04_workshop_notebooks/04b_provo_river_workshop.ipynb
@@ -208,7 +208,7 @@
     "    \n",
     "    # Optimization configuration\n",
     "    optimization_target='streamflow',\n",
-    "    iterative_optimization_algorithm='DDS',  # Dynamically Dimensioned Search\n",
+    "    iterative_optimization_algorithm='DDS',     # Dynamically Dimensioned Search\n",
     "    optimization_metric='KGE',                  # Kling-Gupta Efficiency\n",
     "    calibration_timestep='hourly',\n",
     "    iterations=5000,                             # Number of calibration iterations\n",

--- a/examples/04_workshop_notebooks/04b_provo_river_workshop.ipynb
+++ b/examples/04_workshop_notebooks/04b_provo_river_workshop.ipynb
@@ -208,7 +208,7 @@
     "    \n",
     "    # Optimization configuration\n",
     "    optimization_target='streamflow',\n",
-    "    iterative_optimization_algorithm='DDS',               # Dynamically Dimensioned Search\n",
+    "    iterative_optimization_algorithm='DDS',  # Dynamically Dimensioned Search\n",
     "    optimization_metric='KGE',                  # Kling-Gupta Efficiency\n",
     "    calibration_timestep='hourly',\n",
     "    iterations=5000,                             # Number of calibration iterations\n",

--- a/examples/04_workshop_notebooks/04c_sagehen_creek_workshop.ipynb
+++ b/examples/04_workshop_notebooks/04c_sagehen_creek_workshop.ipynb
@@ -273,7 +273,7 @@
     "\n",
     "    # Optimization configuration\n",
     "    optimization_target='streamflow',\n",
-    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',\n",
+    "    iterative_optimization_algorithm='DDS',\n",
     "    optimization_metric='KGE',\n",
     "    calibration_timestep='daily',\n",
     "    iterations=300,\n",

--- a/examples/04_workshop_notebooks/04c_sagehen_creek_workshop.ipynb
+++ b/examples/04_workshop_notebooks/04c_sagehen_creek_workshop.ipynb
@@ -273,7 +273,7 @@
     "\n",
     "    # Optimization configuration\n",
     "    optimization_target='streamflow',\n",
-    "    optimization_algorithm='DDS',\n",
+    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',\n",
     "    optimization_metric='KGE',\n",
     "    calibration_timestep='daily',\n",
     "    iterations=300,\n",

--- a/examples/04_workshop_notebooks/04d_diguillin_river_chile.ipynb
+++ b/examples/04_workshop_notebooks/04d_diguillin_river_chile.ipynb
@@ -128,7 +128,7 @@
     "    # Calibration\n",
     "    OPTIMIZATION_METHODS=['iteration'],\n",
     "    optimization_target='streamflow',\n",
-    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',\n",
+    "    iterative_optimization_algorithm='DDS',\n",
     "    optimization_metric='KGE',\n",
     "    iterations=100,\n",
     ")\n",

--- a/examples/04_workshop_notebooks/04d_diguillin_river_chile.ipynb
+++ b/examples/04_workshop_notebooks/04d_diguillin_river_chile.ipynb
@@ -128,7 +128,7 @@
     "    # Calibration\n",
     "    OPTIMIZATION_METHODS=['iteration'],\n",
     "    optimization_target='streamflow',\n",
-    "    optimization_algorithm='DDS',\n",
+    "    ITERATIVE_OPTIMIZATION_ALGORITHM='DDS',\n",
     "    optimization_metric='KGE',\n",
     "    iterations=100,\n",
     ")\n",

--- a/examples/paper_case_studies/configs/configs_orig/11_data_pipeline/config_Bow_pipeline_distributed.yaml
+++ b/examples/paper_case_studies/configs/configs_orig/11_data_pipeline/config_Bow_pipeline_distributed.yaml
@@ -33,7 +33,7 @@ ELEVATION_BAND_SIZE: 200  # metres
 MIN_HRU_SIZE: 4.0         # km²
 
 # DEM and geospatial attributes
-DEM_SOURCE: MERIT
+DEM_SOURCE: copernicus   # Cloud-reachable default (Copernicus GLO-30). Use 'merit_hydro' only with DATA_ACCESS: hpc via MAF gistool.
 DEM_PATH: default
 SOIL_CLASS_PATH: default
 LAND_CLASS_PATH: default

--- a/examples/paper_case_studies/configs/configs_orig/11_data_pipeline/config_Bow_pipeline_era5.yaml
+++ b/examples/paper_case_studies/configs/configs_orig/11_data_pipeline/config_Bow_pipeline_era5.yaml
@@ -33,7 +33,7 @@ CATCHMENT_SHP_PATH: default
 RIVER_NETWORK_SHP_PATH: default
 
 # DEM and geospatial attributes
-DEM_SOURCE: MERIT
+DEM_SOURCE: copernicus   # Cloud-reachable default (Copernicus GLO-30). Use 'merit_hydro' only with DATA_ACCESS: hpc via MAF gistool.
 DEM_PATH: default
 SOIL_CLASS_PATH: default
 LAND_CLASS_PATH: default

--- a/examples/paper_case_studies/configs/configs_orig/11_data_pipeline/config_Iceland_pipeline_era5.yaml
+++ b/examples/paper_case_studies/configs/configs_orig/11_data_pipeline/config_Iceland_pipeline_era5.yaml
@@ -34,7 +34,7 @@ ELEVATION_BAND_SIZE: 200  # metres
 MIN_HRU_SIZE: 10.0        # km² (larger minimum for regional domain)
 
 # DEM and geospatial attributes
-DEM_SOURCE: MERIT
+DEM_SOURCE: copernicus   # Cloud-reachable default (Copernicus GLO-30). Use 'merit_hydro' only with DATA_ACCESS: hpc via MAF gistool.
 DEM_PATH: default
 SOIL_CLASS_PATH: default
 LAND_CLASS_PATH: default

--- a/examples/paper_case_studies/configs/configs_orig/11_data_pipeline/config_Paradise_pipeline_era5.yaml
+++ b/examples/paper_case_studies/configs/configs_orig/11_data_pipeline/config_Paradise_pipeline_era5.yaml
@@ -32,7 +32,7 @@ CATCHMENT_SHP_PATH: default
 RIVER_NETWORK_SHP_PATH: none
 
 # DEM and geospatial attributes
-DEM_SOURCE: MERIT
+DEM_SOURCE: copernicus   # Cloud-reachable default (Copernicus GLO-30). Use 'merit_hydro' only with DATA_ACCESS: hpc via MAF gistool.
 DEM_PATH: default
 SOIL_CLASS_PATH: default
 LAND_CLASS_PATH: default

--- a/src/symfluence/data/acquisition/acquisition_service.py
+++ b/src/symfluence/data/acquisition/acquisition_service.py
@@ -421,7 +421,37 @@ class AcquisitionService(ConfigurableMixin):
                             self._acquire_elevation_data(gr, dem_dir, latlims, lonlims)
                             return dem_dir / f"domain_{self.domain_name}_elv.tif"
                         else:
-                            raise ValueError(f"Unsupported DEM_SOURCE: '{dem_source}'.")
+                            # Surface common misconfigurations with an actionable
+                            # hint instead of just "unsupported". MERIT-Hydro in
+                            # particular looks superficially right — it's in many
+                            # of our HPC paper configs — but it's only reachable
+                            # via the MAF gistool path, not cloud. If the user
+                            # set it with DATA_ACCESS=cloud they need a
+                            # cloud-reachable source.
+                            lower = str(dem_source).lower()
+                            accepted_cloud = [
+                                'copernicus', 'copdem90', 'copernicus_90',
+                                'fabdem', 'nasadem', 'srtm', 'etopo',
+                                'mapzen', 'alos',
+                            ]
+                            hint = ""
+                            if 'merit' in lower:
+                                hint = (
+                                    " MERIT-Hydro is only available via the MAF "
+                                    "gistool path (DATA_ACCESS: hpc). For "
+                                    "DATA_ACCESS: cloud, use 'copernicus' "
+                                    "(the default) or one of: "
+                                    f"{', '.join(accepted_cloud)}."
+                                )
+                            else:
+                                hint = (
+                                    f" Accepted cloud DEM sources: "
+                                    f"{', '.join(accepted_cloud)}."
+                                )
+                            raise ValueError(
+                                f"Unsupported DEM_SOURCE: '{dem_source}' for "
+                                f"DATA_ACCESS: cloud.{hint}"
+                            )
                     attr_tasks.append(('DEM', _acquire_dem))
                 else:
                     self.logger.info("Skipping DEM acquisition (DOWNLOAD_DEM is False)")

--- a/src/symfluence/data/observation/handlers/__init__.py
+++ b/src/symfluence/data/observation/handlers/__init__.py
@@ -9,6 +9,7 @@ from multiple sources including satellite products, in-situ networks, and
 reanalysis datasets.
 """
 
+from .ana import ANAStreamflowHandler
 from .camels import (
     CAMELSAUSStreamflowHandler,
     CAMELSBRStreamflowHandler,
@@ -152,6 +153,8 @@ __all__ = [
     "ESACCISMHandler",
     "SMOSSMHandler",
     "ASCATSMHandler",
+    # ANA (Brazil / CAMELS-BR)
+    "ANAStreamflowHandler",
     # DGA (Chile)
     "DGAStreamflowHandler",
     # USGS

--- a/src/symfluence/data/observation/handlers/ana.py
+++ b/src/symfluence/data/observation/handlers/ana.py
@@ -1,0 +1,272 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""
+ANA (Agencia Nacional de Aguas) Observation Handler
+
+Provides cloud-accessible streamflow data for 897 Brazilian catchments via the
+CAMELS-BR dataset hosted on Zenodo. Data is downloaded automatically on
+first use and cached locally.
+
+Data source:
+    Chagas, V.B.P., et al. (2020). CAMELS-BR: hydrometeorological time series
+    and landscape attributes for 897 catchments in Brazil. Earth System
+    Science Data, 12(3), 2075-2098.
+    https://doi.org/10.5194/essd-12-2075-2020
+
+    Zenodo: https://doi.org/10.5281/zenodo.3709337
+
+Station codes:
+    ANA gauge codes (8-digit, e.g., '15930000').
+
+Configuration:
+    STATION_ID: ANA station code (e.g., '15930000')
+    STREAMFLOW_DATA_PROVIDER: 'ANA'
+    DOWNLOAD_ANA_DATA: True (default, downloads from Zenodo if not cached)
+"""
+
+import zipfile
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+import requests
+
+from symfluence.core.exceptions import DataAcquisitionError, symfluence_error_handler
+
+from ..base import BaseObservationHandler
+from ..registry import ObservationRegistry
+
+ZENODO_STREAMFLOW_URL = (
+    "https://zenodo.org/api/records/15025488/files/"
+    "03_CAMELS_BR_streamflow_m3s.zip/content"
+)
+
+ANA_STATIONS = {
+    "15930000": "Rio Aripuana (Amazon, 98% forest)",
+    "17345000": "Rio Teles Pires (Xingu headwaters, 88% forest)",
+    "12400000": "Rio Jurua (Western Amazon, 100% forest)",
+    "14350000": "Rio Negro (Central Amazon, 95% forest)",
+    "10100000": "Rio Solimoes em Tabatinga",
+}
+
+
+@ObservationRegistry.register("ana_streamflow")
+class ANAStreamflowHandler(BaseObservationHandler):
+    """Handles Brazilian ANA streamflow data via CAMELS-BR (Zenodo).
+
+    Downloads the CAMELS-BR streamflow dataset from Zenodo on first use,
+    caches it locally, and extracts the requested station's time series.
+    Covers 897 ANA stations with daily data (period varies by station).
+
+    Usage in config::
+
+        station_id: '15930000'
+        streamflow_data_provider: 'ANA'
+        download_ana_data: true
+    """
+
+    obs_type = "streamflow"
+    source_name = "ANA"
+    SOURCE_INFO = {
+        "source": "ANA (via CAMELS-BR / Zenodo)",
+        "source_doi": "10.5281/zenodo.3709337",
+        "url": "https://doi.org/10.5281/zenodo.3709337",
+        "citation": (
+            "Chagas, V.B.P., et al. (2020). CAMELS-BR: hydrometeorological "
+            "time series and landscape attributes for 897 catchments in "
+            "Brazil. ESSD, 12(3), 2075-2098."
+        ),
+    }
+
+    def acquire(self) -> Path:
+        """Download ANA streamflow data from Zenodo and extract station."""
+        station_id = self._get_station_id()
+        if not station_id:
+            self.logger.debug("STATION_ID not found, skipping ANA acquisition")
+            return self.project_observations_dir / "streamflow" / "raw_data"
+
+        station_id = str(station_id).strip()
+
+        raw_dir = self.project_observations_dir / "streamflow" / "raw_data"
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        raw_file = raw_dir / f"ana_{station_id}_raw.csv"
+
+        if raw_file.exists():
+            self.logger.info(f"ANA data already available: {raw_file}")
+            return raw_file
+
+        download_enabled = self._get_config_value(
+            lambda: self.config.data.download_ana_data, default=True
+        )
+        if not download_enabled:
+            if raw_file.exists():
+                return raw_file
+            raise DataAcquisitionError(
+                f"ANA data not found and download disabled: {raw_file}"
+            )
+
+        cache_dir = self._get_cache_dir()
+        cached_zip = cache_dir / "03_CAMELS_BR_streamflow_m3s.zip"
+
+        if not cached_zip.exists():
+            self._download_zenodo(cached_zip)
+
+        self._extract_station(cached_zip, station_id, raw_file)
+        return raw_file
+
+    def process(self, input_path: Path) -> Path:
+        """Process raw ANA CSV into standard SYMFLUENCE streamflow format."""
+        if not input_path.exists():
+            raise FileNotFoundError(f"ANA raw data not found: {input_path}")
+
+        self.logger.info(f"Processing ANA streamflow from {input_path}")
+
+        df = pd.read_csv(input_path, parse_dates=["datetime"])
+        df.set_index("datetime", inplace=True)
+        df["discharge_cms"] = pd.to_numeric(df["discharge_cms"], errors="coerce")
+        df = df.dropna(subset=["discharge_cms"])
+
+        df = df.loc[self.start_date : self.end_date]
+
+        if df.empty:
+            raise DataAcquisitionError(
+                f"No ANA data in experiment period "
+                f"({self.start_date} to {self.end_date})."
+            )
+
+        resample_freq = self._get_resample_freq()
+        resampled = df["discharge_cms"].resample(resample_freq).mean()
+        resampled = resampled.interpolate(
+            method="time", limit_direction="both", limit=30
+        )
+
+        output_dir = self.project_observations_dir / "streamflow" / "preprocessed"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_file = output_dir / f"{self.domain_name}_streamflow_processed.csv"
+        resampled.to_csv(output_file, header=True, index_label="datetime")
+
+        self.logger.info(
+            f"ANA streamflow processing complete: {output_file} "
+            f"({len(resampled)} records)"
+        )
+        return output_file
+
+    def _get_station_id(self) -> Optional[str]:
+        """Retrieve ANA station ID from config."""
+        return self._get_config_value(
+            lambda: self.config.evaluation.streamflow.station_id
+        ) or self._get_config_value(
+            lambda: self.config.data.streamflow_station_id
+        )
+
+    def _get_cache_dir(self) -> Path:
+        """Get or create cache directory for CAMELS-BR bulk download."""
+        data_dir = self._get_config_value(
+            lambda: self.config.system.data_dir, default=None
+        )
+        if data_dir:
+            cache = Path(data_dir) / ".cache" / "camels_br"
+        else:
+            cache = self.project_observations_dir / ".cache" / "camels_br"
+        cache.mkdir(parents=True, exist_ok=True)
+        return cache
+
+    def _download_zenodo(self, output_path: Path) -> None:
+        """Download CAMELS-BR streamflow ZIP from Zenodo."""
+        self.logger.info(
+            "Downloading CAMELS-BR streamflow data from Zenodo..."
+        )
+
+        with symfluence_error_handler(
+            "Zenodo download", self.logger, error_type=DataAcquisitionError
+        ):
+            response = requests.get(
+                ZENODO_STREAMFLOW_URL, timeout=300, stream=True
+            )
+            response.raise_for_status()
+
+            with open(output_path, "wb") as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    f.write(chunk)
+
+            size_mb = output_path.stat().st_size / 1e6
+            self.logger.info(
+                f"Downloaded CAMELS-BR streamflow: "
+                f"{output_path} ({size_mb:.1f} MB)"
+            )
+
+    def _extract_station(
+        self, zip_path: Path, station_id: str, output_path: Path
+    ) -> None:
+        """Extract a single station from the CAMELS-BR ZIP.
+
+        CAMELS-BR stores each station as a separate file:
+        3_CAMELS_BR_streamflow_m3s/{station_id}_streamflow_m3s.txt
+        """
+        self.logger.info(
+            f"Extracting station {station_id} from CAMELS-BR archive..."
+        )
+
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            candidates = [
+                f"3_CAMELS_BR_streamflow_m3s/{station_id}_streamflow_m3s.txt",
+                f"{station_id}_streamflow_m3s.txt",
+            ]
+
+            target = None
+            for c in candidates:
+                if c in zf.namelist():
+                    target = c
+                    break
+
+            if target is None:
+                matching = [n for n in zf.namelist() if station_id in n]
+                if matching:
+                    target = matching[0]
+
+            if target is None:
+                available = [n for n in zf.namelist() if n.endswith(".txt")][:10]
+                raise DataAcquisitionError(
+                    f"Station {station_id} not found in CAMELS-BR archive. "
+                    f"Sample files: {available}"
+                )
+
+            with zf.open(target) as f:
+                df = None
+                for sep in [r"\s+", ",", ";", "\t"]:
+                    try:
+                        f.seek(0)
+                        df = pd.read_csv(f, sep=sep)
+                        if len(df.columns) >= 2:  # noqa: PLR2004
+                            break
+                    except Exception:  # noqa: BLE001
+                        continue
+
+        if df is None or len(df.columns) < 2:  # noqa: PLR2004
+            raise DataAcquisitionError(
+                f"Could not parse streamflow file for station {station_id}"
+            )
+
+        date_cols = [c for c in df.columns if "date" in c.lower()]
+        date_col = date_cols[0] if date_cols else df.columns[0]
+        val_cols = [
+            c for c in df.columns
+            if any(k in c.lower() for k in ["streamflow", "discharge", "m3"])
+        ]
+        val_col = val_cols[0] if val_cols else df.columns[1]
+
+        result = pd.DataFrame({
+            "datetime": pd.to_datetime(df[date_col]),
+            "discharge_cms": pd.to_numeric(df[val_col], errors="coerce"),
+        })
+        result = result.dropna(subset=["discharge_cms"])
+        result = result[result["discharge_cms"] >= 0]
+        result.to_csv(output_path, index=False)
+
+        station_name = ANA_STATIONS.get(station_id, "unknown")
+        self.logger.info(
+            f"Extracted ANA station {station_id} ({station_name}): "
+            f"{len(result)} records, "
+            f"{result['datetime'].min()} to {result['datetime'].max()}"
+        )

--- a/src/symfluence/evaluation/analysis_manager.py
+++ b/src/symfluence/evaluation/analysis_manager.py
@@ -315,6 +315,18 @@ class AnalysisManager(ConfigurableMixin):
         """
         self.logger.info("Starting benchmarking analysis")
 
+        opt_target = self._get_config_value(
+            lambda: self.config.optimization.target,
+            dict_key='OPTIMIZATION_TARGET',
+        ) or 'streamflow'
+        if opt_target.lower() != 'streamflow':
+            self.logger.info(
+                "Skipping benchmarking: HydroBM benchmarks are streamflow-specific "
+                "and do not apply to OPTIMIZATION_TARGET='%s'",
+                opt_target,
+            )
+            return None
+
         with symfluence_error_handler(
             "benchmarking analysis",
             self.logger,

--- a/src/symfluence/evaluation/sensitivity_analysis.py
+++ b/src/symfluence/evaluation/sensitivity_analysis.py
@@ -19,6 +19,12 @@ from tqdm import tqdm
 
 from symfluence.core.mixins import ConfigMixin
 
+_NON_PARAM_COLS = frozenset({
+    'Iteration', 'iteration', 'score', 'timestamp', 'crash_count', 'crash_rate',
+    'Calib_RMSE', 'Calib_KGE', 'Calib_KGEp', 'Calib_KGEnp', 'Calib_NSE', 'Calib_MAE',
+    'RMSE', 'KGE', 'KGEp', 'NSE', 'MAE', 'objective', 'Objective', 'fitness',
+})
+
 
 class SensitivityAnalyzer(ConfigMixin):
     """
@@ -98,9 +104,7 @@ class SensitivityAnalyzer(ConfigMixin):
             pd.Series: Sensitivity indices for each parameter, or -999 if failed.
         """
         self.logger.info(f"Performing sensitivity analysis using {metric} metric")
-        non_param_cols = {'Iteration', 'iteration', 'score', 'timestamp', 'crash_count', 'crash_rate',
-                          'Calib_RMSE', 'Calib_KGE', 'Calib_KGEp', 'Calib_KGEnp', 'Calib_NSE', 'Calib_MAE'}
-        parameter_columns = [col for col in samples.columns if col not in non_param_cols]
+        parameter_columns = [col for col in samples.columns if col not in _NON_PARAM_COLS]
 
         if len(samples) < min_samples:
             self.logger.warning(f"Insufficient data for reliable sensitivity analysis. Have {len(samples)} samples, recommend at least {min_samples}.")
@@ -151,7 +155,7 @@ class SensitivityAnalyzer(ConfigMixin):
             pd.Series: Total-order Sobol indices for each parameter.
         """
         self.logger.info(f"Performing Sobol analysis using {metric} metric")
-        parameter_columns = [col for col in samples.columns if col not in ['Iteration', 'RMSE', 'KGE', 'KGEp', 'NSE', 'MAE']]
+        parameter_columns = [col for col in samples.columns if col not in _NON_PARAM_COLS]
 
         problem = {
             'num_vars': len(parameter_columns),
@@ -220,7 +224,7 @@ class SensitivityAnalyzer(ConfigMixin):
             pd.Series: Spearman correlation coefficients for each parameter.
         """
         self.logger.info(f"Performing correlation analysis using {metric} metric")
-        parameter_columns = [col for col in samples.columns if col not in ['Iteration', 'RMSE', 'KGE', 'KGEp', 'NSE', 'MAE']]
+        parameter_columns = [col for col in samples.columns if col not in _NON_PARAM_COLS]
         correlations = []
         for param in parameter_columns:
             corr, _ = spearmanr(samples[param], samples[metric])

--- a/src/symfluence/models/base/standard_postprocessor.py
+++ b/src/symfluence/models/base/standard_postprocessor.py
@@ -544,15 +544,20 @@ class RoutedModelPostprocessor(StandardModelPostprocessor):
 
             if sim_reach_id is not None:
                 sim_reach_id = int(sim_reach_id)
-                # Select by reach ID
                 if 'reachID' in ds:
-                    segment_index = ds['reachID'].values == sim_reach_id
-                    ds_selected = ds.sel(seg=segment_index)
+                    segment_mask = ds['reachID'].values == sim_reach_id
+                    if segment_mask.any():
+                        idx = int(segment_mask.argmax())
+                        ds_selected = ds.isel(seg=idx)
+                    else:
+                        self.logger.warning(
+                            f"SIM_REACH_ID={sim_reach_id} not found in reachID; "
+                            f"falling back to outlet (last segment)"
+                        )
+                        ds_selected = ds.isel(seg=-1)
                 else:
-                    # Fall back to last segment (outlet)
                     ds_selected = ds.isel(seg=-1)
             else:
-                # Default to last segment
                 ds_selected = ds.isel(seg=-1)
 
             # Extract routing variable

--- a/src/symfluence/models/clm/domain_generator.py
+++ b/src/symfluence/models/clm/domain_generator.py
@@ -103,23 +103,97 @@ class CLMDomainGenerator:
             return 2210.0
 
     def get_mean_elevation(self) -> float:
-        """Get mean elevation from DEM."""
-        dem_dir = self.pp.project_attributes_dir / 'elevation'
-        if dem_dir.exists():
-            for f in dem_dir.glob('*dem*.nc'):
+        """Get mean elevation from HRU shapefile or DEM (GeoTIFF/NetCDF)."""
+        # 1. Try HRU shapefile elev_mean attribute
+        try:
+            gdf = self._load_hru_shapefile()
+            if gdf is not None and 'elev_mean' in gdf.columns:
+                val = float(gdf['elev_mean'].mean())
+                if val > 0:
+                    logger.info(f"Elevation from HRU shapefile: {val:.1f} m")
+                    return val
+        except Exception:  # noqa: BLE001
+            pass
+
+        # 2. Try DEM GeoTIFF
+        elev_dir = self.pp.project_attributes_dir / 'elevation'
+        if elev_dir.exists():
+            import rasterio
+            for pattern in ['**/*elv*.tif', '**/*dem*.tif', '**/*elevation*.tif']:
+                for f in elev_dir.glob(pattern):
+                    try:
+                        with rasterio.open(f) as src:
+                            data = src.read(1)
+                            valid = data[(data > -9999) & (data < 9000)]
+                            if len(valid) > 0:
+                                val = float(valid.mean())
+                                logger.info(f"Elevation from DEM GeoTIFF: {val:.1f} m")
+                                return val
+                    except Exception:  # noqa: BLE001
+                        continue
+
+        # 3. Try DEM NetCDF
+        if elev_dir.exists():
+            for f in elev_dir.glob('*dem*.nc'):
                 try:
                     ds = xr.open_dataset(f)
                     for var in ['elev', 'elevation', 'dem', 'z']:
                         if var in ds.data_vars:
                             val = float(ds[var].mean().values)
                             ds.close()
+                            logger.info(f"Elevation from DEM NetCDF: {val:.1f} m")
                             return val
                     ds.close()
-                except Exception:  # noqa: BLE001 — model execution resilience
+                except Exception:  # noqa: BLE001
                     continue
-        return float(self.pp._get_config_value(
-            lambda: None, default=1500.0, dict_key='MEAN_ELEVATION'
+
+        default = float(self.pp._get_config_value(
+            lambda: None, default=300.0, dict_key='MEAN_ELEVATION'
         ))
+        logger.warning(f"Could not read DEM; using default elevation: {default} m")
+        return default
+
+    def get_elevation_stats(self) -> tuple:
+        """Get elevation std dev and mean slope from DEM GeoTIFF."""
+        elev_dir = self.pp.project_attributes_dir / 'elevation'
+        if elev_dir.exists():
+            import rasterio
+            for pattern in ['**/*elv*.tif', '**/*dem*.tif', '**/*elevation*.tif']:
+                for f in elev_dir.glob(pattern):
+                    try:
+                        with rasterio.open(f) as src:
+                            data = src.read(1).astype(float)
+                            valid_mask = (data > -9999) & (data < 9000)
+                            valid = data[valid_mask]
+                            if len(valid) < 4:
+                                continue
+                            std_elev = float(np.std(valid))
+                            res = abs(src.res[0]) * 111000
+                            gy, gx = np.gradient(data, res)
+                            slope_rad = np.arctan(np.sqrt(gx**2 + gy**2))
+                            slope_deg = float(np.degrees(slope_rad[valid_mask].mean()))
+                            logger.info(f"DEM stats: std_elev={std_elev:.1f} m, slope={slope_deg:.1f} deg")
+                            return std_elev, slope_deg
+                    except Exception:  # noqa: BLE001
+                        continue
+        return 100.0, 5.0
+
+    def _load_hru_shapefile(self):
+        """Load HRU shapefile from standard project paths."""
+        import geopandas as gpd
+        search_dirs = [
+            self.pp.project_dir / 'shapefiles' / 'catchment' / 'lumped',
+            self.pp.project_dir / 'shapefiles' / 'river_basins',
+        ]
+        for d in search_dirs:
+            if not d.exists():
+                continue
+            for f in d.rglob('*.shp'):
+                try:
+                    return gpd.read_file(f)
+                except Exception:  # noqa: BLE001
+                    continue
+        return None
 
     # ------------------------------------------------------------------ #
     #  Domain and mesh file generation

--- a/src/symfluence/models/clm/surface_generator.py
+++ b/src/symfluence/models/clm/surface_generator.py
@@ -153,11 +153,12 @@ class CLMSurfaceGenerator:
         v = ds.createVariable('PCT_CFT', 'f8', ('lsmlat', 'lsmlon', 'cft'))
         v[:] = pct_cft
 
-        # -- Topography --
+        # -- Topography (from DEM) --
+        std_elev, mean_slope = self.pp.domain_generator.get_elevation_stats()
         add_2d('FMAX', 0.5)
         add_2d('TOPO', mean_elev, units='m')
-        add_2d('STD_ELEV', 500.0, units='m')
-        add_2d('SLOPE', 15.0)
+        add_2d('STD_ELEV', std_elev, units='m')
+        add_2d('SLOPE', mean_slope)
 
         # -- Soil properties (10 layers) --
         n_sl = 10

--- a/src/symfluence/models/clm/surface_generator.py
+++ b/src/symfluence/models/clm/surface_generator.py
@@ -140,11 +140,10 @@ class CLMSurfaceGenerator:
         add_2d('PCT_OCEAN', 0.0)
         add_2d('PCT_URBAN', 0.0)
 
-        # PFT distribution: 5% bare, 60% needleleaf evergreen, 35% c3 arctic
+        # PFT distribution from MODIS land cover
+        pft_dist = self._get_pft_distribution(lat)
         pct_nat = np.zeros((1, 1, 15))
-        pct_nat[0, 0, 0] = 5.0
-        pct_nat[0, 0, 1] = 60.0
-        pct_nat[0, 0, 12] = 35.0
+        pct_nat[0, 0, :] = pft_dist
         v = ds.createVariable('PCT_NAT_PFT', 'f8', ('lsmlat', 'lsmlon', 'natpft'))
         v[:] = pct_nat
 
@@ -209,22 +208,37 @@ class CLMSurfaceGenerator:
             add_2d(ef_name, ef_val, units='ug/m2/hr')
 
         # -- Monthly vegetation data for satellite phenology (SP) --
-        # LAI seasonal cycle for active PFTs
-        lai_tree = [2.5, 2.5, 2.5, 3.0, 3.5, 4.0, 4.5, 4.5, 4.0, 3.5, 3.0, 2.5]
-        lai_grass = [0., 0., 0., 0.2, 0.5, 1.2, 1.5, 1.5, 0.8, 0.3, 0., 0.]
+        lai_net = [2.5, 2.5, 2.5, 3.0, 3.5, 4.0, 4.5, 4.5, 4.0, 3.5, 3.0, 2.5]
+        lai_bet = [5.0, 5.0, 5.0, 5.2, 5.5, 5.8, 6.0, 6.0, 5.8, 5.5, 5.2, 5.0]
+        lai_bdt = [0.5, 0.5, 1.0, 2.0, 3.5, 5.0, 5.5, 5.0, 4.0, 2.5, 1.0, 0.5]
+        lai_shrub = [0.2, 0.2, 0.3, 0.5, 1.0, 1.5, 1.8, 1.8, 1.2, 0.6, 0.3, 0.2]
+        lai_c3g = [0., 0., 0., 0.2, 0.5, 1.2, 1.5, 1.5, 0.8, 0.3, 0., 0.]
+        lai_c4g = [0., 0., 0., 0.3, 0.8, 1.8, 2.5, 2.5, 1.5, 0.5, 0., 0.]
+
+        pft_lai = {1: lai_net, 2: lai_net, 3: lai_net,
+                   4: lai_bet, 5: lai_bet, 6: lai_bdt, 7: lai_bdt, 8: lai_bdt,
+                   9: lai_shrub, 10: lai_shrub, 11: lai_shrub,
+                   12: lai_c3g, 13: lai_c3g, 14: lai_c4g}
+        pft_sai = {i: [1.0]*12 for i in range(1, 9)}
+        pft_sai.update({i: [0.5]*12 for i in range(9, 15)})
+        pft_htop = {1: 17., 2: 17., 3: 14., 4: 35., 5: 20., 6: 20., 7: 18.,
+                    8: 14., 9: 0.5, 10: 0.5, 11: 0.5, 12: 0.5, 13: 0.5, 14: 0.5}
+        pft_hbot = {k: v * 0.5 if v > 1.0 else 0.1 for k, v in pft_htop.items()}
+
+        active_pfts = [i for i in range(15) if pft_dist[i] > 0.5]
+        lai_map = {i: pft_lai.get(i, [0.]*12) for i in active_pfts if i > 0}
+        sai_map = {i: pft_sai.get(i, [0.5]*12) for i in active_pfts if i > 0}
+        htop_map = {i: [pft_htop.get(i, 0.5)]*12 for i in active_pfts if i > 0}
+        hbot_map = {i: [pft_hbot.get(i, 0.1)]*12 for i in active_pfts if i > 0}
 
         for vname, pft_vals, attrs in [
-            ('MONTHLY_LAI',
-             {1: lai_tree, 12: lai_grass},
+            ('MONTHLY_LAI', lai_map,
              {'units': 'm^2/m^2', 'long_name': 'monthly leaf area index'}),
-            ('MONTHLY_SAI',
-             {1: [1.0]*12, 12: [0.5]*12},
+            ('MONTHLY_SAI', sai_map,
              {'units': 'm^2/m^2', 'long_name': 'monthly stem area index'}),
-            ('MONTHLY_HEIGHT_TOP',
-             {1: [17.0]*12, 12: [0.5]*12},
+            ('MONTHLY_HEIGHT_TOP', htop_map,
              {'units': 'm', 'long_name': 'monthly vegetation height top'}),
-            ('MONTHLY_HEIGHT_BOT',
-             {1: [8.5]*12, 12: [0.1]*12},
+            ('MONTHLY_HEIGHT_BOT', hbot_map,
              {'units': 'm', 'long_name': 'monthly vegetation height bottom'}),
         ]:
             data = np.zeros((12, 17, 1, 1))

--- a/src/symfluence/models/summa/structure_analyzer.py
+++ b/src/symfluence/models/summa/structure_analyzer.py
@@ -166,13 +166,68 @@ class SummaStructureAnalyzer(BaseStructureEnsembleAnalyzer):
         else:
             self.logger.info("Skipping mizuRoute routing (not configured)")
 
+    def _get_optimization_target(self) -> str:
+        return (self._resolve(
+            lambda: self.config.optimization.target,
+            'OPTIMIZATION_TARGET', 'streamflow'
+        ) or 'streamflow').lower()
+
     def calculate_performance_metrics(self) -> Dict[str, float]:
         """
-        Calculate performance metrics comparing simulated routed runoff to observations.
+        Calculate performance metrics for the current model run.
+
+        Dispatches to target-specific logic: streamflow uses mizuRoute routed
+        runoff; non-streamflow targets (SWE, SCA, ET, …) delegate to the
+        matching evaluator from the EvaluationRegistry.
 
         Returns:
             Dict: Dictionary containing KGE, NSE, MAE, and RMSE.
         """
+        opt_target = self._get_optimization_target()
+        if opt_target not in ('streamflow', 'flow', 'discharge'):
+            return self._calculate_evaluator_metrics(opt_target)
+        return self._calculate_streamflow_metrics()
+
+    def _calculate_evaluator_metrics(self, opt_target: str) -> Dict[str, float]:
+        """Delegate metric calculation to the appropriate evaluator."""
+        from symfluence.evaluation.registry import EvaluationRegistry
+
+        target_to_family = {
+            'swe': 'SNOW', 'sca': 'SNOW', 'snow_depth': 'SNOW', 'snow': 'SNOW',
+            'et': 'ET', 'latent_heat': 'ET', 'evapotranspiration': 'ET',
+            'sm_point': 'SOIL_MOISTURE', 'sm_smap': 'SOIL_MOISTURE',
+            'sm_esa': 'SOIL_MOISTURE', 'sm_ismn': 'SOIL_MOISTURE',
+            'soil_moisture': 'SOIL_MOISTURE', 'sm': 'SOIL_MOISTURE',
+        }
+        family = target_to_family.get(opt_target, opt_target.upper())
+
+        evaluator = EvaluationRegistry.get_evaluator(
+            family, self.config, self.logger, self.project_dir,
+            target=opt_target,
+        )
+        if evaluator is None:
+            self.logger.error(
+                "No evaluator registered for '%s' (family '%s')", opt_target, family,
+            )
+            return {'kge': np.nan, 'kgep': np.nan, 'nse': np.nan, 'mae': np.nan, 'rmse': np.nan}
+
+        sim_dir = self.project_dir / 'simulations' / self.experiment_id / 'SUMMA'
+        result = evaluator.calculate_metrics(
+            sim=sim_dir, calibration_only=False,
+        )
+        if not result:
+            return {'kge': np.nan, 'kgep': np.nan, 'nse': np.nan, 'mae': np.nan, 'rmse': np.nan}
+
+        return {
+            'kge': float(result.get('KGE', result.get('Calib_KGE', np.nan))),
+            'kgep': float(result.get('KGEp', result.get('Calib_KGEp', np.nan))),
+            'nse': float(result.get('NSE', result.get('Calib_NSE', np.nan))),
+            'mae': float(result.get('MAE', result.get('Calib_MAE', np.nan))),
+            'rmse': float(result.get('RMSE', result.get('Calib_RMSE', np.nan))),
+        }
+
+    def _calculate_streamflow_metrics(self) -> Dict[str, float]:
+        """Original streamflow-specific metric calculation using mizuRoute output."""
         # Load observations
         obs_file_path = self._resolve(
             lambda: self.config.paths.observations_path,
@@ -198,7 +253,6 @@ class SummaStructureAnalyzer(BaseStructureEnsembleAnalyzer):
         )
 
         if sim_path_config == 'default' or not sim_path_config:
-            # Construct default mizuRoute output path
             start_year = (self.time_start or '1990').split('-')[0]
             sim_file_path = (
                 self.project_dir / 'simulations' / self.experiment_id /
@@ -213,27 +267,22 @@ class SummaStructureAnalyzer(BaseStructureEnsembleAnalyzer):
 
         # Process observations
         dfObs = pd.read_csv(obs_file_path, index_col='datetime', parse_dates=True)
-        # Use discharge_cms and resample to hourly
         if 'discharge_cms' in dfObs.columns:
             obs_series = dfObs['discharge_cms'].resample('h').mean()
         else:
-            # Fallback to first non-date column
             data_col = [c for c in dfObs.columns if c.lower() not in ['datetime', 'date']][0]
             obs_series = dfObs[data_col].resample('h').mean()
 
         # Process simulations
         with xr.open_dataset(sim_file_path, engine='netcdf4') as ds:
-            # Filter by reach ID
             if 'reachID' in ds.variables:
                 segment_index = ds['reachID'].values == int(sim_reach_ID)
                 ds_sel = ds.sel(seg=segment_index)
             else:
                 ds_sel = ds.isel(seg=0)
 
-            # Extract routed runoff
             var_name = 'IRFroutedRunoff' if 'IRFroutedRunoff' in ds_sel.variables else 'KWTroutedRunoff'
             if var_name not in ds_sel.variables:
-                # Fallback to any routed runoff variable
                 var_name = [v for v in ds_sel.variables if 'routedRunoff' in v][0]
 
             sim_df = ds_sel[var_name].to_dataframe().reset_index()

--- a/src/symfluence/optimization/optimization_manager.py
+++ b/src/symfluence/optimization/optimization_manager.py
@@ -467,9 +467,11 @@ class OptimizationManager(BaseManager):
 
                         # Extract optimization history
                         history = []
-                        if 'iteration' in results_df.columns or 'Iteration' in results_df.columns:
-                            iter_col = 'iteration' if 'iteration' in results_df.columns else 'Iteration'
-                            obj_cols = [c for c in results_df.columns if 'objective' in c.lower() or 'kge' in c.lower() or 'fitness' in c.lower()]
+                        iter_candidates = ['iteration', 'Iteration']
+                        iter_col = next((c for c in iter_candidates if c in results_df.columns), None)
+                        if iter_col:
+                            obj_cols = [c for c in results_df.columns
+                                        if any(k in c.lower() for k in ['objective', 'kge', 'fitness', 'score', 'nse', 'rmse'])]
                             obj_col = obj_cols[0] if obj_cols else None
                             if obj_col:
                                 for _, row in results_df.iterrows():
@@ -479,7 +481,12 @@ class OptimizationManager(BaseManager):
                                     })
 
                         # Extract best parameters - find actual best row, not just row 0
-                        param_cols = [c for c in results_df.columns if c not in ['iteration', 'Iteration', 'objective', 'Objective', 'kge', 'KGE', 'fitness']]
+                        non_param = {'iteration', 'Iteration', 'objective', 'Objective',
+                                     'kge', 'KGE', 'fitness', 'score', 'timestamp',
+                                     'crash_count', 'crash_rate', 'Calib_RMSE',
+                                     'Calib_KGE', 'Calib_KGEp', 'Calib_KGEnp',
+                                     'Calib_NSE', 'Calib_MAE'}
+                        param_cols = [c for c in results_df.columns if c not in non_param]
                         best_params = {}
                         if not results_df.empty and param_cols:
                             # Try to load best params from JSON file first (most reliable)

--- a/src/symfluence/reporting/orchestrators/calibration_orchestrator.py
+++ b/src/symfluence/reporting/orchestrators/calibration_orchestrator.py
@@ -47,6 +47,27 @@ class CalibrationOrchestrator(ConfigMixin):
         self.analysis_plotter = analysis_plotter
         self.model_output_orchestrator = model_output_orchestrator
 
+    def _find_summa_final_evaluation_file(self, experiment_id: str) -> Optional[Path]:
+        """Find calibrated SUMMA daily output from the final evaluation run."""
+        algorithm = str(self._get_config_value(
+            lambda: self.config.optimization.algorithm,
+            default='optimization',
+            dict_key='ITERATIVE_OPTIMIZATION_ALGORITHM',
+        )).lower()
+        final_eval_file = (
+            self.project_dir / "optimization" / "SUMMA" /
+            f"{algorithm}_{experiment_id}" / "final_evaluation" /
+            f"{experiment_id}_day.nc"
+        )
+        if final_eval_file.exists():
+            return final_eval_file
+
+        optimization_dir = self.project_dir / "optimization" / "SUMMA"
+        candidates = list(optimization_dir.glob(f"*/final_evaluation/{experiment_id}_day.nc"))
+        if not candidates:
+            return None
+        return max(candidates, key=lambda path: path.stat().st_mtime)
+
     @skip_if_not_visualizing()
     def generate_model_comparison_overview(
         self,
@@ -201,7 +222,17 @@ class CalibrationOrchestrator(ConfigMixin):
 
             elif calibration_target in ('swe', 'snow', 'snow_water_equivalent'):
                 # SWE calibration -> SUMMA outputs with SWE observations
-                summa_plots = self.model_output_orchestrator.visualize_summa_outputs(experiment_id)
+                final_eval_file = self._find_summa_final_evaluation_file(experiment_id)
+                if final_eval_file is not None:
+                    self.logger.info(f"Loading calibrated SUMMA output from: {final_eval_file}")
+                    summa_plots = self.analysis_plotter.plot_summa_outputs(
+                        experiment_id,
+                        summa_file=final_eval_file,
+                        output_suffix="calibrated",
+                    )
+                else:
+                    self.logger.info("No calibrated SUMMA final-evaluation output found; using standard simulation output")
+                    summa_plots = self.model_output_orchestrator.visualize_summa_outputs(experiment_id)
                 if 'scalarSWE' in summa_plots:
                     plot_paths['scalarSWE'] = summa_plots['scalarSWE']
                     plot_paths['model_comparison'] = summa_plots['scalarSWE']

--- a/src/symfluence/reporting/orchestrators/calibration_orchestrator.py
+++ b/src/symfluence/reporting/orchestrators/calibration_orchestrator.py
@@ -231,7 +231,7 @@ class CalibrationOrchestrator(ConfigMixin):
                         output_suffix="calibrated",
                     )
                 else:
-                    self.logger.info("No calibrated SUMMA final-evaluation output found; using standard simulation output")
+                    self.logger.info("No calibrated SUMMA final evaluation output found; using standard simulation output")
                     summa_plots = self.model_output_orchestrator.visualize_summa_outputs(experiment_id)
                 if 'scalarSWE' in summa_plots:
                     plot_paths['scalarSWE'] = summa_plots['scalarSWE']

--- a/src/symfluence/reporting/plotters/analysis_plotter.py
+++ b/src/symfluence/reporting/plotters/analysis_plotter.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 import pandas as pd
 
-from symfluence.core.constants import ConfigKeys, UnitConversion
+from symfluence.core.constants import ConfigKeys, UnitConversion, UnitConverter
 from symfluence.reporting.core.base_plotter import BasePlotter
 from symfluence.reporting.panels import (
     FDCPanel,
@@ -669,15 +669,11 @@ class AnalysisPlotter(BasePlotter):
 
         obs_series = df[swe_col].astype(float)
 
-        # Auto-detect units: if max < 50, likely inches; convert to mm
-        if obs_series.max() < 50:
-            obs_series = obs_series * 25.4  # inches to mm
-        elif obs_series.max() < 500:
-            # Could be cm, convert to mm
-            if obs_series.max() < 100:
-                obs_series = obs_series * 10  # cm to mm
-
-        return obs_series
+        return UnitConverter.swe_inches_to_mm(
+            obs_series,
+            auto_detect=True,
+            logger=self.logger,
+        )
 
     @BasePlotter._plot_safe("loading energy flux observations")
     def _load_energy_flux_observations(self, flux_type: str = 'LE') -> Optional[pd.Series]:
@@ -819,7 +815,13 @@ class AnalysisPlotter(BasePlotter):
         })
 
     @BasePlotter._plot_safe("plot_summa_outputs")
-    def plot_summa_outputs(self, experiment_id: str) -> Dict[str, str]:
+    def plot_summa_outputs(
+        self,
+        experiment_id: str,
+        *,
+        summa_file: Optional[Path] = None,
+        output_suffix: str = "",
+    ) -> Dict[str, str]:
         """
         Create professional visualizations for SUMMA output variables.
 
@@ -858,7 +860,8 @@ class AnalysisPlotter(BasePlotter):
             'scalarSenHeatTotal': lambda: self._load_energy_flux_observations('H'),
         }
 
-        summa_file = self.project_dir / "simulations" / experiment_id / "SUMMA" / f"{experiment_id}_day.nc"
+        if summa_file is None:
+            summa_file = self.project_dir / "simulations" / experiment_id / "SUMMA" / f"{experiment_id}_day.nc"
         if not summa_file.exists():
             return {}
 
@@ -1191,7 +1194,8 @@ class AnalysisPlotter(BasePlotter):
                 # Layout adjustment not critical - may fail with complex GridSpec
                 pass
 
-            plot_file = plot_dir / f'{var_name}.png'
+            suffix = f"_{output_suffix}" if output_suffix else ""
+            plot_file = plot_dir / f'{var_name}{suffix}.png'
             self._save_and_close(fig, plot_file)
             plot_paths[str(var_name)] = str(plot_file)
         ds.close()

--- a/src/symfluence/reporting/plotters/model_comparison/_data_loading.py
+++ b/src/symfluence/reporting/plotters/model_comparison/_data_loading.py
@@ -143,7 +143,9 @@ class ModelComparisonDataLoadingMixin:
         if "seg" in var_data.dims:
             if sim_reach_id and dataset is not None and "reachID" in dataset:
                 segment_mask = dataset["reachID"].values == int(sim_reach_id)
-                return var_data.sel(seg=segment_mask).to_pandas()
+                if segment_mask.any():
+                    idx = int(segment_mask.argmax())
+                    return var_data.isel(seg=idx).to_pandas()
             outlet_idx = int(np.argmax(var_data.mean(dim="time").values))
             return var_data.isel(seg=outlet_idx).to_pandas()
 

--- a/src/symfluence/reporting/plotters/workflow_diagnostic_plotter.py
+++ b/src/symfluence/reporting/plotters/workflow_diagnostic_plotter.py
@@ -786,20 +786,37 @@ class WorkflowDiagnosticPlotter(BasePlotter):
         # Create validation summary text
         validation_items = []
 
-        # Check for common required files based on model
-        required_files = {
-            'SUMMA': ['forcing.nc', 'attributes.nc', 'coldState.nc'],
-            'FUSE': ['forcing.nc', 'elev_bands.nc'],
-            'HYPE': ['Qobs.txt', 'Pobs.txt'],
-            'MESH': ['MESH_drainage_database.r2c'],
-        }
+        # Check for common required files based on model.
+        # SUMMA forcing is split into monthly files in the input_dir;
+        # attributes.nc and coldState.nc live in settings/SUMMA/.
+        settings_dir = input_dir.parent.parent / 'settings' / model_name.upper()
+        if model_name.upper() == 'SUMMA':
+            checks = [
+                ('forcing (*.nc)', any(input_dir.glob('*.nc'))),
+                ('attributes.nc', (settings_dir / 'attributes.nc').exists()),
+                ('coldState.nc', (settings_dir / 'coldState.nc').exists()),
+            ]
+        elif model_name.upper() == 'FUSE':
+            checks = [
+                ('forcing (*.nc)', any(input_dir.glob('*.nc'))),
+                ('elev_bands.nc', any(input_dir.glob('*elev_bands*'))),
+            ]
+        elif model_name.upper() == 'HYPE':
+            checks = [
+                ('Qobs.txt', (input_dir / 'Qobs.txt').exists()),
+                ('Pobs.txt', (input_dir / 'Pobs.txt').exists()),
+            ]
+        elif model_name.upper() == 'MESH':
+            checks = [
+                ('MESH_drainage_database.r2c', any(input_dir.glob('*drainage_database*'))),
+            ]
+        else:
+            checks = []
 
-        model_reqs = required_files.get(model_name.upper(), [])
-        if model_reqs and input_dir.exists():
-            for req in model_reqs:
-                found = any(f.name == req or req in f.name for f in input_dir.glob('*'))
+        if checks:
+            for label, found in checks:
                 status = '  [OK]' if found else ' [MISSING]'
-                validation_items.append(f'{req}: {status}')
+                validation_items.append(f'{label}: {status}')
         else:
             validation_items.append(f'No specific requirements for {model_name}')
 

--- a/src/symfluence/reporting/plotters/workflow_diagnostic_plotter.py
+++ b/src/symfluence/reporting/plotters/workflow_diagnostic_plotter.py
@@ -706,6 +706,12 @@ class WorkflowDiagnosticPlotter(BasePlotter):
         timestamp = self._get_timestamp()
         plot_filename = output_dir / f'{timestamp}_{model_name}_input_diagnostic.png'
 
+        # Routing models keep their files in settings/, not forcing/
+        if model_name.upper() == 'MIZUROUTE':
+            settings_candidate = input_dir.parent.parent / 'settings' / 'mizuRoute'
+            if settings_candidate.exists():
+                input_dir = settings_candidate
+
         fig, axes = plt.subplots(1, 3, figsize=(15, 5))
 
         # Panel 1: File inventory
@@ -805,6 +811,11 @@ class WorkflowDiagnosticPlotter(BasePlotter):
             checks = [
                 ('Qobs.txt', (input_dir / 'Qobs.txt').exists()),
                 ('Pobs.txt', (input_dir / 'Pobs.txt').exists()),
+            ]
+        elif model_name.upper() == 'MIZUROUTE':
+            checks = [
+                ('topology.nc', any(input_dir.glob('*topology*'))),
+                ('control file', any(input_dir.glob('*.control'))),
             ]
         elif model_name.upper() == 'MESH':
             checks = [

--- a/tests/unit/data/acquisition/test_dem_source_error_hints.py
+++ b/tests/unit/data/acquisition/test_dem_source_error_hints.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""
+Regression tests for the DEM_SOURCE error message.
+
+SH reported that paper configs using ``DEM_SOURCE: MERIT`` failed with a
+bare "unsupported" message and the fix was discovered by trial and error
+(switching to ``copernicus``). MERIT-Hydro is only reachable via the MAF
+gistool (``DATA_ACCESS: hpc``) path; with ``DATA_ACCESS: cloud`` the
+request cannot succeed. Rather than silently aliasing ``MERIT`` to
+something the cloud dispatcher could not serve, we surface a specific
+actionable hint in the error so users understand the underlying
+constraint.
+
+The four paper configs in ``configs_orig/11_data_pipeline/`` that
+previously said ``DEM_SOURCE: MERIT`` were also updated to
+``copernicus`` in the same PR; this test only pins the error-message
+contract on the code side.
+"""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from symfluence.core.config.models import SymfluenceConfig
+from symfluence.data.acquisition.acquisition_service import AcquisitionService
+
+pytestmark = [pytest.mark.unit, pytest.mark.quick]
+
+
+def _service(tmp_path, **overrides):
+    cfg = {
+        "SYMFLUENCE_DATA_DIR": str(tmp_path),
+        "SYMFLUENCE_CODE_DIR": str(tmp_path / "code"),
+        "DOMAIN_NAME": "dem_err_test",
+        "EXPERIMENT_ID": "test",
+        "EXPERIMENT_TIME_START": "2020-01-01 00:00",
+        "EXPERIMENT_TIME_END": "2020-01-02 00:00",
+        "FORCING_DATASET": "ERA5",
+        "HYDROLOGICAL_MODEL": "SUMMA",
+        "DOMAIN_DEFINITION_METHOD": "lumped",
+        "SUB_GRID_DISCRETIZATION": "GRUs",
+        "BOUNDING_BOX_COORDS": "44.5/-87.9/44.2/-87.5",
+        "DATA_ACCESS": "cloud",
+    }
+    cfg.update(overrides)
+    return AcquisitionService(
+        SymfluenceConfig(**cfg), logging.getLogger("dem_err_test")
+    )
+
+
+def _trigger_dem_dispatch(svc):
+    """Drive acquire_attributes far enough to hit the DEM-source branch.
+
+    The cloud path reaches the unsupported-DEM_SOURCE raise inside a
+    task appended to a parallel executor. We run the single task inline
+    to bubble the raise directly.
+    """
+    # The raise lives in the cloud branch only; stub out the downloader
+    # so we don't actually hit Copernicus etc.
+    with patch(
+        "symfluence.data.acquisition.acquisition_service.CloudForcingDownloader"
+    ), patch.object(
+        AcquisitionService, "_run_parallel_tasks",
+        side_effect=lambda tasks, desc="": {
+            name: (fn() if callable(fn) else None)  # actually execute the closure
+            for name, fn in tasks
+        },
+    ):
+        svc.acquire_attributes()
+
+
+def test_merit_on_cloud_gives_actionable_error(tmp_path):
+    """DEM_SOURCE=MERIT with DATA_ACCESS=cloud must name MERIT
+    specifically, explain that it needs hpc + gistool, and list cloud
+    alternatives."""
+    svc = _service(tmp_path, DEM_SOURCE="MERIT")
+    with pytest.raises(Exception) as exc:
+        _trigger_dem_dispatch(svc)
+    msg = str(exc.value)
+    # Specific to MERIT → name the cloud/hpc distinction
+    assert "MERIT" in msg or "merit" in msg.lower()
+    assert "hpc" in msg.lower() or "MAF" in msg or "gistool" in msg
+    assert "copernicus" in msg.lower()
+
+
+def test_generic_unsupported_dem_lists_cloud_alternatives(tmp_path):
+    """For any other unsupported DEM_SOURCE, the error lists the cloud
+    alternatives so the user can pick one without spelunking."""
+    svc = _service(tmp_path, DEM_SOURCE="not_a_real_source")
+    with pytest.raises(Exception) as exc:
+        _trigger_dem_dispatch(svc)
+    msg = str(exc.value)
+    assert "not_a_real_source" in msg
+    # Must list at least the default and one alternative
+    assert "copernicus" in msg.lower()
+    assert "fabdem" in msg.lower() or "nasadem" in msg.lower()

--- a/tests/unit/evaluation/test_analysis_manager.py
+++ b/tests/unit/evaluation/test_analysis_manager.py
@@ -107,6 +107,50 @@ def test_validate_analysis_requirements_accepts_processed_streamflow_path() -> N
         }
 
 
+def test_benchmarking_skipped_for_swe_target() -> None:
+    """Benchmarking returns None and logs skip when OPTIMIZATION_TARGET is SWE."""
+    with tempfile.TemporaryDirectory(prefix="sf_analysis_tests_") as tmp_dir:
+        config = SymfluenceConfig.from_minimal(
+            domain_name="test_domain",
+            model="SUMMA",
+            SYMFLUENCE_DATA_DIR=str(tmp_dir),
+            EXPERIMENT_ID="test_exp",
+            EXPERIMENT_TIME_START="2010-01-01 00:00",
+            EXPERIMENT_TIME_END="2010-01-10 23:00",
+            CALIBRATION_PERIOD="2010-01-01, 2010-01-05",
+            EVALUATION_PERIOD="2010-01-06, 2010-01-10",
+            OPTIMIZATION_TARGET="SWE",
+        )
+        logger = logging.getLogger("test_benchmark_skip")
+        manager = AnalysisManager(config, logger)
+
+        result = manager.run_benchmarking()
+        assert result is None
+
+
+def test_benchmarking_not_skipped_for_streamflow_target() -> None:
+    """Benchmarking does not short-circuit for streamflow target."""
+    with tempfile.TemporaryDirectory(prefix="sf_analysis_tests_") as tmp_dir:
+        config = SymfluenceConfig.from_minimal(
+            domain_name="test_domain",
+            model="SUMMA",
+            SYMFLUENCE_DATA_DIR=str(tmp_dir),
+            EXPERIMENT_ID="test_exp",
+            EXPERIMENT_TIME_START="2010-01-01 00:00",
+            EXPERIMENT_TIME_END="2010-01-10 23:00",
+            CALIBRATION_PERIOD="2010-01-01, 2010-01-05",
+            EVALUATION_PERIOD="2010-01-06, 2010-01-10",
+            OPTIMIZATION_TARGET="streamflow",
+        )
+        logger = logging.getLogger("test_benchmark_proceed")
+        manager = AnalysisManager(config, logger)
+
+        # Returns None because observation data is missing, but should
+        # NOT have short-circuited due to the target check
+        result = manager.run_benchmarking()
+        assert result is None
+
+
 def test_validate_analysis_requirements_fails_without_streamflow() -> None:
     """All analyses are marked unavailable when no streamflow observations are found."""
     with tempfile.TemporaryDirectory(prefix="sf_analysis_tests_") as tmp_dir:

--- a/tests/unit/models/test_summa_structure_analyzer.py
+++ b/tests/unit/models/test_summa_structure_analyzer.py
@@ -207,6 +207,145 @@ class TestSummaStructureAnalyzerLazyLoading:
         assert not any('Routing (mizuRoute)' in str(call) for call in self.logger.info.call_args_list)
 
 
+class TestCalculatePerformanceMetricsDispatch:
+    """Test that calculate_performance_metrics dispatches by OPTIMIZATION_TARGET."""
+
+    def setup_method(self):
+        self.base_config = {
+            'SYMFLUENCE_DATA_DIR': '/tmp/test_data',
+            'DOMAIN_NAME': 'test_domain',
+            'EXPERIMENT_ID': 'test_exp',
+            'SUMMA_DECISION_OPTIONS': {},
+        }
+        self.logger = Mock()
+
+    @patch('symfluence.models.summa.structure_analyzer.SummaRunner')
+    def test_default_target_is_streamflow(self, mock_summa_runner):
+        from symfluence.models.summa.structure_analyzer import SummaStructureAnalyzer
+
+        analyzer = SummaStructureAnalyzer(self.base_config, self.logger)
+        assert analyzer._get_optimization_target() == 'streamflow'
+
+    @patch('symfluence.models.summa.structure_analyzer.SummaRunner')
+    def test_swe_target_detected(self, mock_summa_runner):
+        from symfluence.models.summa.structure_analyzer import SummaStructureAnalyzer
+
+        config = {**self.base_config, 'OPTIMIZATION_TARGET': 'SWE'}
+        analyzer = SummaStructureAnalyzer(config, self.logger)
+        assert analyzer._get_optimization_target() == 'swe'
+
+    @patch('symfluence.models.summa.structure_analyzer.SummaRunner')
+    def test_streamflow_target_calls_streamflow_metrics(self, mock_summa_runner):
+        from symfluence.models.summa.structure_analyzer import SummaStructureAnalyzer
+
+        config = {**self.base_config, 'OPTIMIZATION_TARGET': 'streamflow'}
+        analyzer = SummaStructureAnalyzer(config, self.logger)
+        analyzer._calculate_streamflow_metrics = Mock(return_value={'kge': 0.8})
+        analyzer._calculate_evaluator_metrics = Mock()
+
+        result = analyzer.calculate_performance_metrics()
+
+        analyzer._calculate_streamflow_metrics.assert_called_once()
+        analyzer._calculate_evaluator_metrics.assert_not_called()
+        assert result == {'kge': 0.8}
+
+    @patch('symfluence.models.summa.structure_analyzer.SummaRunner')
+    def test_swe_target_calls_evaluator_metrics(self, mock_summa_runner):
+        from symfluence.models.summa.structure_analyzer import SummaStructureAnalyzer
+
+        config = {**self.base_config, 'OPTIMIZATION_TARGET': 'SWE'}
+        analyzer = SummaStructureAnalyzer(config, self.logger)
+        analyzer._calculate_streamflow_metrics = Mock()
+        analyzer._calculate_evaluator_metrics = Mock(return_value={'kge': 0.7})
+
+        result = analyzer.calculate_performance_metrics()
+
+        analyzer._calculate_evaluator_metrics.assert_called_once_with('swe')
+        analyzer._calculate_streamflow_metrics.assert_not_called()
+        assert result == {'kge': 0.7}
+
+    @patch('symfluence.models.summa.structure_analyzer.SummaRunner')
+    def test_flow_target_calls_streamflow_metrics(self, mock_summa_runner):
+        from symfluence.models.summa.structure_analyzer import SummaStructureAnalyzer
+
+        config = {**self.base_config, 'OPTIMIZATION_TARGET': 'flow'}
+        analyzer = SummaStructureAnalyzer(config, self.logger)
+        analyzer._calculate_streamflow_metrics = Mock(return_value={'kge': 0.9})
+
+        result = analyzer.calculate_performance_metrics()
+        analyzer._calculate_streamflow_metrics.assert_called_once()
+
+    @patch('symfluence.models.summa.structure_analyzer.SummaRunner')
+    def test_et_target_calls_evaluator_metrics(self, mock_summa_runner):
+        from symfluence.models.summa.structure_analyzer import SummaStructureAnalyzer
+
+        config = {**self.base_config, 'OPTIMIZATION_TARGET': 'ET'}
+        analyzer = SummaStructureAnalyzer(config, self.logger)
+        analyzer._calculate_evaluator_metrics = Mock(return_value={'kge': 0.6})
+
+        result = analyzer.calculate_performance_metrics()
+        analyzer._calculate_evaluator_metrics.assert_called_once_with('et')
+
+    @patch('symfluence.models.summa.structure_analyzer.SummaRunner')
+    @patch('symfluence.evaluation.registry.EvaluationRegistry.get_evaluator')
+    def test_evaluator_metrics_delegates_to_registry(self, mock_get_evaluator, mock_summa_runner):
+        from symfluence.models.summa.structure_analyzer import SummaStructureAnalyzer
+
+        mock_evaluator = Mock()
+        mock_evaluator.calculate_metrics.return_value = {
+            'KGE': 0.75, 'KGEp': 0.78, 'NSE': 0.70, 'MAE': 1.2, 'RMSE': 2.1,
+        }
+        mock_get_evaluator.return_value = mock_evaluator
+
+        config = {**self.base_config, 'OPTIMIZATION_TARGET': 'SWE'}
+        analyzer = SummaStructureAnalyzer(config, self.logger)
+
+        result = analyzer._calculate_evaluator_metrics('swe')
+
+        mock_get_evaluator.assert_called_once_with(
+            'SNOW', analyzer.config, analyzer.logger, analyzer.project_dir,
+            target='swe',
+        )
+        mock_evaluator.calculate_metrics.assert_called_once()
+        assert result['kge'] == 0.75
+        assert result['nse'] == 0.70
+
+    @patch('symfluence.models.summa.structure_analyzer.SummaRunner')
+    @patch('symfluence.evaluation.registry.EvaluationRegistry.get_evaluator')
+    def test_evaluator_metrics_returns_nan_when_no_evaluator(self, mock_get_evaluator, mock_summa_runner):
+        import numpy as np
+
+        from symfluence.models.summa.structure_analyzer import SummaStructureAnalyzer
+
+        mock_get_evaluator.return_value = None
+
+        config = {**self.base_config, 'OPTIMIZATION_TARGET': 'unknown_var'}
+        analyzer = SummaStructureAnalyzer(config, self.logger)
+
+        result = analyzer._calculate_evaluator_metrics('unknown_var')
+
+        assert np.isnan(result['kge'])
+        assert np.isnan(result['nse'])
+
+    @patch('symfluence.models.summa.structure_analyzer.SummaRunner')
+    @patch('symfluence.evaluation.registry.EvaluationRegistry.get_evaluator')
+    def test_evaluator_metrics_returns_nan_when_metrics_fail(self, mock_get_evaluator, mock_summa_runner):
+        import numpy as np
+
+        from symfluence.models.summa.structure_analyzer import SummaStructureAnalyzer
+
+        mock_evaluator = Mock()
+        mock_evaluator.calculate_metrics.return_value = None
+        mock_get_evaluator.return_value = mock_evaluator
+
+        config = {**self.base_config, 'OPTIMIZATION_TARGET': 'SWE'}
+        analyzer = SummaStructureAnalyzer(config, self.logger)
+
+        result = analyzer._calculate_evaluator_metrics('swe')
+
+        assert np.isnan(result['kge'])
+
+
 class TestBackwardCompatibility:
     """Test that existing code patterns still work."""
 


### PR DESCRIPTION
## Summary

Three improvements to the CLM model integration, each in a separate commit:

1. **MODIS → CLM PFT crosswalk** (`surface_generator.py`): Replace hardcoded PFT distribution (60% NET + 35% C3 arctic grass for all sites) with MODIS IGBP land cover classification mapped to CLM5 natural PFTs. Latitude-based refinement selects tropical/temperate/boreal tree PFTs and C3/C4 grass ratios. Monthly LAI, SAI, and canopy height are now per-PFT. Falls back to latitude-based defaults if MODIS data is unavailable.

2. **DEM-derived elevation** (`domain_generator.py`, `surface_generator.py`): `get_mean_elevation()` now reads from HRU shapefile `elev_mean`, DEM GeoTIFF, or DEM NetCDF before falling back to a configurable default (changed from 1500m to 300m). New `get_elevation_stats()` computes STD_ELEV and SLOPE from the DEM gradient. Previously all sites got hardcoded 1500m / 500m / 15°.

3. **ANA/CAMELS-BR handler** (`handlers/ana.py`): New streamflow observation handler for 897 Brazilian catchments. Downloads CAMELS-BR streamflow archive from Zenodo on first use, caches locally, extracts per-station. Follows the DGA/Chile handler pattern. Configured via `STREAMFLOW_DATA_PROVIDER: ANA`.

## Test plan

- [ ] Run `pytest tests/models/clm/` to verify CLM preprocessing still works
- [ ] Generate surfdata for a tropical site (should get BET_trop PFTs, not NET_temp)
- [ ] Generate surfdata for a grassland site (should get C3/C4 grass, not NET_temp)
- [ ] Verify elevation reads from GeoTIFF DEM for new domains
- [ ] Test ANA handler with station 15930000 (Rio Aripuanã)

🤖 Generated with [Claude Code](https://claude.com/claude-code)