### PR TITLE
fix(sa): loud-fail sensitivity analysis instead of silent skip

### DIFF
--- a/src/symfluence/evaluation/analysis_manager.py
+++ b/src/symfluence/evaluation/analysis_manager.py
@@ -393,22 +393,27 @@ class AnalysisManager(ConfigurableMixin):
             return None
 
         sensitivity_results = {}
+        per_model_errors: Dict[str, str] = {}
 
-        with symfluence_error_handler(
-            "sensitivity analysis",
-            self.logger,
-            reraise=False,
-            error_type=EvaluationError
-        ):
-            models_str = self._get_config_value(
-                lambda: self.config.model.hydrological_model,
-                ''
-            )
-            hydrological_models = str(models_str).split(',')
+        # Previously wrapped in symfluence_error_handler(reraise=False),
+        # which swallowed every SA failure as a warning and let the
+        # workflow step report "complete" with no output. Co-authors
+        # hit exactly this: SA produced no panels but the run said it
+        # succeeded, so there was no trail back to the root cause
+        # (typically "Bounds are not legal" from stringified bounds).
+        # Per-model failures are now captured as warnings (one bad
+        # model shouldn't sink SA for the others), but if NONE of the
+        # configured models produced results we raise so the workflow
+        # step is flagged failed and the user sees the aggregated
+        # cause.
+        models_str = self._get_config_value(
+            lambda: self.config.model.hydrological_model,
+            ''
+        )
+        hydrological_models = [m.strip().upper() for m in str(models_str).split(',') if m.strip()]
 
-            for model in hydrological_models:
-                model = model.strip().upper()
-
+        for model in hydrological_models:
+            try:
                 # Check registry for model-specific sensitivity analyzer
                 analyzer_cls = R.sensitivity_analyzers.get(model)
 
@@ -420,15 +425,35 @@ class AnalysisManager(ConfigurableMixin):
                     if results_file:
                         sensitivity_results[model] = analyzer.run_sensitivity_analysis(results_file)
                     else:
-                        self.logger.warning(f"Calibration results file not found for {model}")
+                        msg = f"Calibration results file not found for {model}"
+                        self.logger.warning(msg)
+                        per_model_errors[model] = msg
                 else:
                     # Fall back to generic sensitivity analyzer (works for SUMMA and similar)
                     self.logger.info(f"Using generic sensitivity analyzer for {model}")
                     sensitivity_results[model] = self._run_generic_sensitivity_analysis(model)
+            except Exception as exc:  # noqa: BLE001 — aggregate per-model failures for the post-loop decision
+                self.logger.error(
+                    f"Sensitivity analysis failed for {model}: {exc}",
+                    exc_info=True,
+                )
+                per_model_errors[model] = f"{type(exc).__name__}: {exc}"
 
-            return sensitivity_results if sensitivity_results else None
+        # Drop any None entries (analyzers that returned None silently).
+        sensitivity_results = {k: v for k, v in sensitivity_results.items() if v is not None}
 
-        return None
+        if not sensitivity_results and hydrological_models:
+            detail = "; ".join(
+                f"{m}: {per_model_errors.get(m, 'no results')}"
+                for m in hydrological_models
+            )
+            raise EvaluationError(
+                "Sensitivity analysis produced no results for any "
+                f"configured model ({', '.join(hydrological_models)}). "
+                f"Per-model causes: {detail}"
+            )
+
+        return sensitivity_results if sensitivity_results else None
 
     def _run_generic_sensitivity_analysis(self, model: str) -> Optional[Dict]:
         """

--- a/src/symfluence/evaluation/sensitivity_analysis.py
+++ b/src/symfluence/evaluation/sensitivity_analysis.py
@@ -157,10 +157,42 @@ class SensitivityAnalyzer(ConfigMixin):
         self.logger.info(f"Performing Sobol analysis using {metric} metric")
         parameter_columns = [col for col in samples.columns if col not in _NON_PARAM_COLS]
 
+        # SALib's sobol.analyze raises a generic "Bounds are not legal"
+        # ValueError when the bounds aren't numeric (e.g. a YAML pass
+        # serialized `[0.1, 2.0]` as `["0.1", "2.0"]`) or when min==max
+        # for any parameter (constant column, nothing to analyse).
+        # Both failures currently get swallowed upstream as a warning,
+        # so co-authors see "SA complete" with no output and no clue
+        # what went wrong. Validate here and raise a message that names
+        # the offending parameter and value.
+        bounds = []
+        for col in parameter_columns:
+            lo = samples[col].min()
+            hi = samples[col].max()
+            if not (isinstance(lo, (int, float, np.integer, np.floating)) and
+                    isinstance(hi, (int, float, np.integer, np.floating))):
+                raise ValueError(
+                    f"Sobol analysis cannot run: parameter '{col}' has "
+                    f"non-numeric bounds ({lo!r}, {hi!r}; types "
+                    f"{type(lo).__name__}/{type(hi).__name__}). This "
+                    "usually means the optimization results CSV has "
+                    "stringified numbers — check that the calibration "
+                    "writer serializes floats, not YAML-quoted strings."
+                )
+            if float(hi) <= float(lo):
+                raise ValueError(
+                    f"Sobol analysis cannot run: parameter '{col}' has "
+                    f"degenerate bounds (min={lo}, max={hi}). Every "
+                    "sample produced the same value, so there is no "
+                    "variance to attribute. Drop constant parameters "
+                    "from the calibration, or widen the search range."
+                )
+            bounds.append([float(lo), float(hi)])
+
         problem = {
             'num_vars': len(parameter_columns),
             'names': parameter_columns,
-            'bounds': [[samples[col].min(), samples[col].max()] for col in parameter_columns]
+            'bounds': bounds,
         }
 
         param_values = sobol_sample.sample(problem, 1024)

--- a/tests/unit/evaluation/test_sensitivity_loud_fail.py
+++ b/tests/unit/evaluation/test_sensitivity_loud_fail.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Regression tests for Sobol SA loud-fail on malformed inputs.
+
+A co-author reported that the sensitivity_analysis workflow step
+consistently reported '✓ Complete' with empty result panels. Root
+cause was that when the calibration-results CSV contained stringified
+parameter bounds (YAML round-trip artefact), SALib's sobol.analyze
+raised ``ValueError("Bounds are not legal")`` — and that exception
+was silently swallowed by a surrounding error-handler context with
+``reraise=False``.
+
+These tests pin two behaviours:
+
+1. ``SensitivityAnalyzer.perform_sobol_analysis`` validates bounds
+   up front and raises a named, actionable ``ValueError`` (naming the
+   offending parameter and its bogus value) rather than letting
+   SALib's opaque message propagate.
+2. ``AnalysisManager.run_sensitivity_analysis`` raises
+   ``EvaluationError`` when no configured model produces results,
+   so the workflow step is marked FAILED instead of silently
+   'complete with no output'.
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from symfluence.core.exceptions import EvaluationError
+from symfluence.evaluation.sensitivity_analysis import SensitivityAnalyzer
+
+pytestmark = [pytest.mark.unit, pytest.mark.quick]
+
+
+def _make_analyzer():
+    cfg = MagicMock()
+    logger = logging.getLogger("test_sa_loud_fail")
+    reporting = MagicMock()
+    return SensitivityAnalyzer(cfg, logger, reporting)
+
+
+def test_stringified_bounds_raise_actionable_value_error():
+    """If the samples DataFrame was round-tripped through YAML and
+    parameter columns ended up as strings, perform_sobol_analysis
+    must refuse up-front with a message that names the parameter
+    and the offending values — not SALib's generic 'Bounds are not
+    legal'."""
+    samples = pd.DataFrame({
+        "param_a": ["0.1", "0.5", "2.0"],
+        "param_b": [1.0, 2.0, 3.0],
+        "RMSE": [0.1, 0.2, 0.3],
+    })
+    analyzer = _make_analyzer()
+    with pytest.raises(ValueError) as excinfo:
+        analyzer.perform_sobol_analysis(samples, metric="RMSE")
+    msg = str(excinfo.value)
+    assert "param_a" in msg
+    assert "non-numeric" in msg
+    assert "stringified" in msg.lower() or "yaml" in msg.lower()
+
+
+def test_constant_parameter_raises_actionable_value_error():
+    """A parameter column with zero variance (min == max) has no
+    attributable sensitivity; SALib rejects it, but the current
+    silent-swallow made this look like success. Validate here and
+    point the user at the fix."""
+    samples = pd.DataFrame({
+        "const_param": [0.5, 0.5, 0.5],
+        "other_param": [1.0, 2.0, 3.0],
+        "RMSE": [0.1, 0.2, 0.3],
+    })
+    analyzer = _make_analyzer()
+    with pytest.raises(ValueError) as excinfo:
+        analyzer.perform_sobol_analysis(samples, metric="RMSE")
+    msg = str(excinfo.value)
+    assert "const_param" in msg
+    assert "degenerate" in msg.lower() or "constant" in msg.lower() or "variance" in msg.lower()
+
+
+def test_analysis_manager_raises_when_no_model_produces_results(monkeypatch, tmp_path):
+    """When every configured model's sensitivity analysis fails or
+    returns nothing, AnalysisManager must raise EvaluationError so
+    the workflow runner marks the step FAILED — not silently
+    'complete with no output' like it did before."""
+    from symfluence.evaluation.analysis_manager import AnalysisManager
+
+    cfg = MagicMock()
+    cfg.model.hydrological_model = "SUMMA,FUSE"
+    cfg.analysis.run_sensitivity_analysis = True
+    logger = logging.getLogger("test_sa_manager_loud")
+    reporting = MagicMock()
+
+    mgr = AnalysisManager.__new__(AnalysisManager)
+    mgr.config = cfg
+    mgr.logger = logger
+    mgr.reporting_manager = reporting
+    mgr._get_config_value = lambda getter, default=None, **_: (
+        getter() if callable(getter) else default
+    )
+
+    def fail_generic(model):
+        raise ValueError(
+            "Sobol analysis cannot run: parameter 'x' has non-numeric bounds"
+        )
+
+    monkeypatch.setattr(mgr, "_run_generic_sensitivity_analysis", fail_generic)
+
+    with pytest.raises(EvaluationError) as excinfo:
+        mgr.run_sensitivity_analysis()
+
+    msg = str(excinfo.value)
+    assert "no results" in msg.lower()
+    assert "SUMMA" in msg
+    assert "FUSE" in msg
+    assert "non-numeric bounds" in msg

--- a/tests/unit/evaluation/test_sensitivity_loud_fail.py
+++ b/tests/unit/evaluation/test_sensitivity_loud_fail.py
@@ -36,10 +36,22 @@ pytestmark = [pytest.mark.unit, pytest.mark.quick]
 
 
 def _make_analyzer():
-    cfg = MagicMock()
-    logger = logging.getLogger("test_sa_loud_fail")
-    reporting = MagicMock()
-    return SensitivityAnalyzer(cfg, logger, reporting)
+    """Build an analyzer without running __init__.
+
+    SensitivityAnalyzer's ConfigMixin base computes a project directory
+    from config.system.data_dir at construction time. With a MagicMock
+    config those attribute accesses return child MagicMocks whose repr
+    (e.g. "<MagicMock name='mock.system.data_dir' ...>") contains '<'
+    and '>'. POSIX Path() silently accepts that string; Windows rejects
+    it with WinError 123. Bypassing __init__ avoids the path-construction
+    code entirely — the bounds validation under test doesn't touch self
+    attributes beyond self.logger.
+    """
+    analyzer = SensitivityAnalyzer.__new__(SensitivityAnalyzer)
+    analyzer.config = MagicMock()
+    analyzer.logger = logging.getLogger("test_sa_loud_fail")
+    analyzer.reporting_manager = MagicMock()
+    return analyzer
 
 
 def test_stringified_bounds_raise_actionable_value_error():

--- a/tools/quality/broad_exception_allowlist.txt
+++ b/tools/quality/broad_exception_allowlist.txt
@@ -390,6 +390,7 @@ src/symfluence/data/utils/variable_utils.py:VariableHandler.save_mappings:except
 src/symfluence/data_assimilation/da_manager.py:DataAssimilationManager.run_data_assimilation:except Exception as e:  # noqa: BLE001 — must-not-raise contract
 src/symfluence/data_assimilation/enkf/ensemble_manager.py:SubprocessEnsembleManager.extract_predictions:except Exception:  # noqa: BLE001 — must-not-raise contract
 src/symfluence/data_assimilation/enkf/ensemble_manager.py:SubprocessEnsembleManager.forecast_step:except Exception as e:  # noqa: BLE001 — must-not-raise contract
+src/symfluence/evaluation/analysis_manager.py:AnalysisManager.run_sensitivity_analysis:except Exception as exc:  # noqa: BLE001 — aggregate per-model failures for the post-loop decision
 src/symfluence/evaluation/benchmarking.py:Benchmarker._save_results:except Exception as e:  # noqa: BLE001 — wrap-and-raise to domain error
 src/symfluence/evaluation/benchmarking.py:Benchmarker.run_benchmarking:except Exception as e:  # noqa: BLE001 — wrap-and-raise to domain error
 src/symfluence/evaluation/evaluators/base.py:ModelEvaluator._calculate_likelihood_metrics:except Exception as e:  # noqa: BLE001 — optional feature, must not break metrics


### PR DESCRIPTION
## Summary

Iteration-2 P1 item. A co-author reported that `sensitivity_analysis` reported `✓ Complete` with empty panels — no errors above INFO. Two cooperating bugs:

1. **`perform_sobol_analysis` swallowed stringified bounds** — if the calibration CSV had YAML-quoted numbers, SALib raised opaque `ValueError(\"Bounds are not legal\")`. A constant parameter (min==max) triggered the same.
2. **`AnalysisManager.run_sensitivity_analysis` wrapped the loop in `symfluence_error_handler(reraise=False)`** — every SA failure was demoted to a WARNING and the method returned None, indistinguishable from \"SA disabled\".

## Fix

- `perform_sobol_analysis`: validate bounds up front. Raise `ValueError` naming the parameter + values for both non-numeric and degenerate cases.
- `AnalysisManager`: stop using the global `reraise=False` handler. Per-model failures → warnings (one bad model shouldn't sink SA for the rest). If NO model produces results → raise `EvaluationError` with aggregated per-model causes so the orchestrator flags the step FAILED.

## Test plan

- [x] `tests/unit/evaluation/test_sensitivity_loud_fail.py` — 3/3 pass locally
  - stringified bounds → actionable ValueError
  - degenerate bounds → actionable ValueError
  - no-model-succeeds → EvaluationError aggregating per-model causes
- [x] Existing `tests/unit/evaluation/test_analysis_manager.py` — 3/3 pass
- [ ] CI: full unit suite + cross-platform

Part of the iteration-2 co-author response. Follow-ups still queued: HBV decision-step skip (#19), 08_large_sample bugs (#20), NEX-GDDP CFIF (#21).

Assisted-by: Claude (Anthropic)