### PR TITLE
fix(decision): mark no-decision-structure models as skipped-by-design

### DIFF
--- a/src/symfluence/evaluation/analysis_manager.py
+++ b/src/symfluence/evaluation/analysis_manager.py
@@ -591,11 +591,37 @@ class AnalysisManager(ConfigurableMixin):
                         'best_combinations': best_combinations
                     }
                 else:
-                    available = R.decision_analyzers.keys()
+                    # Decision analysis is only meaningful for models that
+                    # expose alternative physics-parameterization choices
+                    # (currently SUMMA). Conceptual / lumped models like
+                    # HBV, GR4J, HYPE have a fixed structure by design
+                    # and there is nothing to analyse. Previously this
+                    # path emitted a generic INFO ("No decision analyzer
+                    # registered for model X") that a co-author read as
+                    # a bug — "why isn't HBV registered?" — and the step
+                    # still marked ✓ Complete with no output. Record the
+                    # skip explicitly and say why.
                     self.logger.info(
-                        f"No decision analyzer registered for model: {model}. "
-                        f"Available analyzers: {available}"
+                        f"{model}: skipping decision analysis — no "
+                        "decision structure by design (decision analysis "
+                        "requires a model with alternative physics "
+                        "parameterizations; registered analyzers: "
+                        f"{sorted(R.decision_analyzers.keys())})"
                     )
+                    decision_results[model] = {
+                        'skipped': True,
+                        'skipped_reason': 'no decision structure by design',
+                    }
+
+            # Summary so the workflow log makes the skip visible without
+            # re-reading per-model lines.
+            analysed = [m for m, v in decision_results.items() if not v.get('skipped')]
+            skipped = [m for m, v in decision_results.items() if v.get('skipped')]
+            self.logger.info(
+                f"Decision analysis summary: {len(analysed)}/{len(decision_results)} "
+                "models analysed"
+                + (f"; skipped by design: {', '.join(skipped)}" if skipped else "")
+            )
 
             return decision_results if decision_results else None
 

--- a/tests/unit/evaluation/test_decision_analysis_skip.py
+++ b/tests/unit/evaluation/test_decision_analysis_skip.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Regression test for the HBV decision-analysis skip marker.
+
+Co-author SH read the previous decision-analysis log for HBV as a
+bug:
+
+    No decision analyzer registered for model: HBV.
+    Available analyzers: ['SUMMA']
+
+SH's interpretation was "HBV isn't wired up"; the actual meaning is
+"HBV is a fixed-structure conceptual model with no physics decisions
+to analyse — this step is not applicable". The step still reported
+✓ Complete, reinforcing the misread.
+
+These tests pin that AnalysisManager.run_decision_analysis now:
+
+1. Records an explicit ``skipped=True`` entry for models without a
+   registered decision analyzer, naming "no decision structure by
+   design" as the reason.
+2. Emits a summary log naming the skipped models so a reviewer
+   skimming the log can tell analysed-vs-skipped at a glance.
+3. SUMMA (which does have a registered analyzer) still runs
+   normally and is recorded with ``skipped`` unset.
+"""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.quick]
+
+
+def _make_manager(models: str):
+    """Build a bare AnalysisManager bypassing its real __init__ so
+    the test doesn't depend on all of SYMFLUENCE's config
+    infrastructure."""
+    from symfluence.evaluation.analysis_manager import AnalysisManager
+
+    cfg = MagicMock()
+    cfg.model.hydrological_model = models
+    cfg.analysis.run_decision_analysis = True
+
+    mgr = AnalysisManager.__new__(AnalysisManager)
+    mgr.config = cfg
+    mgr.logger = logging.getLogger("test_decision_skip")
+    mgr.reporting_manager = MagicMock()
+    mgr._get_config_value = lambda getter, default=None, **_: (
+        getter() if callable(getter) else default
+    )
+    mgr._import_model_analyzers = lambda: None
+    return mgr
+
+
+def test_hbv_is_marked_skipped_with_design_reason(caplog):
+    """HBV must be recorded as skipped-by-design, not absent or
+    failed, and the log must say "no decision structure by design"
+    so a reader doesn't mistake it for a wiring bug."""
+    mgr = _make_manager("HBV")
+
+    with patch(
+        "symfluence.evaluation.analysis_manager.R.decision_analyzers"
+    ) as registry:
+        registry.get.return_value = None  # HBV has no analyzer
+        registry.keys.return_value = ["SUMMA"]
+        caplog.set_level(logging.INFO)
+        result = mgr.run_decision_analysis()
+
+    assert result is not None, "skip markers must be returned, not swallowed"
+    assert "HBV" in result
+    assert result["HBV"].get("skipped") is True
+    assert "no decision structure by design" in result["HBV"].get("skipped_reason", "")
+
+    log_text = "\n".join(r.getMessage() for r in caplog.records)
+    assert "HBV" in log_text
+    assert "skipping decision analysis" in log_text
+    assert "no decision structure by design" in log_text
+
+
+def test_summary_log_names_analysed_and_skipped(caplog):
+    """The per-run summary log must name both the analysed and the
+    skipped models so reviewers skimming the log can tell at a
+    glance what happened — no need to re-read per-model lines."""
+    mgr = _make_manager("SUMMA,HBV,GR4J")
+
+    summa_analyzer_cls = MagicMock()
+    summa_analyzer_cls.return_value.run_full_analysis.return_value = (
+        "/tmp/fake_results.csv",
+        {"KGE": {"score": 0.87}},
+    )
+
+    def fake_get(name):
+        return summa_analyzer_cls if name == "SUMMA" else None
+
+    with patch(
+        "symfluence.evaluation.analysis_manager.R.decision_analyzers"
+    ) as registry:
+        registry.get.side_effect = fake_get
+        registry.keys.return_value = ["SUMMA"]
+        caplog.set_level(logging.INFO)
+        result = mgr.run_decision_analysis()
+
+    assert result is not None
+    assert result["SUMMA"].get("skipped") is not True
+    assert result["HBV"].get("skipped") is True
+    assert result["GR4J"].get("skipped") is True
+
+    # The summary line should be unambiguous about what ran vs skipped.
+    summary_lines = [
+        r.getMessage() for r in caplog.records
+        if "Decision analysis summary" in r.getMessage()
+    ]
+    assert summary_lines, "summary line must be emitted"
+    line = summary_lines[0]
+    assert "1/3 models analysed" in line
+    assert "HBV" in line and "GR4J" in line
+    assert "skipped by design" in line


### PR DESCRIPTION
## Summary

Iteration-2 P1 item. Co-author SH read the HBV decision-analysis log as a bug ("why isn't HBV wired up?") when the actual meaning is "HBV is a fixed-structure conceptual model with no physics decisions to analyse — this step doesn't apply". The step still reported ✓ Complete with no artefacts, reinforcing the misread.

## Fix

- Per-model log now says **"HBV: skipping decision analysis — no decision structure by design"** so the design intent is unambiguous without reading framework source.
- `decision_results` gains a `{'skipped': True, 'skipped_reason': ...}` marker per non-registered model, so the returned dict is no longer indistinguishable from "nothing ran".
- New summary line: `Decision analysis summary: 1/3 models analysed; skipped by design: HBV, GR4J` — one line tells the whole story.
- SUMMA (the only model with a registered analyzer) behavior unchanged.

## Test plan

- [x] `tests/unit/evaluation/test_decision_analysis_skip.py` — 2/2 pass locally
  - HBV marked skipped with design reason + named in log
  - Mixed SUMMA/HBV/GR4J correctly distinguishes analysed vs skipped in both result dict and summary line
- [ ] CI: full unit suite + cross-platform

Part of the iteration-2 co-author response. P1 items remaining: 08_large_sample bugs (#20), NEX-GDDP CFIF (#21).

Assisted-by: Claude (Anthropic)