### PR TITLE
fix(lamah-ice): accept LAMAH_ICE_DOMAIN_ID as primary basin-id key

### DIFF
--- a/src/symfluence/data/observation/handlers/lamah_ice.py
+++ b/src/symfluence/data/observation/handlers/lamah_ice.py
@@ -33,15 +33,41 @@ class LamahIceStreamflowHandler(BaseObservationHandler):
     def acquire(self) -> Path:
         """
         Locates the raw LamaH-ICE file for the given station ID.
-        Expected config:
-        STATION_ID: '13'
-        LAMAH_ICE_PATH: '/path/to/lamah_ice'
+
+        Accepted config keys for the basin identifier (checked in order):
+            LAMAH_ICE_DOMAIN_ID: 105   # preferred — matches LaMAH-ICE's
+                                       # own D_gauges/.../ID_<n>.csv naming
+                                       # and is what the 08_large_sample
+                                       # paper configs (117 files) all use.
+            STATION_ID: 105            # legacy alias kept for generic
+                                       # cross-dataset configs.
+
+        LAMAH_ICE_PATH points at the local extracted dataset:
+            LAMAH_ICE_PATH: /path/to/lamah_ice
         """
-        station_id = self._get_config_value(lambda: self.config.evaluation.streamflow.station_id, dict_key='STATION_ID')
+        # LAMAH_ICE_DOMAIN_ID takes precedence. The 08_large_sample
+        # paper configs write this key; the handler previously only
+        # recognised STATION_ID, so every run silently failed at
+        # acquire with the misleading error "STATION_ID required for
+        # LAMAH_ICE acquisition".
+        station_id = (
+            self._get_config_value(
+                lambda: self.config.evaluation.lamah_ice.domain_id,
+                dict_key='LAMAH_ICE_DOMAIN_ID',
+            )
+            or self._get_config_value(
+                lambda: self.config.evaluation.streamflow.station_id,
+                dict_key='STATION_ID',
+            )
+        )
         lamah_path_str = self._get_config_value(lambda: self.config.data.lamah_ice_path, dict_key='LAMAH_ICE_PATH')
 
         if not station_id:
-            raise ValueError("STATION_ID required for LAMAH_ICE acquisition")
+            raise ValueError(
+                "LAMAH_ICE acquisition requires a basin identifier. Set "
+                "LAMAH_ICE_DOMAIN_ID (preferred — matches LaMAH-ICE's "
+                "own ID_<n>.csv naming) or STATION_ID in your config."
+            )
         if not lamah_path_str:
             raise ValueError("LAMAH_ICE_PATH required for LAMAH_ICE acquisition")
 

--- a/tests/unit/data/observation/test_lamah_ice_config_keys.py
+++ b/tests/unit/data/observation/test_lamah_ice_config_keys.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Regression test for the LAMAH-ICE handler's basin-id config key.
+
+Co-authors reported silent failures across all 08_large_sample
+configs (51 FUSE + 66 GR4J = 117 files). Root cause: every config
+specifies ``LAMAH_ICE_DOMAIN_ID: <n>`` (matching LaMAH-ICE's own
+``D_gauges/.../ID_<n>.csv`` naming), but the handler only looked
+up ``STATION_ID`` and raised a misleading ValueError when the
+lookup missed.
+
+Pin the fix: the handler accepts ``LAMAH_ICE_DOMAIN_ID`` as the
+primary key, falls back to ``STATION_ID`` for backwards compat,
+and raises a message that names both keys when neither is set.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from symfluence.data.observation.handlers.lamah_ice import (
+    LamahIceStreamflowHandler,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.quick]
+
+
+def _make_handler(config_dict, tmp_path):
+    """Build a handler backed by a dict config (mimicking the flat
+    YAML paper configs) and a tmp-path project dir."""
+    config = MagicMock()
+    # Force typed lookups to fail so the dict_key path is exercised —
+    # that's the path the paper configs go through.
+    config.evaluation = None
+    config.data = None
+    config.get = config_dict.get
+    config.__getitem__ = lambda s, k: config_dict[k]
+    config.__contains__ = lambda s, k: k in config_dict
+
+    handler = LamahIceStreamflowHandler.__new__(LamahIceStreamflowHandler)
+    handler.config = config
+    handler.config_dict = config_dict
+    handler.logger = MagicMock()
+    # project_observations_dir is a read-only property derived from
+    # project_dir — assigning to it directly raises AttributeError.
+    # Setting project_dir lets the property resolve naturally to
+    # project_dir/data/observations.
+    proj = tmp_path / "project"
+    (proj / "data" / "observations").mkdir(parents=True, exist_ok=True)
+    handler.project_dir = proj
+    handler.domain_name = "test_domain"
+
+    def _get(getter, dict_key=None, default=None):
+        try:
+            val = getter()
+            if val is not None:
+                return val
+        except AttributeError:
+            pass
+        if dict_key and dict_key in config_dict:
+            return config_dict[dict_key]
+        return default
+
+    handler._get_config_value = _get
+    return handler
+
+
+def _write_fake_lamah_tree(root: Path, station_id: str):
+    daily = root / "D_gauges" / "2_timeseries" / "daily"
+    daily.mkdir(parents=True, exist_ok=True)
+    fake = daily / f"ID_{station_id}.csv"
+    pd.DataFrame({
+        "YYYY": [2015, 2015],
+        "MM": [1, 1],
+        "DD": [1, 2],
+        "qobs": [10.0, 12.0],
+    }).to_csv(fake, sep=";", index=False)
+    return fake
+
+
+def test_lamah_ice_domain_id_is_accepted(tmp_path):
+    """The 08_large_sample paper configs use LAMAH_ICE_DOMAIN_ID.
+    That must be the primary accepted key."""
+    lamah_root = tmp_path / "lamah_ice"
+    _write_fake_lamah_tree(lamah_root, "105")
+
+    cfg = {
+        "LAMAH_ICE_DOMAIN_ID": 105,
+        "LAMAH_ICE_PATH": str(lamah_root),
+    }
+    handler = _make_handler(cfg, tmp_path)
+    out = handler.acquire()
+    assert out.exists()
+    assert "105" in out.name
+
+
+def test_station_id_still_works_as_alias(tmp_path):
+    """STATION_ID was the only accepted key before this fix. Keep it
+    working for generic cross-dataset configs."""
+    lamah_root = tmp_path / "lamah_ice"
+    _write_fake_lamah_tree(lamah_root, "13")
+
+    cfg = {
+        "STATION_ID": 13,
+        "LAMAH_ICE_PATH": str(lamah_root),
+    }
+    handler = _make_handler(cfg, tmp_path)
+    out = handler.acquire()
+    assert out.exists()
+    assert "13" in out.name
+
+
+def test_domain_id_takes_precedence_over_station_id(tmp_path):
+    """If both keys are set (e.g., after a partial config migration),
+    LAMAH_ICE_DOMAIN_ID wins — it's the LaMAH-ICE-native identifier."""
+    lamah_root = tmp_path / "lamah_ice"
+    _write_fake_lamah_tree(lamah_root, "105")
+    _write_fake_lamah_tree(lamah_root, "13")
+
+    cfg = {
+        "LAMAH_ICE_DOMAIN_ID": 105,
+        "STATION_ID": 13,
+        "LAMAH_ICE_PATH": str(lamah_root),
+    }
+    handler = _make_handler(cfg, tmp_path)
+    out = handler.acquire()
+    assert "105" in out.name
+    assert "13" not in out.name.replace("105", "")
+
+
+def test_neither_key_raises_with_both_names(tmp_path):
+    """When no basin id is set, the error must name BOTH accepted
+    config keys — the previous message only mentioned STATION_ID,
+    which sent co-authors on a wild goose chase."""
+    cfg = {"LAMAH_ICE_PATH": str(tmp_path)}
+    handler = _make_handler(cfg, tmp_path)
+    with pytest.raises(ValueError) as excinfo:
+        handler.acquire()
+    msg = str(excinfo.value)
+    assert "LAMAH_ICE_DOMAIN_ID" in msg
+    assert "STATION_ID" in msg


### PR DESCRIPTION
## Summary

Iteration-2 P1 item, 08_large_sample. All 117 paper configs (51 FUSE + 66 GR4J) specify:

    LAMAH_ICE_DOMAIN_ID: 105

mirroring LaMAH-ICE's native `D_gauges/.../ID_<n>.csv` naming. The handler only read `STATION_ID`, so every config hit:

    ValueError: STATION_ID required for LAMAH_ICE acquisition

...and the error message sent co-authors chasing the wrong field.

## Fix

Handler now accepts `LAMAH_ICE_DOMAIN_ID` as primary, keeping `STATION_ID` as backwards-compatible alias for generic cross-dataset configs. No-id error names both accepted keys.

## Test plan

- [x] `tests/unit/data/observation/test_lamah_ice_config_keys.py` — 4/4 pass locally
  - `LAMAH_ICE_DOMAIN_ID` accepted (the paper config case)
  - `STATION_ID` still works as alias
  - `LAMAH_ICE_DOMAIN_ID` wins when both are set
  - No-id error names both keys
- [ ] CI: full unit suite + cross-platform

## Follow-up (not in this PR)

The pour-point complaint in the P1 list still needs specifics — I don't have enough info to pin a bug without seeing the co-author's exact config path. Flagging to loop back after clarification.

Part of the iteration-2 co-author response. Remaining: NEX-GDDP CFIF fallback (#21).

Assisted-by: Claude (Anthropic)