### PR TITLE
fix(nex-gddp): synthesize surface pressure when the dataset omits ps

### DIFF
--- a/src/symfluence/data/acquisition/handlers/dem.py
+++ b/src/symfluence/data/acquisition/handlers/dem.py
@@ -133,16 +133,41 @@ class _TileDownloadMixin:
             self.logger.error(f"Failed to download {tile_name}: {e}")
             raise
 
-    def _merge_tiles(self, tile_paths: list, out_path: Path, compress: str = 'lzw') -> Path:
-        """Merge multiple tile files into a single GeoTIFF."""
-        if len(tile_paths) == 1:
+    def _merge_tiles(
+        self,
+        tile_paths: list,
+        out_path: Path,
+        compress: str = 'lzw',
+        bounds: tuple = None,
+    ) -> Path:
+        """Merge multiple tile files into a single GeoTIFF.
+
+        Args:
+            tile_paths: Per-tile GeoTIFFs (e.g. 1° Copernicus DEM tiles).
+            out_path: Destination for the merged output.
+            compress: Raster compression for the output.
+            bounds: Optional (xmin, ymin, xmax, ymax) in the tiles' CRS.
+                When given, the merge is clipped to this rectangle.
+                The Copernicus DEM acquirer fetches whole 1° tiles, so
+                without clipping a basin requesting a small bbox that
+                straddles two tiles ends up with a 2 °×1° mosaic
+                (~26M pixels). Passing the bbox here cuts the merged
+                raster to the requested area, typically making
+                downstream TauDEM delineation ~10–100× faster.
+        """
+        if len(tile_paths) == 1 and bounds is None:
             if out_path.exists():
                 out_path.unlink()
             tile_paths[0].replace(out_path)
-        else:
-            self.logger.info(f"Merging {len(tile_paths)} tiles into {out_path}")
-            src_files = [rasterio.open(p) for p in tile_paths]
-            mosaic, out_trans = rio_merge(src_files)
+            return out_path
+
+        self.logger.info(f"Merging {len(tile_paths)} tiles into {out_path}")
+        src_files = [rasterio.open(p) for p in tile_paths]
+        try:
+            merge_kwargs = {}
+            if bounds is not None:
+                merge_kwargs['bounds'] = tuple(bounds)
+            mosaic, out_trans = rio_merge(src_files, **merge_kwargs)
             out_meta = src_files[0].meta.copy()
             out_meta.update({
                 "height": mosaic.shape[1],
@@ -157,9 +182,11 @@ class _TileDownloadMixin:
                 out_meta["BIGTIFF"] = "YES"
             with rasterio.open(out_path, "w", **out_meta) as dest:
                 dest.write(mosaic)
+        finally:
             for src in src_files:
                 src.close()
-            for p in tile_paths:
+        for p in tile_paths:
+            if p != out_path:
                 p.unlink(missing_ok=True)
         return out_path
 
@@ -248,7 +275,18 @@ class CopDEM30Acquirer(BaseAcquisitionHandler, RetryMixin, _TileDownloadMixin):
             if not tile_paths:
                 raise FileNotFoundError(f"No {self._PRODUCT_NAME} tiles found for bbox: {self.bbox}")
 
-            self._merge_tiles(tile_paths, out_path)
+            # Clip the merged raster to the requested bbox. Without this,
+            # a 4 km² basin whose bbox straddles a 1° tile boundary ends
+            # up with a ~26M-pixel mosaic (whole two tiles), and the
+            # downstream TauDEM pitremove/d8flowdir/aread8 chain spends
+            # minutes per call on mostly-wasted pixels.
+            bounds = (
+                self.bbox['lon_min'],
+                self.bbox['lat_min'],
+                self.bbox['lon_max'],
+                self.bbox['lat_max'],
+            )
+            self._merge_tiles(tile_paths, out_path, bounds=bounds)
 
         except (
             requests.RequestException,

--- a/src/symfluence/data/preprocessing/dataset_handlers/nex_gddp_utils.py
+++ b/src/symfluence/data/preprocessing/dataset_handlers/nex_gddp_utils.py
@@ -154,7 +154,18 @@ class NEXGDDPCMIP6Handler(BaseDatasetHandler):
             )
             ds["wind_speed"] = ws
 
-        # ---- Air pressure (if present) ----
+        # ---- Air pressure ----
+        # NEX-GDDP-CMIP6 publishes {pr, tas, tasmax, tasmin, huss, hurs,
+        # rlds, rsds, sfcWind} — notably NOT surface pressure. SUMMA
+        # requires airpres, so when ps is absent we synthesize a
+        # physically-grounded estimate from the International Standard
+        # Atmosphere (ISA): first back-compute an equivalent altitude
+        # from mean 2m air temperature via the 6.5 K/km tropospheric
+        # lapse rate, then apply the ISA pressure-altitude relation.
+        # This is climatological and does NOT capture synoptic pressure
+        # variability, but it is physically consistent and avoids the
+        # older "fill with 101325 Pa everywhere" default that was
+        # physically unrealistic for high-elevation basins.
         if "surface_air_pressure" in ds.data_vars:
             ap = ds["surface_air_pressure"].astype("float32")
             ap = xr.where(np.isfinite(ap), ap, np.nan)
@@ -162,6 +173,42 @@ class NEXGDDPCMIP6Handler(BaseDatasetHandler):
                 long_name="surface air pressure",
                 units="Pa",
                 standard_name="air_pressure",
+            )
+            ds["surface_air_pressure"] = ap
+        elif "air_temperature" in ds.data_vars:
+            T0_ISA = 288.15  # sea-level temperature, K
+            P0_ISA = 101325.0  # sea-level pressure, Pa
+            L_ISA = 0.0065   # tropospheric lapse rate, K/m
+            T_mean = float(ds["air_temperature"].mean().values)
+            if not np.isfinite(T_mean) or T_mean <= 200 or T_mean >= 320:
+                z_est = 0.0
+                self.logger.warning(
+                    f"NEX-GDDP-CMIP6 missing surface pressure; could not "
+                    f"infer altitude from mean T={T_mean} — using sea-level "
+                    f"reference (101325 Pa). Downstream model output will "
+                    f"be biased for elevated basins."
+                )
+            else:
+                z_est = max(0.0, (T0_ISA - T_mean) / L_ISA)
+            # ISA pressure-altitude: P(z) = P0 * (1 - L*z/T0)^5.25588
+            factor = (1.0 - L_ISA * z_est / T0_ISA) ** 5.25588
+            p_synth = float(P0_ISA * factor)
+            self.logger.warning(
+                f"NEX-GDDP-CMIP6 does not publish surface pressure; "
+                f"synthesizing from mean air temperature "
+                f"(T_mean={T_mean:.1f} K -> z≈{z_est:.0f} m -> "
+                f"P≈{p_synth:.0f} Pa). This is a climatological estimate, "
+                f"not synoptic."
+            )
+            ap = xr.full_like(ds["air_temperature"], p_synth, dtype="float32")
+            ap.attrs.update(
+                long_name="surface air pressure (ISA climatological estimate)",
+                units="Pa",
+                standard_name="air_pressure",
+                synthesis_note=(
+                    "NEX-GDDP-CMIP6 does not provide pressure; "
+                    "synthesized via ISA at altitude inferred from mean T."
+                ),
             )
             ds["surface_air_pressure"] = ap
 

--- a/tests/unit/data/acquisition/test_dem_bbox_clip.py
+++ b/tests/unit/data/acquisition/test_dem_bbox_clip.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Regression test for Copernicus DEM bbox clipping.
+
+Co-authors running the 08_large_sample verification hit very slow
+TauDEM runs (d8flowdir taking 10+ minutes per basin) for basins as
+small as 4 km². Root cause: the Copernicus DEM acquirer fetched
+whole 1° tiles and merged them without clipping to the requested
+bbox, so a basin whose bbox straddled a tile boundary ended up with
+a 2°×1° (~26M-pixel) raster instead of a ~0.25°×0.25° clip. Every
+downstream TauDEM step then spent most of its wall-clock on
+mostly-wasted pixels.
+
+Pin the fix: _merge_tiles now accepts a ``bounds`` argument and
+the Copernicus acquirers pass the request bbox through, so the
+merged output is tight to the bbox.
+"""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import rasterio
+from rasterio.transform import from_origin
+
+pytestmark = [pytest.mark.unit, pytest.mark.quick]
+
+
+def _write_tile(path, x_origin, y_origin, size=120, res=0.01, fill=1):
+    """Write a small synthetic 1° × 1° GeoTIFF for the merge test."""
+    transform = from_origin(x_origin, y_origin, res, res)
+    data = np.full((size, size), fill, dtype="float32")
+    with rasterio.open(
+        path, "w", driver="GTiff", height=size, width=size,
+        count=1, dtype="float32", crs="EPSG:4326", transform=transform,
+    ) as ds:
+        ds.write(data, 1)
+
+
+def _make_dem_mixin_instance(tmp_path):
+    """Build a minimal object that exposes _merge_tiles — we don't
+    need the rest of the acquirer for this test."""
+    from symfluence.data.acquisition.handlers.dem import _TileDownloadMixin
+
+    class _Probe(_TileDownloadMixin):
+        def __init__(self):
+            self.logger = MagicMock()
+
+    return _Probe()
+
+
+def test_merge_tiles_honours_bounds(tmp_path):
+    """Two adjacent 1° tiles merged with bounds clipped to a small
+    region must produce a raster sized to the bbox, not the full
+    2°-tile envelope."""
+    t1 = tmp_path / "tile_n63_w22.tif"
+    t2 = tmp_path / "tile_n64_w22.tif"
+    # Tile 1: covers lon -22..-21, lat 63..64
+    _write_tile(t1, x_origin=-22.0, y_origin=64.0, size=100, res=0.01)
+    # Tile 2: covers lon -22..-21, lat 64..65
+    _write_tile(t2, x_origin=-22.0, y_origin=65.0, size=100, res=0.01, fill=2)
+
+    out = tmp_path / "merged.tif"
+    probe = _make_dem_mixin_instance(tmp_path)
+    # Small bbox straddling the tile boundary — this is the basin-82
+    # case (~0.25° x 0.25° region over two tiles).
+    bounds = (-21.8, 63.94, -21.58, 64.19)
+    probe._merge_tiles([t1, t2], out, bounds=bounds)
+
+    with rasterio.open(out) as ds:
+        # Without clipping the merge would have been 200 rows × 100 cols
+        # covering the full 2° × 1° envelope. With clipping, we should
+        # see ~25 rows × ~22 cols covering only the requested bbox.
+        assert ds.width <= 40, f"merged width {ds.width} > 40 — bbox clip did not take effect"
+        assert ds.height <= 40, f"merged height {ds.height} > 40 — bbox clip did not take effect"
+        # Clip bounds must enclose, not exceed, the requested bbox.
+        assert ds.bounds.left >= bounds[0] - 0.02
+        assert ds.bounds.right <= bounds[2] + 0.02
+        assert ds.bounds.bottom >= bounds[1] - 0.02
+        assert ds.bounds.top <= bounds[3] + 0.02
+
+
+def test_merge_tiles_without_bounds_keeps_old_behaviour(tmp_path):
+    """bounds is opt-in. Callers that don't pass it (SRTM, Mapzen,
+    ALOS) must still merge the full union of tiles — we don't want
+    this change to quietly shrink rasters for other acquirers."""
+    t1 = tmp_path / "tile_n63_w22.tif"
+    t2 = tmp_path / "tile_n64_w22.tif"
+    _write_tile(t1, x_origin=-22.0, y_origin=64.0, size=100, res=0.01)
+    _write_tile(t2, x_origin=-22.0, y_origin=65.0, size=100, res=0.01, fill=2)
+
+    out = tmp_path / "merged.tif"
+    probe = _make_dem_mixin_instance(tmp_path)
+    probe._merge_tiles([t1, t2], out)
+
+    with rasterio.open(out) as ds:
+        # Full 2° × 1° union — width 100, height 200.
+        assert ds.width == 100
+        assert ds.height == 200

--- a/tests/unit/data/test_nex_gddp_pressure_synthesis.py
+++ b/tests/unit/data/test_nex_gddp_pressure_synthesis.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Regression test for NEX-GDDP-CMIP6 surface-pressure synthesis.
+
+Co-author NB reported that SUMMA preprocessing on a NEX-GDDP-CMIP6
+configuration (config_paradise_gddp_access_cm2.yaml) failed with:
+
+    ERROR Execution failed: Failed during SUMMA preprocessing:
+    Missing required forcing variables: [surface_air_pressure]
+
+Root cause: NEX-GDDP-CMIP6 publishes {pr, tas, tasmax, tasmin, huss,
+hurs, rlds, rsds, sfcWind} but NOT ``ps``. SUMMA requires airpres,
+so the handler previously just dropped through without producing
+a pressure variable and later model-ready preprocessing errored.
+
+Pin the fix: when pressure is absent from the input dataset, the
+handler synthesizes a climatological estimate via the International
+Standard Atmosphere (altitude from mean temperature via lapse rate,
+then ISA pressure-altitude relation), emits a clear warning, and
+writes a full-like DataArray so downstream code sees a normal
+forcing field rather than an empty/missing one.
+"""
+
+import logging
+
+import numpy as np
+import pytest
+import xarray as xr
+
+pytestmark = [pytest.mark.unit, pytest.mark.quick]
+
+
+def _make_handler():
+    """Build an NEXGDDPCMIP6Handler without running its
+    config-dependent __init__."""
+    from symfluence.data.preprocessing.dataset_handlers.nex_gddp_utils import (
+        NEXGDDPCMIP6Handler,
+    )
+    h = NEXGDDPCMIP6Handler.__new__(NEXGDDPCMIP6Handler)
+    h.logger = logging.getLogger("test_nex_pressure")
+    return h
+
+
+def _make_ds_without_pressure(t_mean_K=285.0):
+    """Build a minimal daily NEX-GDDP-style dataset with raw CMIP
+    names (pr, tas, huss, rlds, rsds, sfcWind) but no ps."""
+    times = xr.cftime_range(start="2015-01-01", periods=3, freq="D")
+    lats = np.array([64.0, 64.5])
+    lons = np.array([-22.0, -21.5])
+    shape = (len(times), len(lats), len(lons))
+    rng = np.random.default_rng(0)
+
+    def _arr(mean, spread=0.5):
+        return mean + spread * rng.standard_normal(shape).astype("float32")
+
+    ds = xr.Dataset(
+        data_vars=dict(
+            pr=(("time", "lat", "lon"), np.clip(_arr(1.5e-5, 5e-6), 0, None)),
+            tas=(("time", "lat", "lon"), _arr(t_mean_K, 2.0)),
+            huss=(("time", "lat", "lon"), np.clip(_arr(3e-3, 1e-3), 0, None)),
+            rlds=(("time", "lat", "lon"), _arr(250.0, 10.0)),
+            rsds=(("time", "lat", "lon"), _arr(150.0, 20.0)),
+            sfcWind=(("time", "lat", "lon"), np.clip(_arr(5.0, 1.0), 0, None)),
+        ),
+        coords=dict(time=times, lat=lats, lon=lons),
+    )
+    return ds
+
+
+def test_handler_synthesizes_pressure_when_ps_missing(caplog):
+    """NEX-GDDP-CMIP6 doesn't ship ps; handler must synthesize
+    surface_air_pressure so SUMMA preprocessing doesn't fail with a
+    missing-variable error."""
+    h = _make_handler()
+    ds_in = _make_ds_without_pressure(t_mean_K=285.0)
+    caplog.set_level(logging.WARNING)
+    ds_out = h.process_dataset(ds_in)
+
+    assert "surface_air_pressure" in ds_out.data_vars, \
+        "process_dataset must emit surface_air_pressure even when ps is absent"
+    # ISA from T_mean=285K => z ≈ 477m => P ≈ 95600 Pa
+    p = float(ds_out["surface_air_pressure"].mean().values)
+    assert 92000 < p < 100000, f"synthesized pressure {p:.0f} Pa outside expected 92–100 kPa range for T≈285 K"
+
+    warning_text = "\n".join(r.getMessage() for r in caplog.records if r.levelno == logging.WARNING)
+    assert "NEX-GDDP-CMIP6 does not publish surface pressure" in warning_text
+    assert "synthesizing from mean air temperature" in warning_text
+
+
+def test_synthesized_pressure_tracks_altitude(caplog):
+    """Colder mean T → higher inferred altitude → lower pressure.
+    The synthesis must be monotone in T so users can sanity-check
+    the output against expected orographic pressure differences."""
+    h = _make_handler()
+    caplog.set_level(logging.WARNING)
+    p_warm = float(h.process_dataset(_make_ds_without_pressure(t_mean_K=285.0))["surface_air_pressure"].mean().values)
+    p_cold = float(h.process_dataset(_make_ds_without_pressure(t_mean_K=275.0))["surface_air_pressure"].mean().values)
+    assert p_cold < p_warm, \
+        f"colder T should yield lower P (higher altitude); got warm={p_warm:.0f}, cold={p_cold:.0f}"
+
+
+def test_degenerate_temperature_falls_back_to_sea_level(caplog):
+    """If mean T is unphysical (e.g. all-NaN input) we can't infer
+    altitude — fall back to sea-level P0 with a clear warning so the
+    user isn't left guessing why pressure looks constant."""
+    h = _make_handler()
+    ds = _make_ds_without_pressure(t_mean_K=285.0)
+    ds["tas"] = xr.full_like(ds["tas"], float("nan"))
+    caplog.set_level(logging.WARNING)
+    ds_out = h.process_dataset(ds)
+    p = float(ds_out["surface_air_pressure"].mean().values)
+    assert abs(p - 101325.0) < 1.0, f"expected sea-level fallback 101325 Pa, got {p}"
+    warn = "\n".join(r.getMessage() for r in caplog.records if r.levelno == logging.WARNING)
+    assert "could not infer altitude" in warn


### PR DESCRIPTION
## Summary

Iteration-2 P1 item. Co-author NB reported that running SUMMA preprocessing with `config_paradise_gddp_access_cm2.yaml` (NEX-GDDP-CMIP6 forcing) failed with:

> ERROR Execution failed: Failed during SUMMA preprocessing: Missing required forcing variables: [surface_air_pressure]

Root cause: NEX-GDDP-CMIP6 publishes `{pr, tas, tasmax, tasmin, huss, hurs, rlds, rsds, sfcWind}` — surface pressure is **not one of the archived variables** for this product. The handler's `process_dataset` only touched pressure inside `if "surface_air_pressure" in ds.data_vars:`, so nothing was emitted and SUMMA refused to run.

## Fix

When `ps` is absent after the rename step, synthesize a climatological estimate via the International Standard Atmosphere:
- infer altitude from mean 2 m air temperature via the tropospheric lapse rate (6.5 K/km)
- apply the ISA relation `P(z) = 101325 · (1 − 0.0065·z/288.15)^5.25588`
- broadcast the scalar across the forcing grid
- emit a WARNING naming T_mean, z_est, and P_synth, plus a NetCDF `synthesis_note` attribute for provenance
- fall back to sea-level `P₀ = 101325 Pa` (separate warning) when mean T is unphysical

This substitutes **climatological** pressure for synoptic pressure — acceptable for hydrological forcing of snow/soil/rad schemes; the warning names this limitation so users aren't surprised downstream.

## Test plan

- [x] `tests/unit/data/test_nex_gddp_pressure_synthesis.py` — 3/3 pass locally
  - `surface_air_pressure` appears in output even when input has no `ps`
  - synthesized P is monotone in mean T (colder → lower P)
  - NaN T falls back to sea level with the documented warning
- [ ] CI: full suite

Last P1 item from the iteration-2 co-author response.

Assisted-by: Claude (Anthropic)