### PR TITLE
feat(binary install): ship every paper-ensemble model in the default tier

### DIFF
--- a/src/symfluence/cli/argument_parser.py
+++ b/src/symfluence/cli/argument_parser.py
@@ -66,15 +66,29 @@ DOMAIN_DEFINITION_METHODS = ['lumped', 'point', 'subset', 'delineate']
 # Available tools for binary installation
 # Default tools are installed by `symfluence binary install` (no arguments).
 # Experimental tools require explicit naming, e.g. `symfluence binary install rhessys`.
+# The default tier is the set `symfluence binary install` (no args)
+# compiles out of the box. Every process-based model that appears in
+# the paper's Fig 4 / Fig 8 multi-model ensemble is here so a fresh
+# install is enough to reproduce the paper. JAX re-implementations
+# (HBV*, SACSMA*, XAJ*, HECHMS*, TOPMODEL*, SUMMA+MOD) arrive as
+# pip/jax dependencies in pyproject.toml and don't need a binary
+# install. LSTM and GR4J are pure-Python / R-bridge models (no binary).
 DEFAULT_TOOLS = [
-    'sundials', 'summa', 'mizuroute', 'troute', 'fuse', 'taudem',
-    'gistool', 'datatool', 'ngen', 'ngiab', 'hype', 'mesh',
+    # Framework glue
+    'sundials', 'taudem', 'gistool', 'datatool',
+    # Routing
+    'mizuroute', 'troute',
+    # Hydrology engines in the paper's ensemble (alphabetical)
+    'clm', 'clmparflow', 'crhm', 'fuse', 'gsflow', 'hype',
+    'mesh', 'mhm', 'ngen', 'ngiab', 'parflow', 'pihm',
+    'prms', 'rhessys', 'summa', 'swat', 'vic', 'watflood',
+    'wflow', 'wrfhydro',
 ]
+# Experimental tier: not in the paper ensemble, still buildable on
+# explicit request.
 EXPERIMENTAL_TOOLS = [
-    'rhessys', 'openfews', 'wmfire', 'cfuse', 'droute', 'ignacio',
-    'vic', 'clm', 'swat', 'mhm', 'crhm', 'prms', 'modflow', 'gsflow',
-    'watflood', 'wflow', 'parflow', 'clmparflow', 'wrfhydro', 'pihm',
-    'enzyme',
+    'openfews', 'wmfire', 'cfuse', 'droute', 'ignacio',
+    'modflow', 'enzyme',
 ]
 EXTERNAL_TOOLS = DEFAULT_TOOLS + EXPERIMENTAL_TOOLS
 
@@ -398,8 +412,19 @@ For more help on a specific command:
         )
         _tools_help = (
             'Tools to install. If not specified, installs all default tools.\n'
-            f'  Default:      {", ".join(DEFAULT_TOOLS)}\n'
-            f'  Experimental: {", ".join(EXPERIMENTAL_TOOLS)}'
+            '\n'
+            f'  Default ({len(DEFAULT_TOOLS)} tools — covers every process-based model '
+            'in the paper Fig 4/Fig 8 ensemble):\n'
+            f'    {", ".join(DEFAULT_TOOLS)}\n'
+            f'  Experimental (explicit opt-in): {", ".join(EXPERIMENTAL_TOOLS)}\n'
+            '\n'
+            '  JAX re-implementations (HBV*, SACSMA*, XAJ*, HECHMS*, TOPMODEL*,\n'
+            '  SUMMA+MOD) arrive automatically with "pip install symfluence"\n'
+            '  and do not need a binary build.\n'
+            '  LSTM is PyTorch-only; GR4J uses airGR via rpy2 (R optional dep).\n'
+            '\n'
+            '  Binaries install under SYMFLUENCE_DATA_DIR/installs/<tool>/bin/\n'
+            '  (defaults to ./SYMFLUENCE_data/installs when SYMFLUENCE_DATA_DIR is unset).'
         )
         install_parser.add_argument('tools', nargs='*', metavar='TOOL',
                                   help=_tools_help)

--- a/tests/unit/cli/test_binary_install_default_tools.py
+++ b/tests/unit/cli/test_binary_install_default_tools.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Regression test for the `symfluence binary install` default tier.
+
+Co-author PC (02_model_ensemble) reported "Some binaries are
+missing" when running the paper's multi-model benchmark — the
+default `symfluence binary install` compiled only a subset of the
+engines used in the paper's Fig 4/Fig 8 ensemble, so several models
+never produced output.
+
+Pin the fix: every *process-based* model that appears in the paper
+ensemble (Fig 4 row, Fig 8 table) must be in DEFAULT_TOOLS so a
+fresh install reproduces the paper. JAX re-implementations come via
+pyproject.toml deps and are NOT binaries; LSTM is PyTorch-only;
+GR4J uses airGR via rpy2. Those are called out in the help text but
+not in this list.
+"""
+
+import pytest
+
+from symfluence.cli.argument_parser import DEFAULT_TOOLS, EXPERIMENTAL_TOOLS
+
+pytestmark = [pytest.mark.unit, pytest.mark.quick]
+
+
+# The binary-installable models that appear in Fig 4 / Fig 8 of
+# the paper. Order doesn't matter; membership does.
+PAPER_ENSEMBLE_BINARIES = {
+    'summa', 'fuse', 'hype', 'mesh', 'ngen', 'ngiab',   # merged into default in earlier PRs
+    'clm', 'clmparflow', 'crhm', 'gsflow', 'mhm', 'parflow',  # promoted
+    'pihm', 'prms', 'rhessys', 'swat', 'vic', 'watflood',
+    'wflow', 'wrfhydro',
+}
+
+
+def test_default_tools_cover_paper_ensemble():
+    """Every process-based engine from the paper's multi-model
+    ensemble must be in the default install set so a reviewer
+    reproducing the paper doesn't need to discover and enable
+    models one-by-one."""
+    default = set(DEFAULT_TOOLS)
+    missing = PAPER_ENSEMBLE_BINARIES - default
+    assert not missing, (
+        f"paper-ensemble binaries missing from DEFAULT_TOOLS: "
+        f"{sorted(missing)}. Add them or justify removal."
+    )
+
+
+def test_default_includes_framework_dependencies():
+    """The glue binaries SYMFLUENCE relies on to operate any of the
+    above (routing, DEM analysis, data tooling) must also be in
+    default."""
+    required = {'sundials', 'mizuroute', 'troute', 'taudem',
+                'gistool', 'datatool'}
+    assert required.issubset(set(DEFAULT_TOOLS))
+
+
+def test_default_and_experimental_are_disjoint():
+    """Prevent silent double-counting between tiers."""
+    assert not (set(DEFAULT_TOOLS) & set(EXPERIMENTAL_TOOLS))
+
+
+def test_help_text_names_install_path_and_jax_models():
+    """The -h output must tell the user where binaries land and
+    which paper models don't need a binary build (JAX re-impls,
+    LSTM, GR4J) — co-authors spent time trying to 'install' LSTM
+    because the help didn't mention it's Python-only."""
+    from symfluence.cli.argument_parser import CLIParser
+
+    parser = CLIParser().parser
+    help_text = parser.format_help()
+
+    # Drill into binary → install sub-parser for its own help.
+    for action in parser._actions:
+        if getattr(action, 'choices', None) and 'binary' in action.choices:
+            bin_p = action.choices['binary']
+            for sub in bin_p._actions:
+                if getattr(sub, 'choices', None) and 'install' in sub.choices:
+                    help_text = sub.choices['install'].format_help()
+                    break
+
+    assert 'SYMFLUENCE_DATA_DIR/installs' in help_text, \
+        "help must name the install path"
+    assert 'JAX' in help_text or 'jax' in help_text, \
+        "help must name JAX re-implementations"
+    assert 'LSTM' in help_text, "help must clarify LSTM is not a binary"
+    assert 'GR4J' in help_text, "help must clarify GR4J uses airGR/rpy2"


### PR DESCRIPTION
## Summary

Iter-3 item 02.3 (PC). Running the paper's multi-model benchmark produced *"Some binaries are missing"* — the default `symfluence binary install` built only 12 of the 27 Fig 4 / Fig 8 ensemble models. Reviewers had to discover and enable the rest one at a time.

## Fix

Promote every process-based paper-ensemble engine to `DEFAULT_TOOLS`:

| From experimental → default |
|---|
| CLM, CLMPARFLOW, CRHM, GSFLOW, MHM, PARFLOW, PIHM, PRMS, RHESSys, SWAT, VIC, WATFLOOD, WFLOW, WRFHYDRO |

Experimental tier now retains only non-paper tools (openfews, wmfire, cfuse, droute, ignacio, modflow, enzyme).

## Help text rewrite

`symfluence binary install -h` now names:
- `SYMFLUENCE_DATA_DIR/installs/<tool>/bin/` — the install location
- JAX re-implementations (HBV*, SACSMA*, XAJ*, HECHMS*, TOPMODEL*, SUMMA+MOD) which ride on `pip install symfluence` and need no binary build
- LSTM (PyTorch-only) and GR4J (airGR via rpy2, R optional dep) which aren't in this install system at all

## Test plan

- [x] `tests/unit/cli/test_binary_install_default_tools.py` — 4/4 pass locally
  - every paper-ensemble binary is in `DEFAULT_TOOLS`
  - framework glue (sundials, taudem, routing, …) in default
  - default and experimental tiers are disjoint
  - help text names install path + JAX/LSTM/GR4J clarifications
- [ ] CI

## Note on build cost

A fresh default install now compiles ~26 external tools vs the previous 12. Wall-clock on a dev laptop is on the order of an hour for the heavier engines (CLM, VIC, PARFLOW). For casual use the user can still run `symfluence binary install summa fuse hype` (or any subset) to build only what they need — positional args still constrain the install set.

Assisted-by: Claude (Anthropic)