### PR TITLE
fix(decision): pluggable streamflow reader + loud-fail on all-NaN

### DIFF
--- a/src/symfluence/evaluation/structure_ensemble.py
+++ b/src/symfluence/evaluation/structure_ensemble.py
@@ -208,11 +208,17 @@ class BaseStructureEnsembleAnalyzer(ProjectContextMixin, ABC):
             if col in df.columns:
                 df[col] = pd.to_numeric(df[col], errors='coerce')
 
+        n_total = len(df)
         df = df.dropna(subset=['kge', 'nse'], how='all')
 
         if df.empty:
-            self.logger.warning("No valid results found to analyze.")
-            return {}
+            raise RuntimeError(
+                f"{self.__class__.__name__}: all {n_total} decision "
+                "combinations produced NaN metrics. See the per-combination "
+                "errors in the log (typical causes: missing simulation "
+                "output, misconfigured observations, or OPTIMIZATION_TARGET "
+                "incompatible with this model)."
+            )
 
         metrics_cols = ['kge', 'kgep', 'nse', 'mae', 'rmse']
         decisions = list(self.decision_options.keys())

--- a/src/symfluence/models/summa/structure_analyzer.py
+++ b/src/symfluence/models/summa/structure_analyzer.py
@@ -173,16 +173,7 @@ class SummaStructureAnalyzer(BaseStructureEnsembleAnalyzer):
         ) or 'streamflow').lower()
 
     def calculate_performance_metrics(self) -> Dict[str, float]:
-        """
-        Calculate performance metrics for the current model run.
-
-        Dispatches to target-specific logic: streamflow uses mizuRoute routed
-        runoff; non-streamflow targets (SWE, SCA, ET, …) delegate to the
-        matching evaluator from the EvaluationRegistry.
-
-        Returns:
-            Dict: Dictionary containing KGE, NSE, MAE, and RMSE.
-        """
+        """Dispatch to the appropriate target-specific calculator."""
         opt_target = self._get_optimization_target()
         if opt_target not in ('streamflow', 'flow', 'discharge'):
             return self._calculate_evaluator_metrics(opt_target)
@@ -227,68 +218,14 @@ class SummaStructureAnalyzer(BaseStructureEnsembleAnalyzer):
         }
 
     def _calculate_streamflow_metrics(self) -> Dict[str, float]:
-        """Original streamflow-specific metric calculation using mizuRoute output."""
-        # Load observations
-        obs_file_path = self._resolve(
-            lambda: self.config.paths.observations_path,
-            'OBSERVATIONS_PATH', 'default'
-        )
-        if obs_file_path == 'default' or not obs_file_path:
-            obs_file_path = self.project_observations_dir / 'streamflow' / 'preprocessed' / f"{self.domain_name}_streamflow_processed.csv"
-        else:
-            obs_file_path = Path(obs_file_path)
+        """Streamflow metrics from routed (mizuRoute) or native-SUMMA output.
 
-        if not obs_file_path.exists():
-            self.logger.error(f"Observation file not found: {obs_file_path}")
-            raise FileNotFoundError(f"Missing observation file: {obs_file_path}")
-
-        # Load simulation results (mizuRoute output)
-        sim_reach_ID = self._resolve(
-            lambda: self.config.evaluation.sim_reach_id,
-            'SIM_REACH_ID', None
-        )
-        sim_path_config = self._resolve(
-            lambda: self.config.paths.simulations_path,
-            'SIMULATIONS_PATH', 'default'
-        )
-
-        if sim_path_config == 'default' or not sim_path_config:
-            start_year = (self.time_start or '1990').split('-')[0]
-            sim_file_path = (
-                self.project_dir / 'simulations' / self.experiment_id /
-                'mizuRoute' / f"{self.experiment_id}.h.{start_year}-01-01-03600.nc"
-            )
-        else:
-            sim_file_path = Path(sim_path_config)
-
-        if not sim_file_path.exists():
-            self.logger.error(f"Simulation output file not found: {sim_file_path}")
-            raise FileNotFoundError(f"Missing simulation output: {sim_file_path}")
-
-        # Process observations
-        dfObs = pd.read_csv(obs_file_path, index_col='datetime', parse_dates=True)
-        if 'discharge_cms' in dfObs.columns:
-            obs_series = dfObs['discharge_cms'].resample('h').mean()
-        else:
-            data_col = [c for c in dfObs.columns if c.lower() not in ['datetime', 'date']][0]
-            obs_series = dfObs[data_col].resample('h').mean()
-
-        # Process simulations
-        with xr.open_dataset(sim_file_path, engine='netcdf4') as ds:
-            if 'reachID' in ds.variables:
-                segment_index = ds['reachID'].values == int(sim_reach_ID)
-                ds_sel = ds.sel(seg=segment_index)
-            else:
-                ds_sel = ds.isel(seg=0)
-
-            var_name = 'IRFroutedRunoff' if 'IRFroutedRunoff' in ds_sel.variables else 'KWTroutedRunoff'
-            if var_name not in ds_sel.variables:
-                var_name = [v for v in ds_sel.variables if 'routedRunoff' in v][0]
-
-            sim_df = ds_sel[var_name].to_dataframe().reset_index()
-            sim_df.set_index('time', inplace=True)
-            sim_df.index = sim_df.index.round(freq='h')
-            sim_series = sim_df[var_name]
+        Reads mizuRoute output when ROUTING_MODEL is mizuRoute and the
+        file exists; otherwise falls back to SUMMA's own
+        ``averageRoutedRunoff`` (m/s, converted to m³/s via HRU area).
+        """
+        obs_series = self._load_streamflow_observations()
+        sim_series = self._load_streamflow_simulations()
 
         # Align series
         obs_aligned = obs_series.reindex(sim_series.index).dropna()
@@ -308,3 +245,128 @@ class SummaStructureAnalyzer(BaseStructureEnsembleAnalyzer):
             'mae': float(mae(obs_vals, sim_vals, transfo=1)),
             'rmse': float(rmse(obs_vals, sim_vals, transfo=1))
         }
+
+    def _load_streamflow_observations(self) -> pd.Series:
+        """Read the domain's preprocessed gauge CSV at hourly resolution."""
+        obs_file_path = self._resolve(
+            lambda: self.config.paths.observations_path,
+            'OBSERVATIONS_PATH', 'default'
+        )
+        if obs_file_path == 'default' or not obs_file_path:
+            obs_file_path = (
+                self.project_observations_dir / 'streamflow' / 'preprocessed'
+                / f"{self.domain_name}_streamflow_processed.csv"
+            )
+        else:
+            obs_file_path = Path(obs_file_path)
+
+        if not obs_file_path.exists():
+            raise FileNotFoundError(f"Missing observation file: {obs_file_path}")
+
+        dfObs = pd.read_csv(obs_file_path, index_col='datetime', parse_dates=True)
+        if 'discharge_cms' in dfObs.columns:
+            return dfObs['discharge_cms'].resample('h').mean()
+        data_col = [c for c in dfObs.columns if c.lower() not in ['datetime', 'date']][0]
+        return dfObs[data_col].resample('h').mean()
+
+    def _load_streamflow_simulations(self) -> pd.Series:
+        """Read simulated streamflow, preferring mizuRoute if configured and
+        present, otherwise falling back to SUMMA's native routed runoff.
+
+        Raises:
+            FileNotFoundError: when neither mizuRoute output nor a readable
+                SUMMA native output is available.
+        """
+        routing_model = str(self._resolve(
+            lambda: self.config.model.routing_model, 'ROUTING_MODEL', 'none'
+        )).lower()
+
+        if routing_model == 'mizuroute':
+            mizu_path = self._resolve_mizuroute_output_path()
+            if mizu_path.exists():
+                return self._read_mizuroute_series(mizu_path)
+            self.logger.warning(
+                f"ROUTING_MODEL=mizuRoute but {mizu_path} not found — "
+                "falling back to SUMMA native routed runoff."
+            )
+
+        return self._read_summa_native_series()
+
+    def _resolve_mizuroute_output_path(self) -> Path:
+        sim_path_config = self._resolve(
+            lambda: self.config.paths.simulations_path,
+            'SIMULATIONS_PATH', 'default'
+        )
+        if sim_path_config != 'default' and sim_path_config:
+            return Path(sim_path_config)
+        start_year = (self.time_start or '1990').split('-')[0]
+        return (
+            self.project_dir / 'simulations' / self.experiment_id
+            / 'mizuRoute' / f"{self.experiment_id}.h.{start_year}-01-01-03600.nc"
+        )
+
+    def _read_mizuroute_series(self, sim_file_path: Path) -> pd.Series:
+        sim_reach_ID = self._resolve(
+            lambda: self.config.evaluation.sim_reach_id, 'SIM_REACH_ID', None
+        )
+        with xr.open_dataset(sim_file_path, engine='netcdf4') as ds:
+            if 'reachID' in ds.variables and sim_reach_ID is not None:
+                ds_sel = ds.sel(seg=(ds['reachID'].values == int(sim_reach_ID)))
+            else:
+                ds_sel = ds.isel(seg=0)
+
+            var_name = 'IRFroutedRunoff' if 'IRFroutedRunoff' in ds_sel.variables else 'KWTroutedRunoff'
+            if var_name not in ds_sel.variables:
+                routed = [v for v in ds_sel.variables if 'routedRunoff' in v]
+                if not routed:
+                    raise KeyError(f"No routedRunoff variable found in {sim_file_path}")
+                var_name = routed[0]
+
+            sim_df = ds_sel[var_name].to_dataframe().reset_index()
+            sim_df.set_index('time', inplace=True)
+            sim_df.index = sim_df.index.round(freq='h')
+            return sim_df[var_name]
+
+    def _read_summa_native_series(self) -> pd.Series:
+        """Fallback: build a m³/s streamflow series from SUMMA's own
+        ``averageRoutedRunoff`` (m/s) scaled by HRU area."""
+        summa_dir = self.project_dir / 'simulations' / self.experiment_id / 'SUMMA'
+        candidates = sorted(summa_dir.glob(f"{self.experiment_id}*.nc"))
+        candidates = [p for p in candidates if 'day' not in p.stem]
+        if not candidates:
+            raise FileNotFoundError(
+                f"No SUMMA output under {summa_dir} and mizuRoute output also unavailable — "
+                "cannot compute streamflow metrics. Either enable routing "
+                "(ROUTING_MODEL: mizuRoute with a routed domain) or ensure the "
+                "SUMMA run produced averageRoutedRunoff."
+            )
+
+        with xr.open_dataset(candidates[0]) as ds:
+            if 'averageRoutedRunoff' not in ds:
+                raise KeyError(
+                    f"averageRoutedRunoff not in {candidates[0]}; "
+                    "native SUMMA fallback needs it."
+                )
+            var = ds['averageRoutedRunoff']
+            if 'hru' in var.dims and var.sizes['hru'] > 1:
+                if 'HRUarea' in ds:
+                    weights = ds['HRUarea'] / ds['HRUarea'].sum()
+                    series_m = (var * weights).sum(dim='hru').to_pandas()
+                else:
+                    series_m = var.mean(dim='hru').to_pandas()
+            else:
+                series_m = var.squeeze().to_pandas()
+
+            basin_area_m2 = float(ds['HRUarea'].sum()) if 'HRUarea' in ds else None
+
+        if basin_area_m2:
+            series_cms = series_m * basin_area_m2
+        else:
+            series_cms = series_m
+            self.logger.warning(
+                "HRUarea not present in SUMMA output; streamflow will be in m/s "
+                "(depth/time) rather than m³/s. Metrics may be on a different scale."
+            )
+
+        series_cms.index = pd.to_datetime(series_cms.index).round(freq='h')
+        return series_cms

--- a/tests/unit/evaluation/test_decision_analysis_routing_guards.py
+++ b/tests/unit/evaluation/test_decision_analysis_routing_guards.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Decision analysis: pluggable streamflow reader + loud-fail on all-NaN.
+
+SH (iter-3, 04.SH.4) saw SUMMA+DDS decision analysis silently complete
+with zero valid rows: mizuRoute output missing → FileNotFoundError per
+combination → NaN row → aggregate "No valid results" warning → ✓ Complete.
+Two fixes pinned here:
+
+1. ``_load_streamflow_simulations`` prefers mizuRoute if configured and
+   present, otherwise falls back to SUMMA's native averageRoutedRunoff —
+   so no-routing configs still produce metrics.
+2. ``BaseStructureEnsembleAnalyzer.analyze_results`` raises when every
+   combination produced NaN, so the outer workflow step isn't marked
+   complete on zero output.
+"""
+
+import csv
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+pytestmark = [pytest.mark.unit, pytest.mark.quick]
+
+
+@pytest.fixture
+def summa_analyzer(tmp_path, monkeypatch):
+    """Fixture: a SummaStructureAnalyzer wired for isolated testing.
+
+    Several attributes (project_dir, experiment_id, time_start, etc.)
+    are read-only properties derived from config in the real class;
+    patch them at class level for the test duration so the fixture
+    can seed them directly.
+    """
+    from symfluence.models.summa.structure_analyzer import SummaStructureAnalyzer
+
+    experiment_id = "exp"
+    for attr, val in (
+        ('project_dir', tmp_path),
+        ('experiment_id', experiment_id),
+        ('domain_name', 'test_domain'),
+        ('time_start', '2015-01-01'),
+        ('project_observations_dir', tmp_path / 'obs'),
+    ):
+        monkeypatch.setattr(SummaStructureAnalyzer, attr, val, raising=False)
+
+    analyzer = SummaStructureAnalyzer.__new__(SummaStructureAnalyzer)
+    analyzer.config = MagicMock()
+    analyzer.logger = logging.getLogger("test_routing_reader")
+    analyzer.reporting_manager = MagicMock()
+    analyzer._mizuroute_runner = None
+    analyzer._resolved = {}
+    analyzer._resolve = lambda typed, key=None, default=None: analyzer._resolved.get(key, default)
+    return analyzer
+
+
+def _write_summa_native_nc(path: Path, area_m2: float = 1_000_000.0):
+    times = pd.date_range("2015-01-01", periods=6, freq="h")
+    ds = xr.Dataset(
+        data_vars=dict(
+            averageRoutedRunoff=(("time", "hru"), np.full((len(times), 1), 1e-6, dtype="float32")),
+            HRUarea=(("hru",), np.array([area_m2], dtype="float32")),
+        ),
+        coords=dict(time=times, hru=np.array([1])),
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ds.to_netcdf(path)
+
+
+def test_native_summa_fallback_used_when_mizuroute_missing(summa_analyzer, tmp_path):
+    """ROUTING_MODEL=none should flow to the native-SUMMA reader —
+    not raise FileNotFoundError."""
+    analyzer = summa_analyzer
+    analyzer._resolved['ROUTING_MODEL'] = 'none'
+    _write_summa_native_nc(
+        tmp_path / 'simulations' / analyzer.experiment_id / 'SUMMA' / f"{analyzer.experiment_id}_timestep.nc"
+    )
+
+    series = analyzer._load_streamflow_simulations()
+    assert len(series) == 6
+    # 1e-6 m/s × 1e6 m² = 1.0 m³/s
+    assert float(series.iloc[0]) == pytest.approx(1.0, rel=1e-3)
+
+
+def test_mizuroute_preferred_when_configured_and_present(summa_analyzer, tmp_path):
+    """With ROUTING_MODEL=mizuRoute and the file on disk we should read
+    mizuRoute, not the SUMMA native fallback."""
+    analyzer = summa_analyzer
+    analyzer._resolved['ROUTING_MODEL'] = 'mizuRoute'
+    analyzer._resolved['SIM_REACH_ID'] = 1
+
+    mizu_path = analyzer._resolve_mizuroute_output_path()
+    mizu_path.parent.mkdir(parents=True, exist_ok=True)
+    times = pd.date_range("2015-01-01", periods=4, freq="h")
+    xr.Dataset(
+        data_vars=dict(
+            reachID=(("seg",), np.array([1])),
+            IRFroutedRunoff=(("time", "seg"), np.full((len(times), 1), 2.5, dtype="float32")),
+        ),
+        coords=dict(time=times),
+    ).to_netcdf(mizu_path)
+
+    series = analyzer._load_streamflow_simulations()
+    assert len(series) == 4
+    assert float(series.iloc[0]) == pytest.approx(2.5)
+
+
+def test_mizuroute_configured_but_missing_falls_back_to_native(summa_analyzer, tmp_path, caplog):
+    """If the user sets ROUTING_MODEL=mizuRoute but the run didn't
+    actually produce a mizuRoute file, we log a warning and fall back
+    to native SUMMA — don't crash."""
+    analyzer = summa_analyzer
+    analyzer._resolved['ROUTING_MODEL'] = 'mizuRoute'
+    _write_summa_native_nc(
+        tmp_path / 'simulations' / analyzer.experiment_id / 'SUMMA' / f"{analyzer.experiment_id}_timestep.nc"
+    )
+
+    caplog.set_level(logging.WARNING)
+    series = analyzer._load_streamflow_simulations()
+    assert len(series) == 6
+    assert any("falling back to SUMMA native" in r.getMessage() for r in caplog.records)
+
+
+def test_neither_output_present_raises_named_error(summa_analyzer, tmp_path):
+    """When both mizuRoute and SUMMA outputs are missing, raise a named
+    FileNotFoundError that tells the user what to check — not a silent
+    NaN row."""
+    analyzer = summa_analyzer
+    analyzer._resolved['ROUTING_MODEL'] = 'none'
+    with pytest.raises(FileNotFoundError) as excinfo:
+        analyzer._load_streamflow_simulations()
+    msg = str(excinfo.value)
+    assert 'mizuRoute' in msg
+    assert 'averageRoutedRunoff' in msg or 'SUMMA' in msg
+
+
+def test_analyze_results_raises_when_every_combination_failed(summa_analyzer, tmp_path):
+    """If every combination has NaN metrics, analyze_results raises so
+    the workflow step is marked FAILED instead of ✓ Complete with no
+    output (SH's silent-success report). Reuse the SUMMA fixture since
+    its concrete class is fully instantiable."""
+    analyzer = summa_analyzer
+    analyzer.decision_options = {'opt1': ['A', 'B']}
+    analyzer.master_file = tmp_path / 'master.csv'
+
+    master = analyzer.master_file
+    with open(master, 'w', newline='') as f:
+        w = csv.writer(f)
+        w.writerow(['Iteration', 'opt1', 'kge', 'kgep', 'nse', 'mae', 'rmse'])
+        w.writerow([1, 'A', '', '', '', '', ''])
+        w.writerow([2, 'B', '', '', '', '', ''])
+
+    with pytest.raises(RuntimeError, match="all 2 decision combinations"):
+        analyzer.analyze_results(master)


### PR DESCRIPTION
## Summary

Iter-3 item 04.SH.4. SH saw SUMMA+DDS decision analysis silently complete with zero valid rows: `ROUTING_MODEL: none` → each combination raised `FileNotFoundError` on the missing mizuRoute output → caught as a NaN row → aggregate *"No valid results found"* warning → workflow step reported ✓ Complete.

## Fix (two independent changes)

**1. Pluggable streamflow reader.** `_load_streamflow_simulations` now:
- reads mizuRoute when `ROUTING_MODEL: mizuRoute` and the file exists;
- falls back to SUMMA's own `averageRoutedRunoff` (m/s × `HRUarea` → m³/s);
- raises a named `FileNotFoundError` only when neither is available.

Split into small helpers (`_resolve_mizuroute_output_path`, `_read_mizuroute_series`, `_read_summa_native_series`) so each path is independently testable.

**Keeps decision analysis open for both SUMMA and FUSE with or without routing** — configs that use `ROUTING_MODEL: none` now produce metrics via native SUMMA output instead of failing.

**2. Loud-fail on all-NaN.** `BaseStructureEnsembleAnalyzer.analyze_results` raises `RuntimeError` when every combination's KGE and NSE are NaN. Previous behaviour (warn + return `{}`) was indistinguishable from "no configured models" to the outer runner.

## Test plan

- [x] `tests/unit/evaluation/test_decision_analysis_routing_guards.py` — 5/5 pass locally
  - native SUMMA fallback when mizuRoute not configured
  - mizuRoute preferred when configured + present
  - graceful fallback with warning when configured but missing
  - named error when both outputs absent
  - `analyze_results` raises on all-NaN
- [x] Full evaluation suite (275) green
- [ ] CI

Part of the iter-3 response. Doesn't replace #57 (SA gradient-column filter) — they address separate failure modes from the same SH report.

Assisted-by: Claude (Anthropic)