### PR TITLE
fix(config): accept semi_distributed / semi-distributed as aliases

### DIFF
--- a/src/symfluence/core/config/constants.py
+++ b/src/symfluence/core/config/constants.py
@@ -32,4 +32,6 @@ VALID_DOMAIN_METHODS_CANONICAL = frozenset({
 VALID_DOMAIN_METHODS_WITH_LEGACY = frozenset({
     'point', 'lumped', 'semidistributed', 'distributed',
     'discretized', 'distribute', 'subset', 'delineate',
+    # Spelling variants — several paper configs write these
+    'semi_distributed', 'semi-distributed',
 })

--- a/src/symfluence/core/config/models/domain.py
+++ b/src/symfluence/core/config/models/domain.py
@@ -194,6 +194,9 @@ class DomainConfig(BaseModel):
             'distribute': 'distributed',
             'discretized': 'semidistributed',  # deprecated
             'subset': 'semidistributed',  # now use subset_from_geofabric=True
+            # Spelling variants written by several paper configs
+            'semi_distributed': 'semidistributed',
+            'semi-distributed': 'semidistributed',
         }
         if v in legacy_mapping:
             if v == 'discretized':

--- a/tests/unit/config/test_semi_distributed_alias.py
+++ b/tests/unit/config/test_semi_distributed_alias.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""DOMAIN_DEFINITION_METHOD accepts hyphen/underscore spelling variants.
+
+SH (iter-3, 11.SH.3) reported that the paper configs write
+``DOMAIN_DEFINITION_METHOD: semi_distributed`` (underscore) but the
+validator only accepted ``semidistributed`` (no separator). Accept
+both underscore and hyphen variants so the paper configs run as-is.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from symfluence.core.config.models.root import SymfluenceConfig
+
+pytestmark = [pytest.mark.unit, pytest.mark.quick]
+
+
+def _base_config(definition_method):
+    return {
+        'SYMFLUENCE_DATA_DIR': '/tmp/data',
+        'SYMFLUENCE_CODE_DIR': '/tmp/code',
+        'DOMAIN_NAME': 'test',
+        'EXPERIMENT_ID': 'exp_001',
+        'EXPERIMENT_TIME_START': '2020-01-01 00:00',
+        'EXPERIMENT_TIME_END': '2020-12-31 23:00',
+        'DOMAIN_DEFINITION_METHOD': definition_method,
+        'SUB_GRID_DISCRETIZATION': 'GRUs',
+        'HYDROLOGICAL_MODEL': 'SUMMA',
+        'FORCING_DATASET': 'ERA5',
+    }
+
+
+@pytest.mark.parametrize('v', ['semidistributed', 'semi_distributed', 'semi-distributed'])
+def test_semidistributed_spelling_variants_accepted(v):
+    cfg = SymfluenceConfig(**_base_config(v))
+    assert cfg.domain.definition_method == 'semidistributed'
+
+
+def test_other_legacy_aliases_still_work():
+    for v in ('delineate', 'discretized', 'subset'):
+        cfg = SymfluenceConfig(**_base_config(v))
+        assert cfg.domain.definition_method == 'semidistributed'
+
+
+def test_typo_still_rejected():
+    """A close typo (missing letter) must still raise."""
+    with pytest.raises(ValidationError):
+        SymfluenceConfig(**_base_config('semi_disributed'))


### PR DESCRIPTION
## Summary

Iter-3 item 11.SH.3. SH reported:

> DOMAIN_DISCRETIZATION: semi_distributed is not a valid value in the installed version — the paper config uses it but the code rejects it.

Root cause: two validators (root `VALID_DOMAIN_METHODS_WITH_LEGACY` allow-list and nested `DomainConfig.normalize_definition_method`) both accepted only `semidistributed` (no separator). Paper configs and several co-author workflows write `semi_distributed` (underscore).

## Fix

Add `semi_distributed` and `semi-distributed` as aliases at both layers. They normalise to the canonical `semidistributed`. Typos not in the allow-list (e.g. `semi_disributed`) still raise.

## Test plan

- [x] `tests/unit/config/test_semi_distributed_alias.py` — 5/5 pass
- [x] Full config suite (184) green

Assisted-by: Claude (Anthropic)