### PR TITLE
feat(lamah-ice): auto-download daily streamflow from HydroShare

### DIFF
--- a/src/symfluence/data/observation/handlers/lamah_ice.py
+++ b/src/symfluence/data/observation/handlers/lamah_ice.py
@@ -4,30 +4,172 @@
 """
 LamaH-ICE Observation Handlers
 
-Provides handlers for LamaH-ICE (Iceland) streamflow data from local files.
+Provides handlers for LamaH-ICE (Iceland) streamflow data, with
+optional auto-download from HydroShare when the local dataset is
+missing.
 """
+import logging
+import shutil
+import zipfile
 from pathlib import Path
+from typing import Iterable
 
 import pandas as pd
 
 from symfluence.core.exceptions import DataAcquisitionError
+from symfluence.data.acquisition.utils import create_robust_session
 
 from ..base import BaseObservationHandler
 from ..registry import ObservationRegistry
 
+# HydroShare record for LamaH-Ice (Helgason & Nijssen, 2024, ESSD).
+# DOI: 10.4211/hs.86117a5f36cc4b7c90a5d54e18161c91
+_LAMAH_ICE_HS_RESOURCE_ID = "86117a5f36cc4b7c90a5d54e18161c91"
+_LAMAH_ICE_DAILY_ZIP_NAME = "lamah_ice.zip"  # ~636 MB on HydroShare
+_LAMAH_ICE_DAILY_ZIP_URL = (
+    f"https://www.hydroshare.org/resource/{_LAMAH_ICE_HS_RESOURCE_ID}"
+    f"/data/contents/{_LAMAH_ICE_DAILY_ZIP_NAME}"
+)
+_LAMAH_ICE_REQUIRED_SUBPATH = Path("D_gauges") / "2_timeseries" / "daily"
+
+
+def ensure_lamah_ice_streamflow(lamah_path: Path, logger: logging.Logger, *,
+                                 force: bool = False) -> Path:
+    """Ensure ``lamah_path/D_gauges/`` is populated, downloading from
+    HydroShare if needed.
+
+    Args:
+        lamah_path: Target root for the dataset
+            (``LAMAH_ICE_PATH`` in configs). Created if missing.
+        logger: Logger for progress / warning messages.
+        force: Re-download even when the target subtree is present.
+
+    Returns:
+        The resolved ``lamah_path``.
+
+    Raises:
+        DataAcquisitionError: When the HydroShare fetch or extraction fails.
+    """
+    lamah_path = Path(lamah_path).expanduser().resolve()
+    daily_dir = lamah_path / _LAMAH_ICE_REQUIRED_SUBPATH
+    if not force and daily_dir.exists() and any(daily_dir.glob("ID_*.csv")):
+        return lamah_path
+
+    lamah_path.mkdir(parents=True, exist_ok=True)
+    cache_dir = lamah_path / ".cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    zip_path = cache_dir / _LAMAH_ICE_DAILY_ZIP_NAME
+
+    if force or not zip_path.exists() or zip_path.stat().st_size < 1_000_000:
+        _download_lamah_ice_zip(zip_path, logger)
+
+    _extract_d_gauges(zip_path, lamah_path, logger)
+
+    # Drop the cached zip to save ~636 MB once we've extracted D_gauges.
+    try:
+        zip_path.unlink()
+        cache_dir.rmdir()
+    except OSError:
+        pass
+
+    if not any(daily_dir.glob("ID_*.csv")):
+        raise DataAcquisitionError(
+            f"LaMAH-Ice download finished but {daily_dir} contains no "
+            "ID_*.csv files — the HydroShare archive layout may have "
+            "changed. Report to SYMFLUENCE maintainers."
+        )
+    logger.info(f"LaMAH-Ice daily streamflow ready at {daily_dir}")
+    return lamah_path
+
+
+def _download_lamah_ice_zip(zip_path: Path, logger: logging.Logger) -> None:
+    """Stream the 636 MB daily-zip from HydroShare into ``zip_path``."""
+    tmp = zip_path.with_suffix(".zip.part")
+    logger.info(
+        f"Downloading LaMAH-Ice daily streamflow (~636 MB) from HydroShare: "
+        f"{_LAMAH_ICE_DAILY_ZIP_URL}"
+    )
+    session = create_robust_session(max_retries=3, backoff_factor=2.0)
+    try:
+        with session.get(_LAMAH_ICE_DAILY_ZIP_URL, stream=True, timeout=600) as resp:
+            resp.raise_for_status()
+            total = int(resp.headers.get("content-length", 0))
+            downloaded = 0
+            last_pct = -1
+            with open(tmp, "wb") as fh:
+                for chunk in resp.iter_content(chunk_size=1_048_576):
+                    if not chunk:
+                        continue
+                    fh.write(chunk)
+                    downloaded += len(chunk)
+                    if total:
+                        pct = int(downloaded * 100 / total)
+                        if pct != last_pct and pct % 10 == 0:
+                            logger.info(
+                                f"LaMAH-Ice download progress: {pct}% ({downloaded/1e6:.0f} MB)"
+                            )
+                            last_pct = pct
+        tmp.replace(zip_path)
+    except Exception as e:  # noqa: BLE001 — wrap transport errors
+        tmp.unlink(missing_ok=True)
+        raise DataAcquisitionError(
+            f"Failed to download LaMAH-Ice from HydroShare: {e}. "
+            f"Manual fallback: visit https://doi.org/10.4211/hs.{_LAMAH_ICE_HS_RESOURCE_ID} "
+            f"and extract {_LAMAH_ICE_DAILY_ZIP_NAME} into LAMAH_ICE_PATH."
+        ) from e
+
+
+def _extract_d_gauges(zip_path: Path, lamah_path: Path,
+                      logger: logging.Logger) -> None:
+    """Extract only ``D_gauges/*`` from the HydroShare zip (~57 MB of
+    2 GB decompressed). The rest of the archive is polygon / stream
+    data that streamflow calibration doesn't need."""
+    logger.info("Extracting D_gauges from LaMAH-Ice archive...")
+    try:
+        with zipfile.ZipFile(zip_path) as zf:
+            members: Iterable[zipfile.ZipInfo] = [
+                m for m in zf.infolist() if "D_gauges/" in m.filename
+            ]
+            if not members:
+                raise DataAcquisitionError(
+                    f"D_gauges not found inside {zip_path.name}; "
+                    "HydroShare archive layout may have changed."
+                )
+            for m in members:
+                # Strip any leading ``lamah_ice/`` prefix so the layout
+                # under lamah_path matches what LAMAH_ICE_PATH expects.
+                rel = m.filename.split("D_gauges/", 1)[1]
+                target = lamah_path / "D_gauges" / rel if rel else lamah_path / "D_gauges"
+                if m.is_dir():
+                    target.mkdir(parents=True, exist_ok=True)
+                    continue
+                target.parent.mkdir(parents=True, exist_ok=True)
+                with zf.open(m) as src, open(target, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
+    except zipfile.BadZipFile as e:
+        raise DataAcquisitionError(
+            f"LaMAH-Ice archive at {zip_path} is corrupt: {e}. "
+            "Re-run with force=True to redownload."
+        ) from e
+
 
 @ObservationRegistry.register('lamah_ice_streamflow')
 class LamahIceStreamflowHandler(BaseObservationHandler):
-    """
-    Handles LamaH-ICE streamflow data processing from a local dataset.
-    """
+    """Handles LamaH-ICE streamflow data processing, with auto-download
+    from HydroShare when the local dataset is missing."""
 
     obs_type = "streamflow"
     source_name = "LAMAH_ICE"
     SOURCE_INFO = {
         'source': 'LamaH-Ice',
-        'source_doi': '10.5281/zenodo.4683950',
-        'url': 'https://zenodo.org/record/4683950',
+        'source_doi': '10.4211/hs.86117a5f36cc4b7c90a5d54e18161c91',
+        'url': 'https://doi.org/10.4211/hs.86117a5f36cc4b7c90a5d54e18161c91',
+        'citation': (
+            'Helgason, H. B. and Nijssen, B.: LamaH-Ice: LArge-SaMple DAta '
+            'for Hydrology and Environmental Sciences for Iceland, Earth '
+            'System Science Data, 16, 2741–2771, 2024. '
+            'doi:10.5194/essd-16-2741-2024'
+        ),
     }
 
     def acquire(self) -> Path:
@@ -69,15 +211,30 @@ class LamahIceStreamflowHandler(BaseObservationHandler):
                 "own ID_<n>.csv naming) or STATION_ID in your config."
             )
         if not lamah_path_str:
-            raise ValueError("LAMAH_ICE_PATH required for LAMAH_ICE acquisition")
+            # Default to a SYMFLUENCE-managed cache so users don't need to
+            # discover + manually download the dataset.
+            data_dir = self._get_config_value(
+                lambda: self.config.system.data_dir, dict_key='SYMFLUENCE_DATA_DIR'
+            )
+            if not data_dir:
+                raise ValueError(
+                    "LAMAH_ICE_PATH not set and SYMFLUENCE_DATA_DIR is not "
+                    "configured — nowhere to download LaMAH-Ice to."
+                )
+            lamah_path = Path(data_dir) / "lamah_ice"
+        else:
+            lamah_path = Path(lamah_path_str)
 
-        lamah_path = Path(lamah_path_str)
-        # Standard LamaH-ICE structure: D_gauges/2_timeseries/daily/ID_{station_id}.csv
         raw_file = lamah_path / "D_gauges" / "2_timeseries" / "daily" / f"ID_{station_id}.csv"
+        if not raw_file.exists():
+            ensure_lamah_ice_streamflow(lamah_path, self.logger)
 
         if not raw_file.exists():
-            self.logger.error(f"LamaH-ICE file not found at {raw_file}")
-            raise FileNotFoundError(f"LamaH-ICE file not found: {raw_file}")
+            raise FileNotFoundError(
+                f"LamaH-ICE file not found at {raw_file} after auto-download "
+                f"attempt. Check LAMAH_ICE_DOMAIN_ID={station_id} is a valid "
+                "LaMAH-Ice basin (1–111 per the published record)."
+            )
 
         # Copy or link to project directory for processing consistency
         dest_dir = self.project_observations_dir / "streamflow" / "raw_data"

--- a/src/symfluence/models/fuse/calibration/worker.py
+++ b/src/symfluence/models/fuse/calibration/worker.py
@@ -457,6 +457,24 @@ class FUSEWorker(BaseWorker):
             gauge_mapping_path = Path(gauge_mapping_path)
             obs_dir = Path(obs_dir)
 
+            # Auto-download LaMAH-Ice daily streamflow if the user pointed
+            # at a LaMAH-Ice D_gauges directory that isn't there yet.
+            if 'D_gauges' in obs_dir.parts and not obs_dir.exists():
+                try:
+                    from symfluence.data.observation.handlers.lamah_ice import (
+                        ensure_lamah_ice_streamflow,
+                    )
+                    # Trim to the dataset root (parent of D_gauges/...)
+                    lamah_root = obs_dir
+                    while lamah_root.name != 'D_gauges' and lamah_root.parent != lamah_root:
+                        lamah_root = lamah_root.parent
+                    lamah_root = lamah_root.parent
+                    ensure_lamah_ice_streamflow(lamah_root, self.logger)
+                except Exception as exc:  # noqa: BLE001 — let the existence check below surface the real failure
+                    self.logger.warning(
+                        f"LaMAH-Ice auto-download skipped: {exc}"
+                    )
+
             # Get topology file
             topology_path = self._find_topology_path(kwargs.get('settings_dir'))
 

--- a/tests/unit/data/observation/test_lamah_ice_auto_download.py
+++ b/tests/unit/data/observation/test_lamah_ice_auto_download.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Regression test for the LaMAH-Ice HydroShare auto-downloader.
+
+Nico (09_large_domain) needed the LaMAH-Ice daily streamflow dataset
+to run his Iceland calibration. Rather than distribute the 2 GB
+bundle out of band, the LAMAH_ICE_STREAMFLOW handler now fetches
+``lamah_ice.zip`` from HydroShare on first use and extracts only
+``D_gauges/`` (~57 MB of the 2 GB decompressed).
+
+These tests use a locally-generated fake zip to avoid hitting
+HydroShare from CI — the same code path that would be taken in
+production.
+"""
+
+import logging
+import zipfile
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from symfluence.data.observation.handlers.lamah_ice import (
+    _LAMAH_ICE_DAILY_ZIP_NAME,
+    ensure_lamah_ice_streamflow,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.quick]
+
+
+def _fake_hydroshare_zip() -> bytes:
+    """Build an in-memory zip matching the HydroShare layout with a
+    couple of synthetic gauge CSVs and a Gauge_attributes.csv."""
+    buf = BytesIO()
+    with zipfile.ZipFile(buf, 'w') as zf:
+        zf.writestr(
+            "lamah_ice/D_gauges/1_attributes/Gauge_attributes.csv",
+            "id;lat;lon\n1;64.0;-22.0\n3;65.3;-18.9\n"
+        )
+        for station in (1, 3, 11):
+            zf.writestr(
+                f"lamah_ice/D_gauges/2_timeseries/daily/ID_{station}.csv",
+                "YYYY;MM;DD;qobs;qc_flag\n2015;1;1;5.0;40.0\n2015;1;2;4.8;40.0\n"
+            )
+        # Adjacent subtree we should NOT extract.
+        zf.writestr(
+            "lamah_ice/A_basins_total_upstrm/3_shapefiles/Basins_A.shp",
+            b"\x00" * 128,
+        )
+    return buf.getvalue()
+
+
+class _FakeSession:
+    def __init__(self, body: bytes):
+        self._body = body
+    def get(self, url, **_):
+        return _FakeResponse(self._body)
+
+
+class _FakeResponse:
+    def __init__(self, body: bytes):
+        self._body = body
+        self.headers = {"content-length": str(len(body))}
+    def __enter__(self):
+        return self
+    def __exit__(self, *a):
+        return False
+    def raise_for_status(self):
+        pass
+    def iter_content(self, chunk_size=1):
+        yield self._body
+
+
+def test_auto_download_populates_d_gauges(tmp_path, caplog):
+    """Given an empty LAMAH_ICE_PATH, ensure_lamah_ice_streamflow
+    downloads the HydroShare archive, extracts only D_gauges/, and
+    leaves the expected ID_*.csv files on disk."""
+    lamah = tmp_path / "lamah_ice"
+    caplog.set_level(logging.INFO)
+    with patch(
+        'symfluence.data.observation.handlers.lamah_ice.create_robust_session',
+        return_value=_FakeSession(_fake_hydroshare_zip()),
+    ):
+        result = ensure_lamah_ice_streamflow(lamah, logging.getLogger("t"))
+    assert result == lamah.resolve()
+    daily = lamah / "D_gauges" / "2_timeseries" / "daily"
+    assert daily.exists()
+    assert (daily / "ID_1.csv").exists()
+    assert (daily / "ID_3.csv").exists()
+    assert (lamah / "D_gauges" / "1_attributes" / "Gauge_attributes.csv").exists()
+
+
+def test_auto_download_skips_unneeded_subtrees(tmp_path):
+    """Only D_gauges/ should land on disk. The ~2 GB of basin
+    polygons / stream network data in the archive is irrelevant to
+    streamflow calibration and shouldn't bloat the user's data dir."""
+    lamah = tmp_path / "lamah_ice"
+    with patch(
+        'symfluence.data.observation.handlers.lamah_ice.create_robust_session',
+        return_value=_FakeSession(_fake_hydroshare_zip()),
+    ):
+        ensure_lamah_ice_streamflow(lamah, logging.getLogger("t"))
+    assert not (lamah / "A_basins_total_upstrm").exists(), \
+        "adjacent subtrees must not be extracted"
+
+
+def test_auto_download_idempotent_when_already_present(tmp_path):
+    """If D_gauges is already populated, the downloader must not
+    fetch again (important for re-runs + offline use)."""
+    lamah = tmp_path / "lamah_ice"
+    daily = lamah / "D_gauges" / "2_timeseries" / "daily"
+    daily.mkdir(parents=True)
+    (daily / "ID_1.csv").write_text("pre-existing\n")
+
+    with patch(
+        'symfluence.data.observation.handlers.lamah_ice.create_robust_session',
+        side_effect=AssertionError("downloader should not run when data is present"),
+    ):
+        ensure_lamah_ice_streamflow(lamah, logging.getLogger("t"))
+    assert (daily / "ID_1.csv").read_text() == "pre-existing\n"
+
+
+def test_cache_cleanup_removes_zip_after_extraction(tmp_path):
+    """Post-extraction the 636 MB zip gets deleted so the cache dir
+    doesn't balloon for every run."""
+    lamah = tmp_path / "lamah_ice"
+    with patch(
+        'symfluence.data.observation.handlers.lamah_ice.create_robust_session',
+        return_value=_FakeSession(_fake_hydroshare_zip()),
+    ):
+        ensure_lamah_ice_streamflow(lamah, logging.getLogger("t"))
+    cache_zip = lamah / ".cache" / _LAMAH_ICE_DAILY_ZIP_NAME
+    assert not cache_zip.exists()
+
+
+def test_handler_auto_downloads_when_file_missing(tmp_path, caplog):
+    """The LamahIceStreamflowHandler.acquire path must call the
+    downloader and then find the requested ID_<n>.csv."""
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    from symfluence.data.observation.handlers.lamah_ice import (
+        LamahIceStreamflowHandler,
+    )
+
+    handler = LamahIceStreamflowHandler.__new__(LamahIceStreamflowHandler)
+    # Plain namespaces so typed-config lookups raise AttributeError
+    # cleanly and the _get fallback hits the dict_key branch.
+    handler.config = SimpleNamespace()
+    handler.logger = logging.getLogger("t_handler")
+    proj = tmp_path / "project"
+    (proj / "data" / "observations").mkdir(parents=True, exist_ok=True)
+    handler.project_dir = proj
+    handler.domain_name = "icelandic_domain"
+    handler.config_dict = {
+        'LAMAH_ICE_DOMAIN_ID': 1,
+        'LAMAH_ICE_PATH': str(tmp_path / "lamah_cache"),
+    }
+
+    def _get(getter, dict_key=None, default=None):
+        try:
+            v = getter()
+            if v is not None:
+                return v
+        except AttributeError:
+            pass
+        return handler.config_dict.get(dict_key, default)
+    handler._get_config_value = _get
+
+    with patch(
+        'symfluence.data.observation.handlers.lamah_ice.create_robust_session',
+        return_value=_FakeSession(_fake_hydroshare_zip()),
+    ):
+        out = handler.acquire()
+    assert out.exists()
+    assert "1" in out.name

--- a/tools/quality/broad_exception_allowlist.txt
+++ b/tools/quality/broad_exception_allowlist.txt
@@ -282,6 +282,7 @@ src/symfluence/data/observation/handlers/hubeau.py:HubEauStreamflowHandler._down
 src/symfluence/data/observation/handlers/ims_snow.py:IMSSnowHandler.process:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/observation/handlers/jrc_water.py:JRCWaterHandler._compute_basin_stats:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/observation/handlers/jrc_water.py:JRCWaterHandler.process:except Exception as e:  # noqa: BLE001 — preprocessing resilience
+src/symfluence/data/observation/handlers/lamah_ice.py:_download_lamah_ice_zip:except Exception as e:  # noqa: BLE001 — wrap transport errors
 src/symfluence/data/observation/handlers/modis_snow.py:MODISSnowHandler._extract_with_catchment_mask:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/observation/handlers/modis_snow.py:MODISSnowHandler._process_netcdf:except Exception as e2:  # noqa: BLE001 — must-not-raise contract
 src/symfluence/data/observation/handlers/modis_snow.py:MODISSnowHandler._process_netcdf:except Exception as e:  # noqa: BLE001 — preprocessing resilience
@@ -678,6 +679,7 @@ src/symfluence/models/fuse/calibration/parameter_manager.py:FUSEParameterManager
 src/symfluence/models/fuse/calibration/parameter_manager.py:FUSEParameterManager.verify_and_fix_parameter_files:except Exception as e:  # noqa: BLE001 — calibration resilience
 src/symfluence/models/fuse/calibration/transfer_functions.py:ParameterTransferManager.create_distributed_para_def:except Exception as e:  # noqa: BLE001 — calibration resilience
 src/symfluence/models/fuse/calibration/worker.py:FUSEWorker._calculate_multi_gauge_metrics:except Exception as e:  # noqa: BLE001 — calibration resilience
+src/symfluence/models/fuse/calibration/worker.py:FUSEWorker._calculate_multi_gauge_metrics:except Exception as exc:  # noqa: BLE001 — let the existence check below surface the real failure
 src/symfluence/models/fuse/forcing_processor.py:FuseForcingProcessor._calculate_distributed_pet:except Exception as e:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/fuse/forcing_processor.py:FuseForcingProcessor._prepare_lumped_forcing:except Exception as e:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/fuse/forcing_processor.py:FuseForcingProcessor.prepare_forcing_data:except Exception as e:  # noqa: BLE001 — wrap-and-raise to domain error


### PR DESCRIPTION
## Summary

Unblocks Nico on 09_large_domain. LaMAH-Ice (~2 GB decompressed) was a manual download — configs that reference it failed with `FileNotFoundError` until the user went and fetched it out of band.

## Fix

New `ensure_lamah_ice_streamflow(lamah_path, logger)` helper that:

- Streams `lamah_ice.zip` (~636 MB) from HydroShare (DOI 10.4211/hs.86117a5f36cc4b7c90a5d54e18161c91)
- Extracts only `D_gauges/*` — ~57 MB of the 2 GB decompressed; basin polygons and stream-network subtrees aren't needed for streamflow calibration
- Removes the cached zip after extraction
- Prints 10%-tick progress
- Idempotent: repeat runs skip download when `D_gauges` is present

Wired into two sites:

1. `LamahIceStreamflowHandler.acquire` falls back to `SYMFLUENCE_DATA_DIR/lamah_ice/` when `LAMAH_ICE_PATH` is unset and auto-downloads if the expected `ID_<n>.csv` is missing.
2. FUSE MultiGauge worker detects `<path>/D_gauges/…` style `MULTI_GAUGE_OBS_DIR` values and auto-downloads before `MultiGaugeMetrics` starts reading — so 09's Iceland multi-gauge calibration runs out of the box.

## Station selection

Existing knobs cover this:

- `MULTI_GAUGE_IDS: [1, 3, 11]` — explicit inclusion
- `MULTI_GAUGE_EXCLUDE_IDS: [...]` — exclusion
- Physical filters: `MULTI_GAUGE_MAX_DISTANCE`, `MIN_OBS_CV`, `MIN_SPECIFIC_Q`, `MIN_OVERLAP_DAYS`, `KGE_FLOOR`, `MIN_GAUGES`

The 09 `config_Iceland_CARRA_large_domain.yaml` already uses these.

Also corrects the handler's `SOURCE_INFO` DOI (previously pointed at an unrelated Zenodo record) and adds the ESSD 2024 paper citation.

## Test plan

- [x] `tests/unit/data/observation/test_lamah_ice_auto_download.py` — 5/5 pass locally (40 in the dir)
  - D_gauges extraction from synthetic zip
  - unrelated-subtree skip (no `A_basins_total_upstrm/`)
  - idempotency
  - cache-zip cleanup
  - end-to-end `handler.acquire` with auto-download
- [ ] CI (synthetic zip means no 636 MB pull in CI)

Assisted-by: Claude (Anthropic)