### PR TITLE
fix(fuse-multi-gauge): enable distributed multi-gauge calibration end-to-end

### DIFF
--- a/src/symfluence/data/data_manager.py
+++ b/src/symfluence/data/data_manager.py
@@ -140,6 +140,74 @@ class DataManager(BaseManager):
         """
         self.acquisition_service.acquire_observations()
 
+    def _ensure_multi_gauge_dataset_present(self) -> None:
+        """Pre-fetch the multi-gauge observation dataset (e.g. LaMAH-Ice)
+        before any calibration path needs it. Recognises LaMAH-Ice when
+        ``MULTI_GAUGE_OBS_DIR`` points at a ``D_gauges/`` subtree.
+        """
+        from pathlib import Path
+        obs_dir = self._get_config_value(
+            lambda: self.config.evaluation.multi_gauge.obs_dir,
+            dict_key='MULTI_GAUGE_OBS_DIR',
+        )
+        if not obs_dir:
+            return
+        obs_path = Path(obs_dir)
+        if 'D_gauges' not in obs_path.parts:
+            return
+
+        lamah_root = obs_path
+        while lamah_root.name != 'D_gauges' and lamah_root.parent != lamah_root:
+            lamah_root = lamah_root.parent
+        lamah_root = lamah_root.parent
+
+        if not obs_path.exists():
+            try:
+                from symfluence.data.observation.handlers.lamah_ice import (
+                    ensure_lamah_ice_streamflow,
+                )
+                self.logger.info(
+                    f"MULTI_GAUGE_OBS_DIR={obs_dir} resolves under a missing "
+                    f"LaMAH-Ice tree at {lamah_root}; auto-downloading."
+                )
+                ensure_lamah_ice_streamflow(lamah_root, self.logger)
+            except Exception as exc:  # noqa: BLE001 — let downstream errors surface specifics
+                self.logger.warning(
+                    f"LaMAH-Ice auto-download skipped: {exc}. Subsequent "
+                    "calibration steps will surface the missing-data error."
+                )
+        self._ensure_gauge_segment_mapping(lamah_root)
+
+    def _ensure_gauge_segment_mapping(self, lamah_root: 'Path') -> None:
+        """Generate the canonical gauge_segment_mapping.csv if missing.
+
+        Maps LaMAH gauge IDs to mizuRoute segment IDs by spatial-joining
+        the LaMAH gauges shapefile with the domain's river basins polygons.
+        """
+        try:
+            from pathlib import Path
+            domain_name = self._get_config_value(
+                lambda: self.config.domain.name,
+                dict_key='DOMAIN_NAME',
+            )
+            data_dir = self._get_config_value(
+                lambda: self.config.system.data_dir,
+                dict_key='SYMFLUENCE_DATA_DIR',
+            )
+            if not domain_name or not data_dir:
+                return
+            project_dir = Path(data_dir) / f"domain_{domain_name}"
+            from symfluence.models.fuse.calibration.multi_gauge_metrics import (
+                ensure_gauge_segment_mapping,
+            )
+            ensure_gauge_segment_mapping(
+                project_dir, lamah_root, domain_name, self.logger,
+            )
+        except Exception as exc:  # noqa: BLE001 — let downstream errors surface specifics
+            self.logger.warning(
+                f"gauge_segment_mapping.csv auto-generation skipped: {exc}"
+            )
+
     def acquire_em_earth_forcings(self):
         """
         Acquire EM-Earth supplementary forcing data.
@@ -157,6 +225,7 @@ class DataManager(BaseManager):
             DataAcquisitionError: If data processing fails
         """
         self.logger.info("Processing observed data")
+        self._ensure_multi_gauge_dataset_present()
         self.acquire_observations()
 
         with symfluence_error_handler(

--- a/src/symfluence/data/utils/variable_utils.py
+++ b/src/symfluence/data/utils/variable_utils.py
@@ -529,7 +529,12 @@ class VariableHandler:
     # Dataset variable name mappings
     DATASET_MAPPINGS = {
         'CFIF': {
-            # CF-Intermediate Format - used by model-agnostic preprocessing output
+            # CF-Intermediate Format. Legacy SUMMA-style short names listed first
+            # so that callers without dataset context (no available_vars) keep
+            # picking these — that's what most existing pipelines (HYPE, SUMMA,
+            # FUSE preprocessor) read. The CF-canonical aliases below allow
+            # dataset-aware callers (process_forcing_data passing available_vars)
+            # to match files produced by the model-agnostic preprocessor.
             'airtemp': {'standard_name': 'air_temperature', 'units': 'K'},
             'airpres': {'standard_name': 'surface_air_pressure', 'units': 'Pa'},
             'spechum': {'standard_name': 'specific_humidity', 'units': '1'},
@@ -538,7 +543,16 @@ class VariableHandler:
             'windspd_v': {'standard_name': 'northward_wind', 'units': 'm/s'},
             'LWRadAtm': {'standard_name': 'surface_downwelling_longwave_flux', 'units': 'W/m^2'},
             'SWRadAtm': {'standard_name': 'surface_downwelling_shortwave_flux', 'units': 'W/m^2'},
-            'pptrate': {'standard_name': 'precipitation_flux', 'units': 'mm/s'}
+            'pptrate': {'standard_name': 'precipitation_flux', 'units': 'mm/s'},
+            'air_temperature': {'standard_name': 'air_temperature', 'units': 'K'},
+            'surface_air_pressure': {'standard_name': 'surface_air_pressure', 'units': 'Pa'},
+            'specific_humidity': {'standard_name': 'specific_humidity', 'units': '1'},
+            'wind_speed': {'standard_name': 'wind_speed', 'units': 'm/s'},
+            'eastward_wind': {'standard_name': 'eastward_wind', 'units': 'm/s'},
+            'northward_wind': {'standard_name': 'northward_wind', 'units': 'm/s'},
+            'surface_downwelling_longwave_flux': {'standard_name': 'surface_downwelling_longwave_flux', 'units': 'W/m^2'},
+            'surface_downwelling_shortwave_flux': {'standard_name': 'surface_downwelling_shortwave_flux', 'units': 'W/m^2'},
+            'precipitation_flux': {'standard_name': 'precipitation_flux', 'units': 'mm/s'},
         },
         'ERA5': {
             'airtemp': {'standard_name': 'air_temperature', 'units': 'K'},

--- a/src/symfluence/models/fuse/calibration/file_manager.py
+++ b/src/symfluence/models/fuse/calibration/file_manager.py
@@ -17,6 +17,21 @@ from symfluence.core.mixins.project import resolve_data_subdir
 logger = logging.getLogger(__name__)
 
 
+def resolve_fuse_id(config: Dict[str, Any], experiment_id: Optional[str] = None) -> str:
+    """Resolve the FUSE file ID, hashing long IDs to fit FUSE's 6-char buffer.
+
+    Mirrors FUSERunner._get_fuse_file_id so worker-side filenames match
+    runner-side filenames (FUSE Fortran uses CHARACTER(LEN=6) for FMODEL_ID).
+    """
+    if experiment_id is None:
+        experiment_id = (config.get('EXPERIMENT_ID') if config else None) or 'run_1'
+    fuse_id = (config.get('FUSE_FILE_ID') if config else None) or experiment_id
+    if fuse_id and len(fuse_id) > 6:
+        import hashlib
+        fuse_id = hashlib.md5(fuse_id.encode(), usedforsecurity=False).hexdigest()[:6]
+    return fuse_id
+
+
 def update_fuse_file_manager(
     filemanager_path: Path,
     settings_dir: Path,
@@ -49,10 +64,10 @@ def update_fuse_file_manager(
         # Read file with encoding fallback
         lines = _read_file_with_fallback(filemanager_path, log)
 
-        # Resolve experiment/fuse IDs
+        # Resolve experiment/fuse IDs (hash long IDs to fit FUSE's 6-char buffer)
         if experiment_id is None:
             experiment_id = config.get('EXPERIMENT_ID', 'run_1') if config else 'run_1'
-        fuse_id = config.get('FUSE_FILE_ID', experiment_id) if config else experiment_id
+        fuse_id = resolve_fuse_id(config, experiment_id)
 
         # Resolve paths
         settings_path_str = "./"

--- a/src/symfluence/models/fuse/calibration/metrics_calculation.py
+++ b/src/symfluence/models/fuse/calibration/metrics_calculation.py
@@ -19,6 +19,7 @@ import pandas as pd
 from symfluence.core.constants import UnitConversion
 from symfluence.core.mixins.project import resolve_data_subdir
 from symfluence.evaluation.utilities import StreamflowMetrics
+from symfluence.models.fuse.calibration.file_manager import resolve_fuse_id
 
 logger = logging.getLogger(__name__)
 
@@ -150,7 +151,7 @@ def _find_fuse_output(
     """Find FUSE output file."""
     domain_name = config.get('DOMAIN_NAME')
     experiment_id = config.get('EXPERIMENT_ID')
-    fuse_id = config.get('FUSE_FILE_ID', experiment_id)
+    fuse_id = resolve_fuse_id(config, experiment_id)
     fuse_output_dir = Path(sim_dir) if sim_dir else output_dir
 
     candidates = [

--- a/src/symfluence/models/fuse/calibration/model_execution.py
+++ b/src/symfluence/models/fuse/calibration/model_execution.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 from symfluence.core.mixins.project import resolve_data_subdir
+from symfluence.models.fuse.calibration.file_manager import resolve_fuse_id
 
 logger = logging.getLogger(__name__)
 
@@ -128,7 +129,7 @@ def prepare_input_files(
     project_dir = data_dir / f"domain_{domain_name}"
     fuse_input_dir = resolve_data_subdir(project_dir, 'forcing') / 'FUSE_input'
     experiment_id = config.get('EXPERIMENT_ID', 'run_1')
-    fuse_id = config.get('FUSE_FILE_ID', experiment_id)
+    fuse_id = resolve_fuse_id(config, experiment_id)
 
     # Input files to symlink
     input_files = [
@@ -142,7 +143,7 @@ def prepare_input_files(
     # Ensure configuration files are present
     project_settings_dir = project_dir / 'settings' / 'FUSE'
     actual_decisions_file = _ensure_config_files(
-        execution_cwd, project_settings_dir, experiment_id, input_files, log
+        execution_cwd, project_settings_dir, fuse_id, input_files, log
     )
 
     # Create symlinks (but NOT para_def.nc which was copied above)
@@ -346,7 +347,7 @@ def execute_fuse(
         CompletedProcess result, or None if execution failed
     """
     log = log or logger
-    fuse_id = config.get('FUSE_FILE_ID', config.get('EXPERIMENT_ID'))
+    fuse_id = resolve_fuse_id(config)
 
     cmd = [str(fuse_exe), str(filemanager_path.name), fuse_run_id, mode]
 
@@ -488,7 +489,7 @@ def handle_fuse_output(
     log = log or logger
 
     domain_name = config.get('DOMAIN_NAME')
-    fuse_id = config.get('FUSE_FILE_ID', config.get('EXPERIMENT_ID'))
+    fuse_id = resolve_fuse_id(config)
 
     run_suffix = 'runs_def' if mode == 'run_def' else 'runs_pre'
     local_output_filename = f"{fuse_run_id}_{fuse_id}_{run_suffix}.nc"

--- a/src/symfluence/models/fuse/calibration/multi_gauge_metrics.py
+++ b/src/symfluence/models/fuse/calibration/multi_gauge_metrics.py
@@ -613,6 +613,70 @@ class MultiGaugeMetrics:
         return available
 
 
+def ensure_gauge_segment_mapping(
+    project_dir: Path,
+    lamah_root: Path,
+    domain_name: str,
+    logger: logging.Logger,
+) -> Optional[Path]:
+    """Ensure gauge_segment_mapping.csv exists at the canonical project path.
+
+    Generates the mapping by spatial-joining the LaMAH-Ice gauge points
+    against the domain's mizuRoute river-basin polygons. Returns the canonical
+    path on success; None if either input shapefile is unavailable.
+    """
+    canonical = project_dir / 'settings' / 'mizuRoute' / 'gauge_segment_mapping.csv'
+    if canonical.exists():
+        return canonical
+
+    gauges_shp = lamah_root / 'D_gauges' / '3_shapefiles' / 'gauges.shp'
+    basins_shp = (
+        project_dir / 'shapefiles' / 'river_basins' /
+        f"{domain_name}_riverBasins_semidistributed.shp"
+    )
+    if not gauges_shp.exists() or not basins_shp.exists():
+        logger.warning(
+            "Cannot generate gauge_segment_mapping.csv: missing "
+            f"gauges shapefile ({gauges_shp.exists()=}) or "
+            f"river basins shapefile ({basins_shp.exists()=})"
+        )
+        return None
+
+    try:
+        import geopandas as gpd
+    except ImportError:
+        logger.warning("geopandas unavailable; cannot auto-generate gauge mapping")
+        return None
+
+    logger.info(f"Auto-generating gauge_segment_mapping.csv at {canonical}")
+    gauges = gpd.read_file(gauges_shp).to_crs('EPSG:4326')
+    basins = gpd.read_file(basins_shp)
+    if basins.crs is None:
+        basins = basins.set_crs('EPSG:4326')
+    else:
+        basins = basins.to_crs('EPSG:4326')
+
+    seg_col = 'GRU_ID' if 'GRU_ID' in basins.columns else 'gru_to_seg'
+    joined = gpd.sjoin_nearest(
+        gauges[['id', 'name', 'geometry']],
+        basins[[seg_col, 'geometry']],
+        how='left',
+        distance_col='distance_to_segment',
+    )
+    joined = joined.rename(columns={seg_col: 'nearest_segment'})
+
+    out = pd.DataFrame({
+        'id': joined['id'].astype(int),
+        'name': joined['name'],
+        'nearest_segment': joined['nearest_segment'].astype(int),
+        'distance_to_segment': joined['distance_to_segment'].astype(float),
+    })
+    canonical.parent.mkdir(parents=True, exist_ok=True)
+    out.to_csv(canonical, index=False)
+    logger.info(f"Wrote {len(out)} gauge→segment rows to {canonical}")
+    return canonical
+
+
 def create_multi_gauge_config(
     gauge_segment_mapping_path: str,
     obs_data_dir: str,

--- a/src/symfluence/models/fuse/calibration/optimizer.py
+++ b/src/symfluence/models/fuse/calibration/optimizer.py
@@ -16,7 +16,8 @@ from symfluence.core.file_utils import copy_file
 from symfluence.optimization.optimizers.base_model_optimizer import BaseModelOptimizer
 from symfluence.optimization.registry import OptimizerRegistry
 
-from .worker import FUSEWorker  # noqa: F401 - Import to trigger worker registration
+from .parameter_manager import FUSEParameterManager  # noqa: F401 - trigger param manager registration
+from .worker import FUSEWorker  # noqa: F401 - trigger worker registration
 
 
 @OptimizerRegistry.register_optimizer('FUSE')
@@ -67,9 +68,10 @@ class FUSEModelOptimizer(BaseModelOptimizer):
         self.fuse_sim_dir = self.project_dir / 'simulations' / exp_id / 'FUSE'
         self.fuse_setup_dir = self.project_dir / 'settings' / 'FUSE'
         self.fuse_exe_path = self._get_fuse_executable_path_pre_init(config)
-        # Use 'or' to treat None as "not set" and fallback to exp_id
+        # Use 'or' to treat None as "not set" and fallback to exp_id; hash long IDs.
+        from symfluence.models.fuse.calibration.file_manager import resolve_fuse_id
         fuse_file_id = config.get('FUSE_FILE_ID') if isinstance(config, dict) else (config.model.fuse.file_id if config.model and config.model.fuse else None)
-        self.fuse_id = fuse_file_id or exp_id
+        self.fuse_id = resolve_fuse_id({'FUSE_FILE_ID': fuse_file_id, 'EXPERIMENT_ID': exp_id})
 
         super().__init__(config, logger, optimization_settings_dir, reporting_manager=reporting_manager)
 
@@ -94,7 +96,6 @@ class FUSEModelOptimizer(BaseModelOptimizer):
 
     def _create_parameter_manager(self):
         """Create FUSE parameter manager."""
-        from .parameter_manager import FUSEParameterManager
         return FUSEParameterManager(
             self.config,
             self.logger,
@@ -851,9 +852,7 @@ class FUSEModelOptimizer(BaseModelOptimizer):
 
         # Copy parameter file to each parallel directory
         # This is critical for parallel workers to modify parameters in isolation
-        # Use 'or' to treat None as "not set" and fallback to experiment_id
-        fuse_id = self._get_config_value(lambda: self.config.model.fuse.file_id, dict_key='FUSE_FILE_ID') or self.experiment_id
-        param_file = self.fuse_sim_dir / f"{self.domain_name}_{fuse_id}_para_def.nc"
+        param_file = self.fuse_sim_dir / f"{self.domain_name}_{self.fuse_id}_para_def.nc"
 
         # If para_def.nc doesn't exist, try to find a complete FUSE template
         # CRITICAL: For run_pre mode, FUSE requires all ~89 variables including:

--- a/src/symfluence/models/fuse/calibration/parameter_manager.py
+++ b/src/symfluence/models/fuse/calibration/parameter_manager.py
@@ -81,7 +81,9 @@ class FUSEParameterManager(BaseParameterManager):
         self.project_dir = self.data_dir / f"domain_{self.domain_name}"
         self.fuse_sim_dir = self.project_dir / 'simulations' / self.experiment_id / 'FUSE'
         self.fuse_setup_dir = self.project_dir / 'settings' / 'FUSE'
-        self.fuse_id = self._get_config_value(lambda: self.config.model.fuse.file_id, default=self.experiment_id, dict_key='FUSE_FILE_ID')
+        from symfluence.models.fuse.calibration.file_manager import resolve_fuse_id
+        raw_fuse_id = self._get_config_value(lambda: self.config.model.fuse.file_id, default=self.experiment_id, dict_key='FUSE_FILE_ID')
+        self.fuse_id = resolve_fuse_id({'FUSE_FILE_ID': raw_fuse_id, 'EXPERIMENT_ID': self.experiment_id})
 
         # Parameter file paths
         self.para_def_path = self.fuse_sim_dir / f"{self.domain_name}_{self.fuse_id}_para_def.nc"

--- a/src/symfluence/models/fuse/calibration/worker.py
+++ b/src/symfluence/models/fuse/calibration/worker.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, Optional
 
 from symfluence.evaluation.utilities import StreamflowMetrics
 from symfluence.models.fuse.calibration.file_manager import (
+    resolve_fuse_id,
     update_fuse_file_manager,
 )
 from symfluence.models.fuse.calibration.metrics_calculation import (
@@ -164,7 +165,7 @@ class FUSEWorker(BaseWorker):
         """Update para_def.nc file using appropriate strategy."""
         domain_name = config.get('DOMAIN_NAME', '')
         experiment_id = config.get('EXPERIMENT_ID', 'run_1')
-        fuse_id = config.get('FUSE_FILE_ID', experiment_id)
+        fuse_id = resolve_fuse_id(config, experiment_id)
         para_def_path = fuse_settings_dir / f"{domain_name}_{fuse_id}_para_def.nc"
 
         if regionalization_method != 'lumped' and para_def_path.exists():
@@ -351,11 +352,6 @@ class FUSEWorker(BaseWorker):
             data_dir = Path(config.get('SYMFLUENCE_DATA_DIR', '.'))
             project_dir = data_dir / f"domain_{domain_name}"
 
-            # Load observations
-            observed = load_observations(config, project_dir, self.logger)
-            if observed is None:
-                return {'kge': self.penalty_score}
-
             # Find simulation output
             mizuroute_dir = kwargs.get('mizuroute_dir')
             proc_id = kwargs.get('proc_id', 0)
@@ -368,7 +364,8 @@ class FUSEWorker(BaseWorker):
             if sim_file_path is None:
                 return {'kge': self.penalty_score}
 
-            # Check multi-gauge mode
+            # Multi-gauge sources its own observations from MULTI_GAUGE_OBS_DIR,
+            # so skip the single-gauge load_observations gate when enabled.
             multi_gauge_enabled = config.get('MULTI_GAUGE_CALIBRATION', False)
             if multi_gauge_enabled and use_routed:
                 kwargs_clean = {k: v for k, v in kwargs.items() if k != 'project_dir'}
@@ -378,6 +375,11 @@ class FUSEWorker(BaseWorker):
                     project_dir=project_dir,
                     **kwargs_clean
                 )
+
+            # Single-gauge path needs preprocessed observations on disk.
+            observed = load_observations(config, project_dir, self.logger)
+            if observed is None:
+                return {'kge': self.penalty_score}
 
             # Read simulated streamflow
             if use_routed:

--- a/src/symfluence/models/fuse/runner.py
+++ b/src/symfluence/models/fuse/runner.py
@@ -142,6 +142,7 @@ class FUSERunner(BaseModelRunner, SpatialOrchestrator, OutputConverterMixin, Miz
         return [
             output_dir / f"{self.domain_name}_{fuse_id}_runs_def.nc",
             output_dir / f"{self.domain_name}_{fuse_id}_runs_best.nc",
+            output_dir / f"{self.domain_name}_{fuse_id}_runs_pre.nc",
         ]
 
     def _convert_routing_units_for_mizuroute(self, dataset: xr.Dataset) -> bool:

--- a/src/symfluence/models/fuse/utilities/mizuroute_converter.py
+++ b/src/symfluence/models/fuse/utilities/mizuroute_converter.py
@@ -16,6 +16,8 @@ from typing import Any, Dict, Optional, Tuple
 import numpy as np
 import pandas as pd
 
+from symfluence.models.fuse.calibration.file_manager import resolve_fuse_id
+
 # Suppress xarray FutureWarning about timedelta64 decoding
 warnings.filterwarnings('ignore',
                        message='.*decode_timedelta.*',
@@ -64,7 +66,7 @@ class FuseToMizurouteConverter:
 
             domain_name = config.get('DOMAIN_NAME')
             experiment_id = config.get('EXPERIMENT_ID')
-            fuse_id = config.get('FUSE_FILE_ID', experiment_id)
+            fuse_id = resolve_fuse_id(config, experiment_id)
 
             # Find FUSE output file (runs_def.nc for run_def mode)
             output_file = fuse_output_dir / f"{domain_name}_{fuse_id}_runs_def.nc"

--- a/src/symfluence/models/summa/calibration/optimizer.py
+++ b/src/symfluence/models/summa/calibration/optimizer.py
@@ -16,7 +16,8 @@ from symfluence.core.file_utils import copy_file
 from symfluence.optimization.optimizers.base_model_optimizer import BaseModelOptimizer
 from symfluence.optimization.registry import OptimizerRegistry
 
-from .worker import SUMMAWorker  # noqa: F401 - Import to trigger worker registration
+from .parameter_manager import SUMMAParameterManager  # noqa: F401 - trigger param manager registration
+from .worker import SUMMAWorker  # noqa: F401 - trigger worker registration
 
 
 @OptimizerRegistry.register_optimizer('SUMMA')
@@ -72,7 +73,6 @@ class SUMMAModelOptimizer(BaseModelOptimizer):
 
     def _create_parameter_manager(self):
         """Create SUMMA parameter manager."""
-        from symfluence.models.summa.calibration.parameter_manager import SUMMAParameterManager
         # SUMMA ParameterManager expects to find localParamInfo.txt and attributes.nc
         # These are located in settings/SUMMA, not optimization/
         summa_settings_dir = self.project_dir / 'settings' / 'SUMMA'

--- a/src/symfluence/optimization/optimization_manager.py
+++ b/src/symfluence/optimization/optimization_manager.py
@@ -292,10 +292,17 @@ class OptimizationManager(BaseManager):
 
             # Skip external DDS for FUSE when built-in SCE calibration is enabled.
             # FUSE's internal calib_sce (run in step 11) makes external DDS redundant.
+            # Multi-gauge calibration always needs the external worker because
+            # FUSE-internal SCE is single-basin only.
             if 'FUSE' in hydrological_models:
                 fuse_cfg = self.config.model.fuse if self.config.model else None
                 use_internal = fuse_cfg.run_internal_calibration if fuse_cfg else True
-                if use_internal:
+                multi_gauge = self._get_config_value(
+                    lambda: self.config.calibration.multi_gauge,
+                    default=False,
+                    dict_key='MULTI_GAUGE_CALIBRATION'
+                )
+                if use_internal and not multi_gauge:
                     self.logger.info(
                         "Skipping external optimization for FUSE — "
                         "using built-in SCE calibration (FUSE_RUN_INTERNAL_CALIBRATION=True). "

--- a/tests/unit/data/test_cfif_variable_handler.py
+++ b/tests/unit/data/test_cfif_variable_handler.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""VariableHandler must match CFIF-named forcing variables.
+
+End-to-end run on the 09_large_domain config failed at FUSE
+preprocessing with "Required variable temp not found in dataset CFIF"
+because the ``DATASET_MAPPINGS['CFIF']`` entry only listed legacy
+SUMMA short names (airtemp, pptrate, …) — but model-agnostic
+preprocessing produces files with the canonical CF names
+(air_temperature, precipitation_flux, …). Pin both forms.
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from symfluence.data.utils.variable_utils import VariableHandler
+
+pytestmark = [pytest.mark.unit, pytest.mark.quick]
+
+
+def _ds_with_cfif_canonical_names():
+    times = pd.date_range("2015-01-01", periods=4, freq="h")
+    rng = np.random.default_rng(0)
+    return xr.Dataset(
+        data_vars=dict(
+            air_temperature=(("time",), rng.uniform(270, 290, 4).astype("float32")),
+            precipitation_flux=(("time",), rng.uniform(0, 5e-5, 4).astype("float32")),
+            specific_humidity=(("time",), rng.uniform(2e-3, 5e-3, 4).astype("float32")),
+            wind_speed=(("time",), rng.uniform(1, 8, 4).astype("float32")),
+            surface_downwelling_longwave_flux=(("time",), rng.uniform(200, 300, 4).astype("float32")),
+            surface_downwelling_shortwave_flux=(("time",), rng.uniform(0, 200, 4).astype("float32")),
+            surface_air_pressure=(("time",), rng.uniform(95000, 102000, 4).astype("float32")),
+        ),
+        coords=dict(time=times),
+    )
+
+
+def _ds_with_legacy_summa_names():
+    times = pd.date_range("2015-01-01", periods=4, freq="h")
+    rng = np.random.default_rng(0)
+    return xr.Dataset(
+        data_vars=dict(
+            airtemp=(("time",), rng.uniform(270, 290, 4).astype("float32")),
+            pptrate=(("time",), rng.uniform(0, 5e-5, 4).astype("float32")),
+            spechum=(("time",), rng.uniform(2e-3, 5e-3, 4).astype("float32")),
+            windspd=(("time",), rng.uniform(1, 8, 4).astype("float32")),
+            LWRadAtm=(("time",), rng.uniform(200, 300, 4).astype("float32")),
+            SWRadAtm=(("time",), rng.uniform(0, 200, 4).astype("float32")),
+            airpres=(("time",), rng.uniform(95000, 102000, 4).astype("float32")),
+        ),
+        coords=dict(time=times),
+    )
+
+
+def _make_handler():
+    return VariableHandler(
+        config=MagicMock(),
+        logger=logging.getLogger("test_cfif_handler"),
+        dataset='CFIF',
+        model='FUSE',
+    )
+
+
+def test_cfif_canonical_names_resolve():
+    """The CFIF dataset_map must include canonical CF names so a
+    file produced by the model-agnostic pipeline matches without
+    relying on metadata attrs."""
+    h = _make_handler()
+    out = h.process_forcing_data(_ds_with_cfif_canonical_names())
+    # FUSE's MODEL_REQUIREMENTS map to short names like 'temp', 'pr', ...
+    # The exact short names depend on MODEL_REQUIREMENTS; what matters
+    # is the call doesn't raise "Required variable not found".
+    assert len(out.data_vars) > 0
+
+
+def test_cfif_legacy_summa_names_still_resolve():
+    """Older intermediate files use the SUMMA short names; the
+    backwards-compat aliases keep them working."""
+    h = _make_handler()
+    out = h.process_forcing_data(_ds_with_legacy_summa_names())
+    assert len(out.data_vars) > 0
+
+
+def test_find_matching_variable_picks_canonical_first():
+    """When both forms are available, _find_matching_variable should
+    pick whichever matches on standard_name and exists in the data —
+    canonical for canonical files, legacy for legacy files. No
+    ordering dependency."""
+    from symfluence.data.utils.variable_utils import VariableHandler
+    h = VariableHandler(MagicMock(), logging.getLogger('t'), 'CFIF', 'FUSE')
+
+    canonical_vars = {'air_temperature'}
+    legacy_vars = {'airtemp'}
+
+    cfif_map = h.DATASET_MAPPINGS['CFIF']
+    canonical = h._find_matching_variable('air_temperature', cfif_map, canonical_vars)
+    legacy = h._find_matching_variable('air_temperature', cfif_map, legacy_vars)
+
+    assert canonical == 'air_temperature'
+    assert legacy == 'airtemp'

--- a/tests/unit/data/test_multi_gauge_auto_download.py
+++ b/tests/unit/data/test_multi_gauge_auto_download.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""DataManager triggers the LaMAH-Ice download at observation acquisition.
+
+Earlier wiring put the auto-download inside the FUSE multi-gauge
+calibration worker. That meant any config that hit the FUSE-internal
+SCE path (FUSE_RUN_INTERNAL_CALIBRATION=True) — which 09_large_domain
+uses — never triggered the download. Move the trigger to
+``DataManager.process_observed_data`` so the dataset lands at
+observation acquisition time regardless of which optimiser the user
+picks.
+"""
+
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.quick]
+
+
+def _make_dm(obs_dir_value):
+    """Build a DataManager bypassing __init__ with just the helper's deps."""
+    from types import SimpleNamespace
+
+    from symfluence.data.data_manager import DataManager
+
+    dm = DataManager.__new__(DataManager)
+    # Plain namespaces so the typed-config getter raises AttributeError
+    # cleanly and the dict_key fallback runs.
+    dm.config = SimpleNamespace()
+    dm.logger = logging.getLogger("test_multi_gauge_dl")
+
+    def _get(getter, default=None, dict_key=None):
+        try:
+            v = getter()
+            if v is not None:
+                return v
+        except (AttributeError, TypeError):
+            pass
+        if dict_key == 'MULTI_GAUGE_OBS_DIR':
+            return obs_dir_value
+        return default
+
+    dm._get_config_value = _get
+    return dm
+
+
+def test_no_multi_gauge_obs_dir_is_a_noop(tmp_path):
+    dm = _make_dm(None)
+    with patch(
+        'symfluence.data.observation.handlers.lamah_ice.ensure_lamah_ice_streamflow',
+    ) as m:
+        dm._ensure_multi_gauge_dataset_present()
+    m.assert_not_called()
+
+
+def test_present_obs_dir_is_a_noop(tmp_path):
+    """If the dir already exists, don't redownload."""
+    obs_dir = tmp_path / "lamah_ice" / "D_gauges" / "2_timeseries" / "daily"
+    obs_dir.mkdir(parents=True)
+    dm = _make_dm(str(obs_dir))
+    with patch(
+        'symfluence.data.observation.handlers.lamah_ice.ensure_lamah_ice_streamflow',
+    ) as m:
+        dm._ensure_multi_gauge_dataset_present()
+    m.assert_not_called()
+
+
+def test_non_lamah_obs_dir_is_a_noop(tmp_path):
+    """An obs_dir without 'D_gauges' in the path is some other
+    multi-gauge source (CAMELS, etc.) — we're not the right helper
+    for that."""
+    obs_dir = tmp_path / "camels" / "streamflow"
+    dm = _make_dm(str(obs_dir))
+    with patch(
+        'symfluence.data.observation.handlers.lamah_ice.ensure_lamah_ice_streamflow',
+    ) as m:
+        dm._ensure_multi_gauge_dataset_present()
+    m.assert_not_called()
+
+
+def test_missing_lamah_obs_dir_triggers_download(tmp_path):
+    """The 09_large_domain case: obs_dir points at a missing
+    LaMAH-Ice subtree — auto-download fires at obs-acquisition time
+    so the dataset is on disk before any optimiser starts."""
+    obs_dir = tmp_path / "lamah_ice" / "D_gauges" / "2_timeseries" / "daily"
+    dm = _make_dm(str(obs_dir))
+    with patch(
+        'symfluence.data.observation.handlers.lamah_ice.ensure_lamah_ice_streamflow',
+    ) as m:
+        dm._ensure_multi_gauge_dataset_present()
+    m.assert_called_once()
+    # Helper must be called with the dataset root (lamah_ice/), not
+    # the inner 2_timeseries/daily/ subdir.
+    args, _ = m.call_args
+    called_with = args[0]
+    assert called_with == tmp_path / "lamah_ice", \
+        f"helper should be called with dataset root, got {called_with}"
+
+
+def test_download_failure_does_not_break_obs_step(tmp_path, caplog):
+    """If the auto-download itself fails, we log a warning and let
+    the existing observation acquisition surface the missing-data
+    error — don't add a new failure mode."""
+    obs_dir = tmp_path / "lamah_ice" / "D_gauges" / "2_timeseries" / "daily"
+    dm = _make_dm(str(obs_dir))
+    with patch(
+        'symfluence.data.observation.handlers.lamah_ice.ensure_lamah_ice_streamflow',
+        side_effect=RuntimeError("zenodo down"),
+    ):
+        caplog.set_level(logging.WARNING)
+        dm._ensure_multi_gauge_dataset_present()  # must not raise
+    msg = "\n".join(r.getMessage() for r in caplog.records)
+    assert "auto-download skipped" in msg
+    assert "zenodo down" in msg

--- a/tests/unit/models/fuse/test_parameter_manager.py
+++ b/tests/unit/models/fuse/test_parameter_manager.py
@@ -120,7 +120,9 @@ class TestFUSEParameterManagerInitialization:
 
         assert manager.domain_name == 'test_catchment'
         assert manager.experiment_id == 'test_fuse_exp'
-        assert manager.fuse_id == 'test_fuse'
+        # FUSE Fortran uses CHARACTER(LEN=6) for FMODEL_ID; longer IDs hash.
+        import hashlib
+        assert manager.fuse_id == hashlib.md5(b'test_fuse', usedforsecurity=False).hexdigest()[:6]
 
     def test_init_handles_empty_params(self, fuse_config, test_logger, tmp_path):
         """Test initialization with empty string uses default parameters.

--- a/tools/quality/broad_exception_allowlist.txt
+++ b/tools/quality/broad_exception_allowlist.txt
@@ -226,6 +226,8 @@ src/symfluence/data/acquisition/zonal_stats_processor.py:DataPreProcessor.calcul
 src/symfluence/data/acquisition/zonal_stats_processor.py:DataPreProcessor.calculate_soil_stats:except Exception as e:  # noqa: BLE001 — wrap-and-raise to domain error
 src/symfluence/data/cache/forcing_cache.py:RawForcingCache._evict_if_needed:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/cache/forcing_cache.py:RawForcingCache.get_cache_stats:except Exception as e:  # noqa: BLE001 — preprocessing resilience
+src/symfluence/data/data_manager.py:DataManager._ensure_gauge_segment_mapping:except Exception as exc:  # noqa: BLE001 — let downstream errors surface specifics
+src/symfluence/data/data_manager.py:DataManager._ensure_multi_gauge_dataset_present:except Exception as exc:  # noqa: BLE001 — let downstream errors surface specifics
 src/symfluence/data/data_manager.py:DataManager.process_observed_data:except Exception as e:  # noqa: BLE001 — must-not-raise contract
 src/symfluence/data/model_ready/attributes_builder.py:AttributesNetCDFBuilder._build_climate_group:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/model_ready/attributes_builder.py:AttributesNetCDFBuilder._build_hru_identity_group:except Exception:  # noqa: BLE001 — preprocessing resilience


### PR DESCRIPTION
## Summary

The paper's distributed FUSE + mizuRoute + multi-gauge calibration workflow (Section 4.3.2 — Iceland Large Domain) didn't run end-to-end on a fresh project directory due to seven independent gaps. Each is small; together they prevented the calibration loop from producing real KGE values. This PR fixes all seven and adds tests + auto-acquisition for the data inputs.

## What's fixed

- **CFIF variable mapping** — add canonical CF-standard aliases (`air_temperature`, `precipitation_flux`, …) alongside legacy SUMMA short names. Legacy listed first so callers without dataset context (HYPE/SUMMA forcing setup) keep getting legacy names; canonical aliases match files produced by the model-agnostic preprocessor when `available_vars` is provided.
- **FUSE `FMODEL_ID` hash consistency** — add `resolve_fuse_id()` helper in `file_manager.py` and route worker, `model_execution` (3 sites), `metrics_calculation`, `mizuroute_converter`, `parameter_manager`, `optimizer` through it. FUSE Fortran's `CHARACTER(LEN=6)` buffer was silently truncating long IDs and the worker-side filenames diverged from the runner-side hashed filenames.
- **`_runs_pre.nc` candidate** — added to `_fuse_output_candidates` since `run_pre` is the preferred mode (`run_def` hits NC_UNLIMITED conflicts in NETCDF3_CLASSIC).
- **Multi-gauge calibration dispatch** — move the multi-gauge branch in `FUSEWorker.calculate_metrics` ahead of the single-gauge `load_observations()` guard. In `OptimizationManager.calibrate_model`, also check `MULTI_GAUGE_CALIBRATION` before skipping FUSE for `FUSE_RUN_INTERNAL_CALIBRATION=True`. FUSE-internal SCE is single-basin only, so the paper's combination has to fall through to the external worker.
- **LaMAH-Ice / gauge mapping auto-acquisition** — `DataManager.process_observed_data()` now calls `_ensure_multi_gauge_dataset_present()` before `acquire_observations()`, which auto-downloads LaMAH-Ice when `MULTI_GAUGE_OBS_DIR` points at a missing `D_gauges/` subtree, then auto-generates the canonical `{project_dir}/settings/mizuRoute/gauge_segment_mapping.csv` via spatial-join of LaMAH gauges against the domain's river basins. Removes the requirement to pre-stage the author-machine-pinned mapping CSV from the paper config.
- **Parameter manager registry discovery** — `SUMMAModelOptimizer` and `FUSEModelOptimizer` imported `.worker` eagerly but `.parameter_manager` only lazily inside `_create_parameter_manager()`, so `OptimizerRegistry.get_parameter_manager('SUMMA')` returned `None` at module load and 12 models were missing from the registry. Made the parameter manager imports eager.

## Test plan

- [x] Full unit suite: 5288 pass.
- [x] Full integration suite: 5514 pass (the previously-failing `test_parameter_manager_registry_has_models` now passes thanks to the eager-import fix).
- [x] Strict-from-scratch validation on the Section 4.3.2 paper config (`config_Iceland_CARRA_large_domain.yaml`) with only `subcatchment_attributes.csv` pre-staged (no auto-generator exists for that file): completes through Step 16 with **DDS = 100/101 evaluations, 0% crash rate, real KGE values across 45 multi-gauge sites**.
- [x] New unit tests: `test_cfif_variable_handler.py` (canonical + legacy resolution) and `test_multi_gauge_auto_download.py` (LaMAH-Ice trigger fires from `process_observed_data`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)