### PR TITLE
fix(cfif): resolve canonical CF names in VariableHandler

### DIFF
--- a/src/symfluence/data/utils/variable_utils.py
+++ b/src/symfluence/data/utils/variable_utils.py
@@ -529,7 +529,22 @@ class VariableHandler:
     # Dataset variable name mappings
     DATASET_MAPPINGS = {
         'CFIF': {
-            # CF-Intermediate Format - used by model-agnostic preprocessing output
+            # Canonical CF names produced by the model-agnostic
+            # preprocessing pipeline. Earlier this entry only listed
+            # the legacy SUMMA short names (airtemp, pptrate, …),
+            # which made VariableHandler fail every lookup against a
+            # CFIF-named file with "No matching variable found" — the
+            # legacy names live below as aliases for backwards compat.
+            'air_temperature': {'standard_name': 'air_temperature', 'units': 'K'},
+            'surface_air_pressure': {'standard_name': 'surface_air_pressure', 'units': 'Pa'},
+            'specific_humidity': {'standard_name': 'specific_humidity', 'units': '1'},
+            'wind_speed': {'standard_name': 'wind_speed', 'units': 'm/s'},
+            'eastward_wind': {'standard_name': 'eastward_wind', 'units': 'm/s'},
+            'northward_wind': {'standard_name': 'northward_wind', 'units': 'm/s'},
+            'surface_downwelling_longwave_flux': {'standard_name': 'surface_downwelling_longwave_flux', 'units': 'W/m^2'},
+            'surface_downwelling_shortwave_flux': {'standard_name': 'surface_downwelling_shortwave_flux', 'units': 'W/m^2'},
+            'precipitation_flux': {'standard_name': 'precipitation_flux', 'units': 'mm/s'},
+            # Legacy SUMMA short names — older intermediate files.
             'airtemp': {'standard_name': 'air_temperature', 'units': 'K'},
             'airpres': {'standard_name': 'surface_air_pressure', 'units': 'Pa'},
             'spechum': {'standard_name': 'specific_humidity', 'units': '1'},
@@ -538,7 +553,7 @@ class VariableHandler:
             'windspd_v': {'standard_name': 'northward_wind', 'units': 'm/s'},
             'LWRadAtm': {'standard_name': 'surface_downwelling_longwave_flux', 'units': 'W/m^2'},
             'SWRadAtm': {'standard_name': 'surface_downwelling_shortwave_flux', 'units': 'W/m^2'},
-            'pptrate': {'standard_name': 'precipitation_flux', 'units': 'mm/s'}
+            'pptrate': {'standard_name': 'precipitation_flux', 'units': 'mm/s'},
         },
         'ERA5': {
             'airtemp': {'standard_name': 'air_temperature', 'units': 'K'},

--- a/tests/unit/data/test_cfif_variable_handler.py
+++ b/tests/unit/data/test_cfif_variable_handler.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""VariableHandler must match CFIF-named forcing variables.
+
+End-to-end run on the 09_large_domain config failed at FUSE
+preprocessing with "Required variable temp not found in dataset CFIF"
+because the ``DATASET_MAPPINGS['CFIF']`` entry only listed legacy
+SUMMA short names (airtemp, pptrate, …) — but model-agnostic
+preprocessing produces files with the canonical CF names
+(air_temperature, precipitation_flux, …). Pin both forms.
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from symfluence.data.utils.variable_utils import VariableHandler
+
+pytestmark = [pytest.mark.unit, pytest.mark.quick]
+
+
+def _ds_with_cfif_canonical_names():
+    times = pd.date_range("2015-01-01", periods=4, freq="h")
+    rng = np.random.default_rng(0)
+    return xr.Dataset(
+        data_vars=dict(
+            air_temperature=(("time",), rng.uniform(270, 290, 4).astype("float32")),
+            precipitation_flux=(("time",), rng.uniform(0, 5e-5, 4).astype("float32")),
+            specific_humidity=(("time",), rng.uniform(2e-3, 5e-3, 4).astype("float32")),
+            wind_speed=(("time",), rng.uniform(1, 8, 4).astype("float32")),
+            surface_downwelling_longwave_flux=(("time",), rng.uniform(200, 300, 4).astype("float32")),
+            surface_downwelling_shortwave_flux=(("time",), rng.uniform(0, 200, 4).astype("float32")),
+            surface_air_pressure=(("time",), rng.uniform(95000, 102000, 4).astype("float32")),
+        ),
+        coords=dict(time=times),
+    )
+
+
+def _ds_with_legacy_summa_names():
+    times = pd.date_range("2015-01-01", periods=4, freq="h")
+    rng = np.random.default_rng(0)
+    return xr.Dataset(
+        data_vars=dict(
+            airtemp=(("time",), rng.uniform(270, 290, 4).astype("float32")),
+            pptrate=(("time",), rng.uniform(0, 5e-5, 4).astype("float32")),
+            spechum=(("time",), rng.uniform(2e-3, 5e-3, 4).astype("float32")),
+            windspd=(("time",), rng.uniform(1, 8, 4).astype("float32")),
+            LWRadAtm=(("time",), rng.uniform(200, 300, 4).astype("float32")),
+            SWRadAtm=(("time",), rng.uniform(0, 200, 4).astype("float32")),
+            airpres=(("time",), rng.uniform(95000, 102000, 4).astype("float32")),
+        ),
+        coords=dict(time=times),
+    )
+
+
+def _make_handler():
+    return VariableHandler(
+        config=MagicMock(),
+        logger=logging.getLogger("test_cfif_handler"),
+        dataset='CFIF',
+        model='FUSE',
+    )
+
+
+def test_cfif_canonical_names_resolve():
+    """The CFIF dataset_map must include canonical CF names so a
+    file produced by the model-agnostic pipeline matches without
+    relying on metadata attrs."""
+    h = _make_handler()
+    out = h.process_forcing_data(_ds_with_cfif_canonical_names())
+    # FUSE's MODEL_REQUIREMENTS map to short names like 'temp', 'pr', ...
+    # The exact short names depend on MODEL_REQUIREMENTS; what matters
+    # is the call doesn't raise "Required variable not found".
+    assert len(out.data_vars) > 0
+
+
+def test_cfif_legacy_summa_names_still_resolve():
+    """Older intermediate files use the SUMMA short names; the
+    backwards-compat aliases keep them working."""
+    h = _make_handler()
+    out = h.process_forcing_data(_ds_with_legacy_summa_names())
+    assert len(out.data_vars) > 0
+
+
+def test_find_matching_variable_picks_canonical_first():
+    """When both forms are available, _find_matching_variable should
+    pick whichever matches on standard_name and exists in the data —
+    canonical for canonical files, legacy for legacy files. No
+    ordering dependency."""
+    from symfluence.data.utils.variable_utils import VariableHandler
+    h = VariableHandler(MagicMock(), logging.getLogger('t'), 'CFIF', 'FUSE')
+
+    canonical_vars = {'air_temperature'}
+    legacy_vars = {'airtemp'}
+
+    cfif_map = h.DATASET_MAPPINGS['CFIF']
+    canonical = h._find_matching_variable('air_temperature', cfif_map, canonical_vars)
+    legacy = h._find_matching_variable('air_temperature', cfif_map, legacy_vars)
+
+    assert canonical == 'air_temperature'
+    assert legacy == 'airtemp'


### PR DESCRIPTION
## Summary
- Adds canonical CF variable names (`air_temperature`, `precipitation_flux`, etc.) as aliases in `DATASET_MAPPINGS['CFIF']` so the VariableHandler can resolve forcing files produced by the model-agnostic preprocessor
- Legacy SUMMA-style short names (`airtemp`, `pptrate`, etc.) are retained for backward compatibility
- Fixes end-to-end FUSE runs that fail at preprocessing with `No matching variable found for standard_name: air_temperature`

## Context
The CFIF migration (`f82bf4bf`) standardized internal variable names to CF convention, but `DATASET_MAPPINGS['CFIF']` only listed the legacy short names. When model-agnostic preprocessing writes files with canonical CF names, the VariableHandler's `standard_name` lookup found no match, and model preprocessors (FUSE, GR, HYPE, etc.) failed.

This is part of the broader design goal: all forcing data flows through CFIF as a canonical intermediate format, and the VariableHandler handles the translation to each model's native variable names and units at the preprocessing boundary.

## Test plan
- [x] New tests in `tests/unit/data/test_cfif_variable_handler.py` pin canonical CFIF name resolution, legacy name resolution, and `_find_matching_variable` behavior
- [x] Verified end-to-end on Iceland multi-gauge calibration (09_large_domain) — all 16 workflow steps pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)