### PR TITLE
fix(mizuroute): match FUSE hashed FMODEL_ID in control file

### DIFF
--- a/src/symfluence/models/mizuroute/control_writer.py
+++ b/src/symfluence/models/mizuroute/control_writer.py
@@ -292,9 +292,15 @@ class ControlFileWriter(ConfigurableMixin):
         if model_config.comment_name == 'FUSE':
             routing_dt = model_config.default_dt  # 86400 (daily)
 
-        # Generate output file name from pattern
+        # Generate output file name from pattern.
+        # FUSE truncates FMODEL_ID to 6 chars, hashing if longer — the
+        # mizuRoute control file must match the actual FUSE output name.
+        eid = self.experiment_id
+        if model_config.comment_name == 'FUSE' and len(eid) > 6:
+            import hashlib
+            eid = hashlib.md5(eid.encode(), usedforsecurity=False).hexdigest()[:6]
         output_file = model_config.output_file_pattern.format(
-            experiment_id=self.experiment_id,
+            experiment_id=eid,
             domain_name=self.domain_name
         )
 


### PR DESCRIPTION
## Summary

- FUSE truncates `FMODEL_ID` to 6 chars, hashing longer experiment IDs (e.g. `exp_024` → `57f45b`)
- The mizuRoute control writer used the unhashed `experiment_id` in `<fname_qsim>`, so mizuRoute looked for `Bow_River_exp_024_runs_def.nc` but FUSE created `Bow_River_57f45b_runs_def.nc`
- Apply the same MD5 truncation when generating the FUSE output filename in the mizuRoute control file

## Test plan

- [x] Verified hash logic matches `FUSERunner._get_fuse_file_id()`
- [ ] Ali's FUSE+mizuRoute pipeline finds the correct file

🤖 Generated with [Claude Code](https://claude.com/claude-code)