### PR TITLE
fix(mizuroute): rename FUSE runoff variable to match control file

### DIFF
--- a/src/symfluence/models/fuse/runner.py
+++ b/src/symfluence/models/fuse/runner.py
@@ -145,6 +145,26 @@ class FUSERunner(BaseModelRunner, SpatialOrchestrator, OutputConverterMixin, Miz
             output_dir / f"{self.domain_name}_{fuse_id}_runs_pre.nc",
         ]
 
+    def _ensure_routing_variable(self, file_path: Path) -> None:
+        """Rename FUSE runoff variable to match what the mizuRoute control file expects.
+
+        FUSE run modes produce different variable names (q_routed vs q_instnt).
+        The control writer always uses mizu_routing_var (default: q_routed), so
+        the NetCDF must match.
+        """
+        target_var = self.mizu_routing_var
+        fuse_runoff_candidates = ['q_routed', 'q_instnt', 'total_discharge', 'runoff']
+
+        with xr.open_dataset(file_path) as ds:
+            actual_var = next((v for v in fuse_runoff_candidates if v in ds.data_vars), None)
+            if actual_var is None or actual_var == target_var:
+                return
+            ds_loaded = ds.load()
+
+        ds_renamed = ds_loaded.rename({actual_var: target_var})
+        ds_renamed.to_netcdf(file_path)
+        self.logger.info(f"Renamed FUSE variable {actual_var} → {target_var} for mizuRoute")
+
     def _convert_routing_units_for_mizuroute(self, dataset: xr.Dataset) -> bool:
         """Convert routed runoff units from mm/day to m/s when required."""
         routing_var = self.mizu_routing_var
@@ -198,6 +218,10 @@ class FUSERunner(BaseModelRunner, SpatialOrchestrator, OutputConverterMixin, Miz
             id_source_dim='gru',
             create_backup=True
         )
+
+        # FUSE run modes produce different variable names (q_instnt in run_pre,
+        # q_routed in run_def). Rename to match what the control file expects.
+        self._ensure_routing_variable(target)
 
         # Filter coastal GRUs using mapping file if available
         mapping_file = self.project_dir / 'settings' / 'mizuRoute' / 'fuse_to_routing_mapping.csv'

--- a/tests/unit/models/test_fuse_utilities.py
+++ b/tests/unit/models/test_fuse_utilities.py
@@ -4,7 +4,11 @@ Tests for FUSE model utilities.
 Tests FUSE-specific utility functions including mizuRoute conversion.
 """
 
+from unittest.mock import MagicMock, PropertyMock
+
+import numpy as np
 import pytest
+import xarray as xr
 
 from symfluence.models.fuse.utilities import FuseToMizurouteConverter
 
@@ -33,6 +37,76 @@ class TestFuseToMizurouteConverter:
         """Test converter has convert method."""
         assert hasattr(self.converter, 'convert')
         assert callable(self.converter.convert)
+
+
+class TestEnsureRoutingVariable:
+    """Test FUSERunner._ensure_routing_variable renames FUSE output vars."""
+
+    def _make_runner_stub(self, routing_var='q_routed'):
+        """Create a minimal object that has _ensure_routing_variable."""
+        from symfluence.models.fuse.runner import FUSERunner
+        stub = object.__new__(FUSERunner)
+        stub.logger = MagicMock()
+        type(stub).mizu_routing_var = PropertyMock(return_value=routing_var)
+        return stub
+
+    def _write_dataset(self, path, var_name='q_instnt'):
+        ds = xr.Dataset({
+            var_name: xr.DataArray(
+                np.random.rand(3, 2),
+                dims=('time', 'gru'),
+            )
+        })
+        ds.to_netcdf(path)
+        return ds
+
+    def test_renames_q_instnt_to_q_routed(self, tmp_path):
+        nc = tmp_path / 'test.nc'
+        self._write_dataset(nc, 'q_instnt')
+        runner = self._make_runner_stub('q_routed')
+
+        runner._ensure_routing_variable(nc)
+
+        ds = xr.open_dataset(nc)
+        assert 'q_routed' in ds.data_vars
+        assert 'q_instnt' not in ds.data_vars
+        ds.close()
+
+    def test_noop_when_variable_already_correct(self, tmp_path):
+        nc = tmp_path / 'test.nc'
+        self._write_dataset(nc, 'q_routed')
+        runner = self._make_runner_stub('q_routed')
+
+        runner._ensure_routing_variable(nc)
+
+        ds = xr.open_dataset(nc)
+        assert 'q_routed' in ds.data_vars
+        ds.close()
+
+    def test_noop_when_no_runoff_variable(self, tmp_path):
+        nc = tmp_path / 'test.nc'
+        ds = xr.Dataset({'temperature': xr.DataArray([1, 2, 3], dims=('time',))})
+        ds.to_netcdf(nc)
+
+        runner = self._make_runner_stub('q_routed')
+        runner._ensure_routing_variable(nc)
+
+        ds = xr.open_dataset(nc)
+        assert 'temperature' in ds.data_vars
+        assert 'q_routed' not in ds.data_vars
+        ds.close()
+
+    def test_renames_total_discharge_fallback(self, tmp_path):
+        nc = tmp_path / 'test.nc'
+        self._write_dataset(nc, 'total_discharge')
+        runner = self._make_runner_stub('q_routed')
+
+        runner._ensure_routing_variable(nc)
+
+        ds = xr.open_dataset(nc)
+        assert 'q_routed' in ds.data_vars
+        assert 'total_discharge' not in ds.data_vars
+        ds.close()
 
 
 class TestFuseUtilitiesBackwardCompatibility:


### PR DESCRIPTION
## Summary
- FUSE `run_pre` mode outputs runoff as `q_instnt`, but the mizuRoute control writer defaults to `<vname_qsim> q_routed` — causing mizuRoute to fail with `NetCDF: Variable not found`
- The distributed conversion path (`_convert_fuse_distributed_to_mizuroute_format`) only reshaped dimensions (squeeze lat, rename lon→gru, add gruId) without checking/renaming the runoff variable
- Added `_ensure_routing_variable()` which detects the actual FUSE output variable (`q_routed`, `q_instnt`, `total_discharge`, or `runoff`) and renames it in-place to match the control file expectation
- The calibration path (`_create_mizuroute_forcing_dataset`) already handled this correctly — this fix brings the main `run_fuse()` path to parity

## Test plan
- [x] 4 new unit tests for `_ensure_routing_variable` (rename, noop when correct, noop when no runoff var, fallback variable)
- [x] Full unit suite passes (5295 passed, 42 skipped)
- [ ] End-to-end: run Bow River FUSE→mizuRoute pipeline with `run_pre` mode and verify routing completes without manual control file edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)