### PR TITLE
fix(ngen): enable SAC-SMA + Snow-17 Fortran BMI modules

### DIFF
--- a/examples/02_watershed_modelling/configs/config_bow_jsacsma_rdrs.yaml
+++ b/examples/02_watershed_modelling/configs/config_bow_jsacsma_rdrs.yaml
@@ -1,0 +1,69 @@
+# ================================================================================
+# jSACSMA + Snow-17 Speed Test — Bow at Banff (RDRS, full period)
+# ================================================================================
+# Forward run only (no optimization). Exercises the in-memory JAX pathway:
+# Python function call → NumPy/JAX SAC-SMA + Snow-17 → zero subprocess overhead.
+# 40-year run to give a comparable wall-clock timescale to the 5-year NGEN run.
+# ================================================================================
+
+system:
+  data_dir: "/Users/darri.eythorsson/compHydro/SYMFLUENCE_data"
+  code_dir: "/Users/darri.eythorsson/compHydro/SYMFLUENCE"
+  num_processes: 1
+  log_level: INFO
+  log_to_file: true
+
+domain:
+  name: Bow_jSACSMA_speed_test
+  experiment_id: run_001
+  time_start: "1980-01-01 00:00"
+  time_end:   "2020-01-01 00:00"
+  definition_method: lumped
+  discretization: GRUs
+  pour_point_coords: "51.1722/-115.5717"
+  bounding_box_coords: "51.3/-115.7/51.0/-115.4"
+  calibration_period: "2004-01-01, 2015-12-31"
+  evaluation_period:  "2016-01-01, 2019-12-31"
+  spinup_period:      "1980-01-01, 2003-12-31"
+  data_access: cloud
+  download_dem: true
+  download_soil: true
+  download_land_cover: true
+  delineation:
+    routing: lumped
+    geofabric_type: na
+    stream_threshold: 5000
+    method: stream_threshold
+    by_pourpoint: true
+
+forcing:
+  dataset: RDRS
+  time_step_size: 3600
+
+data:
+  streamflow_data_provider: WSC
+  download_wsc_data: true
+
+model:
+  hydrological_model: SACSMA
+  routing_model: none
+  sacsma:
+    backend: numpy
+    warmup_days: 365
+    snow_module: snow17
+    latitude: 51.17
+    si: 100.0
+    params_to_calibrate: all
+
+evaluation:
+  streamflow:
+    station_id: "05BB001"
+    download_wsc: true
+  snotel:
+    download: false
+  smap:
+    download: false
+  grace:
+    download: false
+  modis_snow:
+    download: false

--- a/examples/02_watershed_modelling/configs/config_bow_ngen_sacsma_40yr.yaml
+++ b/examples/02_watershed_modelling/configs/config_bow_ngen_sacsma_40yr.yaml
@@ -1,0 +1,66 @@
+# ================================================================================
+# NGEN SAC-SMA + SNOW-17 — 40-year hourly, Bow at Banff (RDRS)
+# ================================================================================
+# Uses agnostic data symlinked from jSACSMA domain. Only NGEN preprocessing
+# and model execution run fresh.
+# ================================================================================
+
+system:
+  data_dir: "/Users/darri.eythorsson/compHydro/SYMFLUENCE_data"
+  code_dir: "/Users/darri.eythorsson/compHydro/SYMFLUENCE"
+  num_processes: 1
+  log_level: INFO
+  log_to_file: true
+
+domain:
+  name: Bow_NGEN_40yr_speed_test
+  experiment_id: run_001
+  time_start: "1980-01-01 00:00"
+  time_end:   "2020-01-01 00:00"
+  definition_method: lumped
+  discretization: GRUs
+  pour_point_coords: "51.1722/-115.5717"
+  bounding_box_coords: "51.3/-115.7/51.0/-115.4"
+  calibration_period: "2004-01-01, 2015-12-31"
+  evaluation_period:  "2016-01-01, 2019-12-31"
+  spinup_period:      "1980-01-01, 2003-12-31"
+  data_access: cloud
+  download_dem: true
+  download_soil: true
+  download_land_cover: true
+  delineation:
+    routing: lumped
+    geofabric_type: na
+    stream_threshold: 5000
+    method: stream_threshold
+    by_pourpoint: true
+
+forcing:
+  dataset: RDRS
+  time_step_size: 3600
+
+data:
+  streamflow_data_provider: WSC
+  download_wsc_data: true
+
+model:
+  hydrological_model: NGEN
+  routing_model: none
+  ngen:
+    exe: "/Users/darri.eythorsson/compHydro/SYMFLUENCE_data/installs/ngen/cmake_build/ngen"
+    install_path: "/Users/darri.eythorsson/compHydro/SYMFLUENCE_data/installs/ngen"
+    modules_selected: "SLOTH, SAC-SMA, SNOW-17, PET"
+    modules_to_calibrate: ""
+
+evaluation:
+  streamflow:
+    station_id: "05BB001"
+    download_wsc: true
+  snotel:
+    download: false
+  smap:
+    download: false
+  grace:
+    download: false
+  modis_snow:
+    download: false

--- a/examples/02_watershed_modelling/configs/config_bow_ngen_sacsma_rdrs.yaml
+++ b/examples/02_watershed_modelling/configs/config_bow_ngen_sacsma_rdrs.yaml
@@ -1,0 +1,67 @@
+# ================================================================================
+# NGEN SAC-SMA + SNOW-17 Speed Test — Bow at Banff (RDRS, 5-year)
+# ================================================================================
+# Forward run only (no optimization). Exercises the full NGEN subprocess pathway:
+# fork ngen → Fortran BMI SAC-SMA + Snow-17 → CSV forcing I/O → output parsing.
+# Compare wall-clock time against the companion jsacsma config.
+# ================================================================================
+
+system:
+  data_dir: "/Users/darri.eythorsson/compHydro/SYMFLUENCE_data"
+  code_dir: "/Users/darri.eythorsson/compHydro/SYMFLUENCE"
+  num_processes: 1
+  log_level: INFO
+  log_to_file: true
+
+domain:
+  name: Bow_NGEN_SACSMA_speed_test
+  experiment_id: run_001
+  time_start: "2015-01-01 00:00"
+  time_end:   "2020-01-01 00:00"
+  definition_method: lumped
+  discretization: GRUs
+  pour_point_coords: "51.1722/-115.5717"
+  bounding_box_coords: "51.3/-115.7/51.0/-115.4"
+  calibration_period: "2016-01-01, 2018-12-31"
+  evaluation_period:  "2019-01-01, 2019-12-31"
+  spinup_period:      "2015-01-01, 2015-12-31"
+  data_access: cloud
+  download_dem: true
+  download_soil: true
+  download_land_cover: true
+  delineation:
+    routing: lumped
+    geofabric_type: na
+    stream_threshold: 5000
+    method: stream_threshold
+    by_pourpoint: true
+
+forcing:
+  dataset: RDRS
+  time_step_size: 3600
+
+data:
+  streamflow_data_provider: WSC
+  download_wsc_data: true
+
+model:
+  hydrological_model: NGEN
+  routing_model: none
+  ngen:
+    exe: "/Users/darri.eythorsson/compHydro/SYMFLUENCE_data/installs/ngen/cmake_build/ngen"
+    install_path: "/Users/darri.eythorsson/compHydro/SYMFLUENCE_data/installs/ngen"
+    modules_selected: "SLOTH, SAC-SMA, SNOW-17, PET"
+    modules_to_calibrate: ""
+
+evaluation:
+  streamflow:
+    station_id: "05BB001"
+    download_wsc: true
+  snotel:
+    download: false
+  smap:
+    download: false
+  grace:
+    download: false
+  modis_snow:
+    download: false

--- a/src/symfluence/models/ngen/config_generator.py
+++ b/src/symfluence/models/ngen/config_generator.py
@@ -665,13 +665,51 @@ num_topodex_values={n_classes}
         }
         params.update(overrides)
 
-        lines = [f"{k}={v}" for k, v in params.items()]
-        config_text = "\n".join(lines) + "\n"
+        sacsma_dir = self.setup_dir / "SACSMA"
+        sacsma_dir.mkdir(parents=True, exist_ok=True)
+        cat_id = f"cat-{catchment_id}"
 
-        config_file = self.setup_dir / "SACSMA" / f"cat-{catchment_id}_sacsma_config.txt"
-        config_file.parent.mkdir(parents=True, exist_ok=True)
+        # 1. Write parameter file (space-delimited, read by ioModule.f90)
+        param_file = sacsma_dir / f"{cat_id}_sacsma_params.txt"
+        param_lines = [
+            f"hru_id     {cat_id}",
+            "hru_area   1.0",
+        ]
+        for k, v in params.items():
+            param_lines.append(f"{k.lower():<11s}{v}")
+        with open(param_file, 'w', encoding='utf-8') as f:
+            f.write("\n".join(param_lines) + "\n")
+
+        # 2. Write Fortran namelist control file (read by namelistModule.f90)
+        sim_start = self._get_config_value(
+            lambda: self.config.domain.time_start, default='2000-01-01 00:00', dict_key='EXPERIMENT_TIME_START')
+        sim_end = self._get_config_value(
+            lambda: self.config.domain.time_end, default='2001-01-01 00:00', dict_key='EXPERIMENT_TIME_END')
+        start_dt = pd.to_datetime(sim_start)
+        end_dt = pd.to_datetime(sim_end)
+        timestep = int(self._get_config_value(
+            lambda: self.config.forcing.time_step_size, default=3600, dict_key='FORCING_TIME_STEP_SIZE'))
+
+        config_file = sacsma_dir / f"{cat_id}_sacsma_config.txt"
+        namelist_text = (
+            f"&SAC_CONTROL\n"
+            f"  main_id               = \"{cat_id}\"\n"
+            f"  n_hrus                = 1\n"
+            f"  forcing_root          = \"\"\n"
+            f"  output_root           = \"\"\n"
+            f"  sac_param_file        = \"{param_file.resolve()}\"\n"
+            f"  output_hrus           = 0\n"
+            f"  start_datehr          = {start_dt.strftime('%Y%m%d%H')}\n"
+            f"  end_datehr            = {end_dt.strftime('%Y%m%d%H')}\n"
+            f"  model_timestep        = {timestep}\n"
+            f"  warm_start_run        = 0\n"
+            f"  write_states          = 0\n"
+            f"  sac_state_in_root     = \"\"\n"
+            f"  sac_state_out_root    = \"\"\n"
+            f"/\n"
+        )
         with open(config_file, 'w', encoding='utf-8') as f:
-            f.write(config_text)
+            f.write(namelist_text)
 
         return config_file
 
@@ -716,15 +754,57 @@ num_topodex_values={n_classes}
         }
         params.update(overrides)
 
-        lines = [f"{k}={v}" for k, v in params.items()]
-        lines.append(f"latitude={lat:.4f}")
-        lines.append(f"elevation={elevation:.1f}")
-        config_text = "\n".join(lines) + "\n"
+        snow17_dir = self.setup_dir / "SNOW17"
+        snow17_dir.mkdir(parents=True, exist_ok=True)
+        cat_id = f"cat-{catchment_id}"
 
-        config_file = self.setup_dir / "SNOW17" / f"cat-{catchment_id}_snow17_config.txt"
-        config_file.parent.mkdir(parents=True, exist_ok=True)
+        # 1. Write parameter file (space-delimited, read by ioModule.f90)
+        param_file = snow17_dir / f"{cat_id}_snow17_params.txt"
+        param_lines = [
+            f"hru_id     {cat_id}",
+            "hru_area   1.0",
+            f"latitude   {lat:.4f}",
+            f"elev       {elevation:.1f}",
+        ]
+        for k, v in params.items():
+            param_lines.append(f"{k.lower():<11s}{v}")
+        param_lines.append(f"{'si':<11s}100.0")
+        adc_values = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
+        for i, v in enumerate(adc_values, 1):
+            param_lines.append(f"{'adc' + str(i):<11s}{v}")
+        with open(param_file, 'w', encoding='utf-8') as f:
+            f.write("\n".join(param_lines) + "\n")
+
+        # 2. Write Fortran namelist control file (read by namelistModule.f90)
+        sim_start = self._get_config_value(
+            lambda: self.config.domain.time_start, default='2000-01-01 00:00', dict_key='EXPERIMENT_TIME_START')
+        sim_end = self._get_config_value(
+            lambda: self.config.domain.time_end, default='2001-01-01 00:00', dict_key='EXPERIMENT_TIME_END')
+        start_dt = pd.to_datetime(sim_start)
+        end_dt = pd.to_datetime(sim_end)
+        timestep = int(self._get_config_value(
+            lambda: self.config.forcing.time_step_size, default=3600, dict_key='FORCING_TIME_STEP_SIZE'))
+
+        config_file = snow17_dir / f"{cat_id}_snow17_config.txt"
+        namelist_text = (
+            f"&SNOW17_CONTROL\n"
+            f"  main_id             = \"{cat_id}\"\n"
+            f"  n_hrus              = 1\n"
+            f"  forcing_root        = \"\"\n"
+            f"  output_root         = \"\"\n"
+            f"  snow17_param_file   = \"{param_file.resolve()}\"\n"
+            f"  output_hrus         = 0\n"
+            f"  start_datehr        = {start_dt.strftime('%Y%m%d%H')}\n"
+            f"  end_datehr          = {end_dt.strftime('%Y%m%d%H')}\n"
+            f"  model_timestep      = {timestep}\n"
+            f"  warm_start_run      = 0\n"
+            f"  write_states        = 0\n"
+            f"  snow_state_in_root  = \"\"\n"
+            f"  snow_state_out_root = \"\"\n"
+            f"/\n"
+        )
         with open(config_file, 'w', encoding='utf-8') as f:
-            f.write(config_text)
+            f.write(namelist_text)
 
         return config_file
 
@@ -818,7 +898,7 @@ num_topodex_values={n_classes}
             main_output = "Qout"
         elif self._include_sacsma:
             model_type = "bmi_multi_sacsma"
-            main_output = "channel_inflow"
+            main_output = "tci"
         else:
             model_type = "bmi_multi_noahowp_cfe"
             main_output = "Q_OUT"
@@ -863,7 +943,7 @@ num_topodex_values={n_classes}
 
         Determines precipitation and ET sources based on which upstream
         modules are enabled:
-        - Precip: NOAH QINSUR > Snow-17 rain_plus_melt > raw forcing
+        - Precip: NOAH QINSUR > Snow-17 raim > raw forcing
         - ET: PET > NOAH fallback
         """
         variables_map = {}
@@ -872,7 +952,7 @@ num_topodex_values={n_classes}
         if self._include_noah:
             variables_map["atmosphere_water__liquid_equivalent_precipitation_rate"] = "QINSUR"
         elif self._include_snow17:
-            variables_map["atmosphere_water__liquid_equivalent_precipitation_rate"] = "rain_plus_melt"
+            variables_map["atmosphere_water__liquid_equivalent_precipitation_rate"] = "raim"
         else:
             variables_map["atmosphere_water__liquid_equivalent_precipitation_rate"] = (
                 "atmosphere_water__liquid_equivalent_precipitation_rate"
@@ -985,7 +1065,7 @@ num_topodex_values={n_classes}
         if self._include_snow17:
             lib_file = str(lib_paths.get("SNOW17", f"./extern/snow17/cmake_build/libsnow17_bmi{lib_ext}"))
             snow17_vars = {
-                "TAIR": "land_surface_air__temperature",
+                "tair": "land_surface_air__temperature",
                 "precip": "atmosphere_water__liquid_equivalent_precipitation_rate",
             }
             modules.append({
@@ -996,9 +1076,9 @@ num_topodex_values={n_classes}
                     "forcing_file": "",
                     "init_config": f"{snow17_base}/{{{{id}}}}_snow17_config.txt",
                     "allow_exceed_end_time": True,
-                    "main_output_variable": "rain_plus_melt",
+                    "main_output_variable": "raim",
                     "variables_names_map": snow17_vars,
-                    "output_variables": ["rain_plus_melt", "sneqv"]
+                    "output_variables": ["raim", "sneqv"]
                 }
             })
 
@@ -1048,7 +1128,18 @@ num_topodex_values={n_classes}
 
         if self._include_sacsma:
             lib_file = str(lib_paths.get("SACSMA", f"./extern/sac-sma/cmake_build/libsacbmi{lib_ext}"))
-            variables_map = self._build_runoff_variables_map()
+            # SAC-SMA Fortran BMI uses short variable names (tair, precip, pet),
+            # not CSDMS standard names like CFE/TOPMODEL.
+            sacsma_vars = {"tair": "land_surface_air__temperature"}
+            if self._include_snow17:
+                sacsma_vars["precip"] = "raim"
+            elif self._include_noah:
+                sacsma_vars["precip"] = "QINSUR"
+            if self._include_pet:
+                sacsma_vars["pet"] = "water_potential_evaporation_flux"
+            elif self._include_noah:
+                et_var = getattr(self, '_noah_et_fallback', 'EVAPOTRANS')
+                sacsma_vars["pet"] = et_var
 
             modules.append({
                 "name": "bmi_fortran",
@@ -1058,8 +1149,8 @@ num_topodex_values={n_classes}
                     "forcing_file": "",
                     "init_config": f"{sacsma_base}/{{{{id}}}}_sacsma_config.txt",
                     "allow_exceed_end_time": True,
-                    "main_output_variable": "channel_inflow",
-                    "variables_names_map": variables_map,
+                    "main_output_variable": "tci",
+                    "variables_names_map": sacsma_vars,
                     "output_variable_units": "m3/s"
                 }
             })

--- a/src/symfluence/models/ngen/preprocessor.py
+++ b/src/symfluence/models/ngen/preprocessor.py
@@ -88,7 +88,12 @@ class NgenPreProcessor(BaseModelPreProcessor):  # type: ignore[misc]
             lambda: self.config.model.ngen.modules_selected,
             default='SLOTH,PET,CFE',
         )
-        _selected = {m.strip().upper() for m in modules_selected_str.split(',') if m.strip()}
+        _alias_map = {'SAC-SMA': 'SACSMA', 'SNOW-17': 'SNOW17', 'NOAH-OWP': 'NOAH'}
+        _selected = set()
+        for m in modules_selected_str.split(','):
+            name = m.strip().upper()
+            if name:
+                _selected.add(_alias_map.get(name, name))
 
         _all_modules = ['SLOTH', 'PET', 'NOAH', 'CFE', 'TOPMODEL', 'SACSMA', 'SNOW17']
         _resolved = {}
@@ -218,6 +223,7 @@ class NgenPreProcessor(BaseModelPreProcessor):  # type: ignore[misc]
             "SACSMA": f"libsacbmi{lib_ext}",
             "SNOW17": f"libsnow17_bmi{lib_ext}",
         }
+        _snow17_alt = f"libsnow17bmi{lib_ext}"
 
         # --- 1. Try npm-bundled libraries first (when install_path is default) ---
         if install_path == 'default':
@@ -227,6 +233,8 @@ class NgenPreProcessor(BaseModelPreProcessor):  # type: ignore[misc]
                 all_found = True
                 for name, libname in module_libs.items():
                     candidate = npm_lib_dir / libname
+                    if not candidate.exists() and name == 'SNOW17':
+                        candidate = npm_lib_dir / _snow17_alt
                     if candidate.exists():
                         npm_paths[name] = candidate
                     else:
@@ -266,13 +274,19 @@ class NgenPreProcessor(BaseModelPreProcessor):  # type: ignore[misc]
             p1 = ngen_base / subpath / libname
             # Try extern under cmake_build
             p2 = ngen_base / "cmake_build" / subpath / libname
+            # Snow-17 upstream renamed the target from snow17_bmi to snow17bmi
+            p3 = ngen_base / subpath / _snow17_alt if name == 'SNOW17' else None
+            p4 = ngen_base / "cmake_build" / subpath / _snow17_alt if name == 'SNOW17' else None
 
             if p1.exists():
                 paths[name] = p1
             elif p2.exists():
                 paths[name] = p2
+            elif p3 and p3.exists():
+                paths[name] = p3
+            elif p4 and p4.exists():
+                paths[name] = p4
             else:
-                # Fallback to p1 for consistent missing path reporting
                 paths[name] = p1
 
         return paths

--- a/src/symfluence/models/ngen/runner.py
+++ b/src/symfluence/models/ngen/runner.py
@@ -393,13 +393,14 @@ class NgenRunner(BaseModelRunner):  # type: ignore[misc]
                                 old_path = mod_params['init_config']
                                 if old_path and old_path != "/dev/null":
                                     mod_type_name = str(mod_params.get('model_type_name', '')).upper()
+                                    old_filename = Path(old_path).name.lower()
                                     target_mod = None
-                                    if 'PET' in mod_type_name or 'pet' in old_path.lower(): target_mod = 'PET'
-                                    elif 'CFE' in mod_type_name or 'cfe' in old_path.lower(): target_mod = 'CFE'
-                                    elif 'NOAH' in mod_type_name or 'noah' in old_path.lower() or '.input' in old_path.lower(): target_mod = 'NOAH'
-                                    elif 'TOPMODEL' in mod_type_name or 'topmodel' in old_path.lower(): target_mod = 'TOPMODEL'
-                                    elif 'SACSMA' in mod_type_name or 'sacsma' in old_path.lower(): target_mod = 'SACSMA'
-                                    elif 'SNOW17' in mod_type_name or 'snow17' in old_path.lower(): target_mod = 'SNOW17'
+                                    if 'PET' in mod_type_name or 'pet' in old_filename: target_mod = 'PET'
+                                    elif 'CFE' in mod_type_name or 'cfe' in old_filename: target_mod = 'CFE'
+                                    elif 'NOAH' in mod_type_name or 'noah' in old_filename or '.input' in old_filename: target_mod = 'NOAH'
+                                    elif 'TOPMODEL' in mod_type_name or 'topmodel' in old_filename: target_mod = 'TOPMODEL'
+                                    elif 'SNOW17' in mod_type_name or 'snow17' in old_filename: target_mod = 'SNOW17'
+                                    elif 'SACSMA' in mod_type_name or 'sacsma' in old_filename: target_mod = 'SACSMA'
 
                                     if target_mod:
                                         filename = Path(old_path).name


### PR DESCRIPTION
## Summary

- Fix six issues preventing NGEN SAC-SMA and Snow-17 Fortran BMI modules from running end-to-end through SYMFLUENCE
- Add example configs for NGEN vs jSACSMA speed comparison (Bow at Banff, RDRS)

### Fixes

| Bug | Root cause | Fix |
|-----|-----------|-----|
| SAC-SMA/Snow-17 always DISABLED | Hyphenated aliases (`SAC-SMA`, `SNOW-17`) not normalized to internal names (`SACSMA`, `SNOW17`) | Add alias map in preprocessor |
| Snow-17 library not found after rebuild | Upstream renamed target from `snow17_bmi` to `snow17bmi` | Fallback resolution for both names |
| Snow-17 init_config routed to SACSMA/ dir | Full-path matching caught domain name containing "sacsma" | Match on filename only, reorder elif chain |
| Fortran runtime "End of file reading namelist" | Config generator wrote key=value format; Fortran BMI expects `&SNOW17_CONTROL`/`&SAC_CONTROL` namelist + separate param file | Generate proper Fortran namelist + param files |
| `{tair}` not found | Variable map used `TAIR` (uppercase); Fortran BMI uses `tair` | Lowercase variable names |
| `{rain_plus_melt}` / `{channel_inflow}` not found | Wrong BMI output variable names | `raim` (Snow-17), `tci` (SAC-SMA) |

### Speed comparison (Bow at Banff, 40-yr hourly RDRS)

| | NGEN SAC-SMA | jSACSMA | Ratio |
|---|---|---|---|
| Model execution | 182.6s | 59.3s | 3.1x |
| Total pipeline (incl. preprocessing) | ~3.3 hrs | ~16 min | ~12x |

## Test plan

- [x] 56 NGEN unit tests pass
- [x] 5295 full unit test suite pass (0 failures)
- [x] NGEN SAC-SMA+Snow-17 runs to completion (5-yr and 40-yr Bow at Banff, RDRS)
- [x] jSACSMA runs to completion (40-yr hourly, same basin)
- [x] Pre-commit hooks pass (ruff, mypy, bandit)
- [ ] Verify no regression on NGEN CFE/TOPMODEL configs (unchanged code paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)