### PR TITLE
fix(mizuroute): use FUSE-specific default for routing variable name

### DIFF
--- a/src/symfluence/models/fuse/runner.py
+++ b/src/symfluence/models/fuse/runner.py
@@ -145,12 +145,23 @@ class FUSERunner(BaseModelRunner, SpatialOrchestrator, OutputConverterMixin, Miz
             output_dir / f"{self.domain_name}_{fuse_id}_runs_pre.nc",
         ]
 
+    @property
+    def mizu_routing_var(self) -> str:
+        """FUSE-specific override: default to q_routed instead of SUMMA's averageRoutedRunoff."""
+        var = self._get_config_value(
+            lambda: self.config.model.mizuroute.routing_var,
+            default='q_routed'
+        )
+        if var in ('default', None, ''):
+            return 'q_routed'
+        return var
+
     def _ensure_routing_variable(self, file_path: Path) -> None:
         """Rename FUSE runoff variable to match what the mizuRoute control file expects.
 
         FUSE run modes produce different variable names (q_routed vs q_instnt).
-        The control writer always uses mizu_routing_var (default: q_routed), so
-        the NetCDF must match.
+        The control writer uses the FUSE model default (q_routed) unless overridden,
+        so the NetCDF must match.
         """
         target_var = self.mizu_routing_var
         fuse_runoff_candidates = ['q_routed', 'q_instnt', 'total_discharge', 'runoff']

--- a/tests/unit/models/test_fuse_utilities.py
+++ b/tests/unit/models/test_fuse_utilities.py
@@ -4,7 +4,7 @@ Tests for FUSE model utilities.
 Tests FUSE-specific utility functions including mizuRoute conversion.
 """
 
-from unittest.mock import MagicMock, PropertyMock
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
@@ -39,6 +39,14 @@ class TestFuseToMizurouteConverter:
         assert callable(self.converter.convert)
 
 
+def _safe_get(getter, default):
+    try:
+        val = getter()
+        return default if val is None else val
+    except (AttributeError, KeyError, TypeError):
+        return default
+
+
 class TestEnsureRoutingVariable:
     """Test FUSERunner._ensure_routing_variable renames FUSE output vars."""
 
@@ -47,7 +55,11 @@ class TestEnsureRoutingVariable:
         from symfluence.models.fuse.runner import FUSERunner
         stub = object.__new__(FUSERunner)
         stub.logger = MagicMock()
-        type(stub).mizu_routing_var = PropertyMock(return_value=routing_var)
+        config = MagicMock()
+        config.model.mizuroute.routing_var = routing_var
+        stub._config = config
+        stub.config = config
+        stub._get_config_value = lambda getter, default=None, **kw: _safe_get(getter, default)
         return stub
 
     def _write_dataset(self, path, var_name='q_instnt'):
@@ -106,6 +118,47 @@ class TestEnsureRoutingVariable:
         ds = xr.open_dataset(nc)
         assert 'q_routed' in ds.data_vars
         assert 'total_discharge' not in ds.data_vars
+        ds.close()
+
+    def test_defaults_to_q_routed_not_summa_var(self, tmp_path):
+        """When routing_var is unset, rename to q_routed (not averageRoutedRunoff)."""
+        nc = tmp_path / 'test.nc'
+        self._write_dataset(nc, 'q_instnt')
+
+        from symfluence.models.fuse.runner import FUSERunner
+        stub = object.__new__(FUSERunner)
+        stub.logger = MagicMock()
+        config = MagicMock()
+        config.model.mizuroute.routing_var = None
+        stub._config = config
+        stub.config = config
+        stub._get_config_value = lambda getter, default=None, **kw: _safe_get(getter, default)
+
+        stub._ensure_routing_variable(nc)
+
+        ds = xr.open_dataset(nc)
+        assert 'q_routed' in ds.data_vars, "Should default to FUSE q_routed, not SUMMA averageRoutedRunoff"
+        assert 'averageRoutedRunoff' not in ds.data_vars
+        ds.close()
+
+    def test_defaults_to_q_routed_when_config_says_default(self, tmp_path):
+        """When routing_var is 'default', resolve to q_routed."""
+        nc = tmp_path / 'test.nc'
+        self._write_dataset(nc, 'q_instnt')
+
+        from symfluence.models.fuse.runner import FUSERunner
+        stub = object.__new__(FUSERunner)
+        stub.logger = MagicMock()
+        config = MagicMock()
+        config.model.mizuroute.routing_var = 'default'
+        stub._config = config
+        stub.config = config
+        stub._get_config_value = lambda getter, default=None, **kw: _safe_get(getter, default)
+
+        stub._ensure_routing_variable(nc)
+
+        ds = xr.open_dataset(nc)
+        assert 'q_routed' in ds.data_vars
         ds.close()
 
 


### PR DESCRIPTION
## Summary

- Override `mizu_routing_var` on `FUSERunner` to default to `q_routed` instead of inheriting SUMMA's `averageRoutedRunoff` from the mixin
- Fixes the root cause of "NetCDF: Variable not found" when mizuRoute reads FUSE run_pre output — `_ensure_routing_variable()` was renaming `q_instnt` → `averageRoutedRunoff` while the control file expected `q_routed`
- Adds 2 regression tests verifying the FUSE default doesn't regress to the SUMMA variable name

Follows up on PRs #68 and #69 which fixed the FUSE filename hashing and added the variable rename logic respectively.

## Test plan

- [x] 5297 unit tests pass
- [x] 39 SUMMA/mizuRoute tests pass (no regression)
- [x] Integration test: FUSE `mizu_routing_var` → `q_routed`, SUMMA → `averageRoutedRunoff`
- [x] Integration test: `_ensure_routing_variable` renames `q_instnt` → `q_routed` (not `averageRoutedRunoff`)
- [x] Integration test: FUSE control file `<vname_qsim>` matches runner variable name
- [ ] Ali to confirm on fresh install