### PR TITLE
fix(workflow): stop double-executing mizuRoute for FUSE and GR

### DIFF
--- a/src/symfluence/models/model_manager.py
+++ b/src/symfluence/models/model_manager.py
@@ -39,9 +39,9 @@ class ModelManager(BaseManager):
         configured_models = [m.strip() for m in str(models_str).split(',') if m.strip()]
         execution_list = []
 
-        # Models that support routing via mizuRoute or dRoute
-        # Note: MESH, HYPE, and NGEN have internal routing, so don't need external routing
-        routable_models = {'SUMMA', 'FUSE', 'GR'}
+        # Models that need an EXTERNAL routing step (standalone MIZUROUTE/dRoute).
+        # FUSE and GR handle routing internally in their runners (like MESH, HYPE, NGEN).
+        routable_models = {'SUMMA'}
 
         # Determine which routing model to use
         routing_model = self._get_config_value(


### PR DESCRIPTION
## Summary

- Remove FUSE and GR from `routable_models` in the workflow resolver
- Both models handle mizuRoute routing internally in their runners (via `_run_distributed_routing`), but the model manager was also adding MIZUROUTE as a separate workflow step, causing mizuRoute to execute twice on the same input
- SUMMA remains the only model needing an external MIZUROUTE step

Spotted in Ali's log: `Execution workflow order: ['FUSE', 'MIZUROUTE']` with both producing `mizuRoute run completed successfully`.

## Test plan

- [x] 5297 unit tests pass
- [x] FUSE routing still handled internally via `_run_distributed_routing`
- [ ] Ali to confirm single mizuRoute execution in log