### PR TITLE
fix(acquisition): skip forcing download when forcing_path has data

### DIFF
--- a/src/symfluence/data/acquisition/acquisition_service.py
+++ b/src/symfluence/data/acquisition/acquisition_service.py
@@ -639,6 +639,35 @@ class AcquisitionService(ConfigurableMixin):
         """Acquire forcing data for the model simulation."""
         self.logger.info("Starting forcing data acquisition")
 
+        # If forcing_path points to existing data, symlink into raw_data and skip download
+        forcing_path = self._get_config_value(
+            lambda: self.config.paths.forcing_path, default=None, dict_key='FORCING_PATH')
+        if forcing_path and forcing_path != 'default':
+            forcing_path = Path(forcing_path)
+            if forcing_path.exists():
+                nc_files = list(forcing_path.glob('*.nc')) + list(forcing_path.glob('*.nc4'))
+                csv_files = list(forcing_path.glob('*.csv'))
+                if nc_files or csv_files:
+                    raw_data_dir = resolve_data_subdir(self.project_dir, 'forcing') / 'raw_data'
+                    raw_data_dir.mkdir(parents=True, exist_ok=True)
+                    existing_raw = list(raw_data_dir.glob('*.nc')) + list(raw_data_dir.glob('*.csv'))
+                    if not existing_raw:
+                        raw_data_dir.symlink_to(forcing_path) if not raw_data_dir.exists() else None
+                        for f in (nc_files + csv_files):
+                            link = raw_data_dir / f.name
+                            if not link.exists():
+                                link.symlink_to(f)
+                        self.logger.info(
+                            f"✓ Using pre-staged forcing data from forcing_path: {forcing_path} "
+                            f"({len(nc_files)} .nc, {len(csv_files)} .csv files symlinked to raw_data/)"
+                        )
+                    else:
+                        self.logger.info(
+                            f"✓ Forcing data already exists in raw_data/ ({len(existing_raw)} files), "
+                            f"skipping acquisition"
+                        )
+                    return
+
         data_access = self._get_config_value(lambda: self.config.domain.data_access, default='MAF').upper()
         forcing_dataset = self._get_config_value(lambda: self.config.forcing.dataset, default='').upper()
 


### PR DESCRIPTION
## Summary

- When `forcing_path` points to an existing directory with `.nc`/`.csv` files, symlink them into `raw_data/` and skip the cloud/MAF download
- Fixes the issue where `data_access: cloud` triggers a redundant multi-GB download even when users have pre-staged forcing data (e.g., AORC on Anvil)

Follow-up to PR #70 — this commit was added after the squash merge.

## Test plan

- [x] 1875 data/acquisition unit tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)