### PR TITLE
fix(mizuroute): treat typed config default as unset for non-SUMMA models

### DIFF
--- a/src/symfluence/models/fuse/runner.py
+++ b/src/symfluence/models/fuse/runner.py
@@ -152,7 +152,7 @@ class FUSERunner(BaseModelRunner, SpatialOrchestrator, OutputConverterMixin, Miz
             lambda: self.config.model.mizuroute.routing_var,
             default='q_routed'
         )
-        if var in ('default', None, ''):
+        if var in ('default', None, '', 'averageRoutedRunoff'):
             return 'q_routed'
         return var
 

--- a/src/symfluence/models/mizuroute/control_writer.py
+++ b/src/symfluence/models/mizuroute/control_writer.py
@@ -276,6 +276,8 @@ class ControlFileWriter(ConfigurableMixin):
         routing_var = self._get_config_value(lambda: self.config.model.mizuroute.routing_var, default=model_config.default_var)
         if routing_var in ('default', None, ''):
             routing_var = model_config.default_var
+        elif routing_var == 'averageRoutedRunoff' and model_config.default_var != 'averageRoutedRunoff':
+            routing_var = model_config.default_var
 
         routing_units = self._get_config_value(lambda: self.config.model.mizuroute.routing_units, default=model_config.default_units)
         if routing_units in ('default', None, ''):


### PR DESCRIPTION
## Summary

- The typed config model defaults `routing_var` to `averageRoutedRunoff` (SUMMA's variable) even when the user doesn't set `SETTINGS_MIZU_ROUTING_VAR`
- This caused the FUSE runner and control writer to use SUMMA's variable name instead of FUSE's `q_routed`
- Treat `averageRoutedRunoff` as "not explicitly set" in the FUSE runner property and in the control writer when the target model has a different default

Found during end-to-end testing: the previous fix (PR #71) was correct in isolation, but the typed config model's field default leaked through at runtime.

## Test plan

- [x] 5297 unit tests pass
- [x] End-to-end: Bow at Banff FUSE → `q_instnt → q_routed` (verified in output)
- [x] End-to-end: output is 2D `(time=10, gru=25)`, no `param_set`
- [x] End-to-end: mizuRoute runs and produces output
- [x] End-to-end: workflow is `['FUSE']` only (no double MIZUROUTE)