### PR TITLE
feat(optimization): periodic checkpoint saves for all algorithms

### DIFF
--- a/src/symfluence/core/config/models/optimization.py
+++ b/src/symfluence/core/config/models/optimization.py
@@ -252,6 +252,7 @@ class OptimizationConfig(BaseModel):
     population_size: int = Field(default=50, alias='POPULATION_SIZE', ge=2, le=10000)
     final_evaluation_numerical_method: str = Field(default='ida', alias='FINAL_EVALUATION_NUMERICAL_METHOD')
     cleanup_parallel_dirs: bool = Field(default=True, alias='CLEANUP_PARALLEL_DIRS')
+    checkpoint_interval: int = Field(default=10, alias='CHECKPOINT_INTERVAL', ge=1)
 
     # Gradient-based optimization settings (Adam, L-BFGS)
     gradient_mode: Literal['auto', 'native', 'finite_difference'] = Field(

--- a/src/symfluence/optimization/optimizers/algorithms/dds.py
+++ b/src/symfluence/optimization/optimizers/algorithms/dds.py
@@ -64,13 +64,6 @@ class DDSAlgorithm(OptimizationAlgorithm):
         """
         self.logger.debug(f"Starting DDS optimization with {n_params} parameters")
 
-        # Checkpoint callback for crash recovery (saves every N iterations)
-        save_checkpoint = kwargs.get('save_checkpoint')
-        checkpoint_interval = self._get_config_value(
-            lambda: self.config.optimization.dds.checkpoint_interval,
-            default=50, dict_key='DDS_CHECKPOINT_INTERVAL'
-        )
-
         # DDS perturbation range (default 0.2, higher values explore more)
         r = self._get_config_value(lambda: self.config.optimization.dds.r, default=0.2, dict_key='DDS_R')
 
@@ -177,10 +170,6 @@ class DDSAlgorithm(OptimizationAlgorithm):
             # Log progress every 10 iterations or at the end to reduce log spam
             if iteration % 10 == 0 or iteration == self.max_iterations:
                 log_progress(self.name, iteration, f_best)
-
-            # Periodic checkpoint for crash recovery
-            if save_checkpoint and iteration % checkpoint_interval == 0:
-                save_checkpoint(self.name, iteration)
 
         return {
             'best_solution': x_best,

--- a/src/symfluence/optimization/optimizers/base_model_optimizer.py
+++ b/src/symfluence/optimization/optimizers/base_model_optimizer.py
@@ -1014,13 +1014,21 @@ class BaseModelOptimizer(
             raise OptimizationError(f"Failed to save results for {algorithm_name} default evaluation")
         return results_path
 
-    def _build_algorithm_callbacks(self) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    def _build_algorithm_callbacks(self, algorithm_name: str = 'optimization') -> Tuple[Dict[str, Any], Dict[str, Any]]:
         """Build callback functions and kwargs dict for algorithm.optimize().
+
+        Args:
+            algorithm_name: Algorithm name used for checkpoint file naming.
 
         Returns:
             Tuple of (callbacks_dict, kwargs_dict) where callbacks_dict contains
             the core function bindings and kwargs_dict contains additional settings.
         """
+        checkpoint_interval = self._get_config_value(
+            lambda: self.config.optimization.checkpoint_interval,
+            default=10, dict_key='CHECKPOINT_INTERVAL',
+        )
+
         def evaluate_solution(normalized_params, proc_id=0):
             return self._evaluate_solution(normalized_params, proc_id)
 
@@ -1030,6 +1038,14 @@ class BaseModelOptimizer(
         def denormalize_params(normalized):
             return self.param_manager.denormalize_parameters(normalized)
 
+        def save_checkpoint(iteration: int):
+            try:
+                self.save_results(algorithm_name, standard_filename=True)
+                self.save_best_params(algorithm_name)
+                self.logger.info(f"Checkpoint saved at iteration {iteration}")
+            except Exception as e:  # noqa: BLE001 — must-not-raise contract
+                self.logger.warning(f"Checkpoint save failed at iteration {iteration}: {e}")
+
         def record_iteration(iteration, score, params, additional_metrics=None):
             crash_stats = self.get_crash_stats()
             merged = dict(additional_metrics or {}, **{
@@ -1037,6 +1053,8 @@ class BaseModelOptimizer(
                 'crash_rate': crash_stats['crash_rate'],
             })
             self.record_iteration(iteration, score, params, additional_metrics=merged)
+            if iteration > 0 and iteration % checkpoint_interval == 0:
+                save_checkpoint(iteration)
 
         def update_best(score, params, iteration):
             self.update_best(score, params, iteration)
@@ -1048,14 +1066,6 @@ class BaseModelOptimizer(
                 n_improved=n_improved, population_size=pop_size,
                 crash_stats=self.get_crash_stats()
             )
-
-        def save_checkpoint(algorithm_name: str, iteration: int):
-            try:
-                self.save_results(algorithm_name, standard_filename=True)
-                self.save_best_params(algorithm_name)
-                self.logger.debug(f"Checkpoint saved at iteration {iteration}")
-            except Exception as e:  # noqa: BLE001 — must-not-raise contract
-                self.logger.warning(f"Checkpoint save failed at iteration {iteration}: {e}")
 
         callbacks = {
             'evaluate_solution': evaluate_solution,
@@ -1069,7 +1079,6 @@ class BaseModelOptimizer(
         kwargs = {
             'log_initial_population': self.log_initial_population,
             'num_processes': self.num_processes if hasattr(self, 'num_processes') else 1,
-            'save_checkpoint': save_checkpoint,
         }
 
         return callbacks, kwargs
@@ -1095,7 +1104,7 @@ class BaseModelOptimizer(
         algorithm = get_algorithm(algorithm_name, self.config, self.logger)
 
         # Build callbacks and kwargs for the algorithm
-        callbacks, kwargs = self._build_algorithm_callbacks()
+        callbacks, kwargs = self._build_algorithm_callbacks(algorithm.name)
 
         # Seed optimization with best previous result (warm-start) or def file defaults
         skip_warm_start = self._get_config_value(lambda: None, default=False, dict_key='SKIP_WARM_START')

--- a/src/symfluence/resources/config_templates/config_template_comprehensive.yaml
+++ b/src/symfluence/resources/config_templates/config_template_comprehensive.yaml
@@ -1408,6 +1408,13 @@ CALIBRATION_VARIABLE: "streamflow"
 #   Usage:      1
 CLEANUP_PARALLEL_DIRS: true
 
+# CHECKPOINT_INTERVAL
+#   Type:        int
+#   Default:     10
+#   Source:      OptimizationConfig (optimization.py)
+#   Usage:      Save best_params.json and iteration results every N iterations during optimization
+CHECKPOINT_INTERVAL: 10
+
 # ERROR_LOG_DIR
 #   Type:        str
 #   Default:     error_logs


### PR DESCRIPTION
## Summary
- Moves checkpoint saving into the `record_iteration` callback in `base_model_optimizer.py`, so **every algorithm** automatically persists results to disk every N iterations — no per-algorithm code needed.
- Adds `CHECKPOINT_INTERVAL` config option (default: 10 iterations) to control save frequency.
- Removes the DDS-specific checkpoint logic that is now redundant.

**Motivation:** Long-running HPC calibration jobs (e.g. AsyncDDS SUMMA on Anvil, 100+ hours) previously only saved results after the optimizer fully completed. If walltime expired, all progress was lost. Checkpoints now write `best_params.json` and `iteration_results.csv` to the optimization results directory periodically.

## Test plan
- [x] All 456 unit tests pass
- [x] Pre-commit hooks pass (ruff, bandit, mypy)
- [ ] Verify checkpoint files appear during a calibration run

🤖 Generated with [Claude Code](https://claude.com/claude-code)