### PR TITLE
fix(fuse): clip eval dates to simulation window in file manager

### DIFF
--- a/src/symfluence/models/fuse/preprocessor.py
+++ b/src/symfluence/models/fuse/preprocessor.py
@@ -12,7 +12,7 @@ import logging
 import os
 import re
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from shutil import copyfile
 from typing import Any, Dict, List, Optional, Tuple
@@ -862,16 +862,27 @@ class FUSEPreProcessor(BaseModelPreProcessor, PETCalculatorMixin, GeospatialUtil
 
         cal_period = self._get_config_value(
             lambda: self.config.domain.calibration_period,
-            default='2000-01-01,2010-12-31'
+            default=None
         )
-        cal_start_time = datetime.strptime(cal_period.split(',')[0], '%Y-%m-%d')
-        cal_end_time = datetime.strptime(cal_period.split(',')[1].strip(), '%Y-%m-%d')
+        if cal_period:
+            cal_start_time = datetime.strptime(cal_period.split(',')[0], '%Y-%m-%d')
+            cal_end_time = datetime.strptime(cal_period.split(',')[1].strip(), '%Y-%m-%d')
+            cal_start_time = max(cal_start_time, start_time)
+            cal_end_time = min(cal_end_time, end_time)
+        else:
+            cal_start_time = start_time + timedelta(days=1)
+            cal_end_time = end_time
+            self.logger.info(
+                f"No calibration_period configured; defaulting eval period to "
+                f"{cal_start_time.strftime('%Y-%m-%d')} – {cal_end_time.strftime('%Y-%m-%d')} "
+                f"(sim window with 1-day spinup)"
+            )
 
         date_settings = {
             'date_start_sim': start_time.strftime('%Y-%m-%d'),
             'date_end_sim': end_time.strftime('%Y-%m-%d'),
-            'date_start_eval': cal_start_time.strftime('%Y-%m-%d'),  # Using same dates for evaluation period
-            'date_end_eval': cal_end_time.strftime('%Y-%m-%d')       # Can be modified if needed
+            'date_start_eval': cal_start_time.strftime('%Y-%m-%d'),
+            'date_end_eval': cal_end_time.strftime('%Y-%m-%d')
         }
 
         try:


### PR DESCRIPTION
## Summary

- **Bug:** When `calibration_period` is not configured, the FUSE file manager (`fm_catch.txt`) wrote eval dates from a hardcoded 2000–2010 default, independent of the actual simulation window. This caused FUSE to fail with `date_start_eval < date_start_sim` on shorter experiments.
- **Fix:** When no `calibration_period` is set, eval dates now default to `sim_start + 1 day` through `sim_end` (one day of spinup). When an explicit `calibration_period` **is** configured, the eval dates are clamped to the simulation bounds so they can never extend outside the sim window.
- Reported by Ali Jamali during end-to-end testing.

## Test plan

- [x] All 100 FUSE unit tests pass
- [ ] Ali to verify with his short-experiment config (`2004-01-01` to `2004-01-10`) — no manual `fm_catch.txt` patching should be needed