### PR TITLE
feat(forcing): temporal completeness validation

### DIFF
--- a/src/symfluence/core/config/models/forcing.py
+++ b/src/symfluence/core/config/models/forcing.py
@@ -125,6 +125,14 @@ class ForcingConfig(BaseModel):
     supplement: bool = Field(default=False, alias='SUPPLEMENT_FORCING')
     keep_raw: bool = Field(default=True, alias='KEEP_RAW_FORCING')
 
+    # Temporal completeness validation
+    missing_data_strategy: Literal['error', 'warn', 'interpolate', 'fill_forward'] = Field(
+        default='error', alias='FORCING_MISSING_DATA_STRATEGY'
+    )
+    max_gap_hours: int = Field(
+        default=24, alias='FORCING_MAX_GAP_HOURS', ge=1
+    )
+
     # ERA5-specific settings (legacy, prefer using era5 subsection)
     era5_use_cds: Optional[bool] = Field(default=None, alias='ERA5_USE_CDS')
 

--- a/src/symfluence/models/ngen/preprocessor.py
+++ b/src/symfluence/models/ngen/preprocessor.py
@@ -654,6 +654,26 @@ class NgenPreProcessor(BaseModelPreProcessor):  # type: ignore[misc]
         forcing_data = fdp.load_forcing_data(self.forcing_basin_path)
         forcing_data = forcing_data.sortby('time')
 
+        # Validate temporal completeness before any transformation
+        strategy = self._get_config_value(
+            lambda: self.config.forcing.missing_data_strategy,
+            default='error'
+        )
+        max_gap = self._get_config_value(
+            lambda: self.config.forcing.max_gap_hours,
+            default=24
+        )
+        forcing_data, gap_report = fdp.validate_temporal_completeness(
+            forcing_data,
+            strategy=strategy,
+            max_gap_hours=max_gap,
+        )
+        if not gap_report.get('valid', True):
+            self.logger.warning(
+                f"Forcing gap report: {gap_report['missing_timesteps']} missing timesteps, "
+                f"{gap_report['coverage_pct']:.1f}% coverage"
+            )
+
         # Normalize legacy SUMMA-style names to CFIF standard at the boundary
         from symfluence.data.preprocessing.cfif.variables import normalize_to_cfif
         forcing_data = normalize_to_cfif(forcing_data)

--- a/src/symfluence/models/utilities/forcing_data_processor.py
+++ b/src/symfluence/models/utilities/forcing_data_processor.py
@@ -11,8 +11,9 @@ NGEN, GR, and SUMMA preprocessors.
 
 import logging
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
+import numpy as np
 import pandas as pd
 import xarray as xr
 
@@ -154,6 +155,164 @@ class ForcingDataProcessor:
 
         return ds
 
+    def validate_temporal_completeness(
+        self,
+        ds: xr.Dataset,
+        expected_freq_seconds: Optional[int] = None,
+        strategy: str = 'error',
+        max_gap_hours: int = 24,
+        time_var: str = 'time'
+    ) -> Tuple[xr.Dataset, Dict[str, Any]]:
+        """
+        Check forcing data for missing timesteps and act based on strategy.
+
+        Args:
+            ds: Dataset to validate
+            expected_freq_seconds: Expected timestep in seconds.
+                If None, inferred from data.
+            strategy: How to handle gaps:
+                - 'error': Raise ValueError on any gap
+                - 'warn': Log warnings but continue
+                - 'interpolate': Fill gaps with linear interpolation
+                - 'fill_forward': Fill gaps with last known value
+            max_gap_hours: Gaps exceeding this escalate to error regardless
+                of strategy (safety limit)
+            time_var: Name of time coordinate
+
+        Returns:
+            Tuple of (dataset, report) where report contains gap details
+
+        Raises:
+            ValueError: When gaps are found and strategy is 'error', or when
+                any gap exceeds max_gap_hours
+        """
+        if time_var not in ds.coords and time_var not in ds.dims:
+            return ds, {'valid': True, 'message': 'No time coordinate found, skipping validation'}
+
+        times = pd.to_datetime(ds[time_var].values)
+        if len(times) < 2:
+            return ds, {'valid': True, 'message': 'Fewer than 2 timesteps, skipping validation'}
+
+        times_sorted = times.sort_values()
+
+        if expected_freq_seconds is None:
+            deltas = np.diff(times_sorted).astype('timedelta64[s]').astype(int)
+            expected_freq_seconds = int(np.median(deltas))
+
+        expected_freq = pd.Timedelta(seconds=expected_freq_seconds)
+        expected_index = pd.date_range(
+            start=times_sorted[0], end=times_sorted[-1], freq=expected_freq
+        )
+        actual_set = set(times_sorted)
+        missing = sorted(expected_index.difference(actual_set))
+
+        report: Dict[str, Any] = {
+            'valid': len(missing) == 0,
+            'expected_timesteps': len(expected_index),
+            'actual_timesteps': len(times_sorted),
+            'missing_timesteps': len(missing),
+            'expected_freq_seconds': expected_freq_seconds,
+            'coverage_pct': len(times_sorted) / len(expected_index) * 100 if len(expected_index) > 0 else 100.0,
+        }
+
+        if not missing:
+            self.logger.info(
+                f"Forcing temporal completeness OK: {len(times_sorted)} timesteps, "
+                f"{expected_freq_seconds}s interval, 100% coverage"
+            )
+            return ds, report
+
+        gap_runs = self._identify_gap_runs(missing, expected_freq)
+        report['gaps'] = gap_runs
+        max_gap_found_hours = max(g['duration_hours'] for g in gap_runs) if gap_runs else 0
+        report['max_gap_hours'] = max_gap_found_hours
+
+        gap_summary = "; ".join(
+            f"{g['start']} to {g['end']} ({g['missing_count']} steps, {g['duration_hours']:.1f}h)"
+            for g in gap_runs[:5]
+        )
+        if len(gap_runs) > 5:
+            gap_summary += f"; ... and {len(gap_runs) - 5} more gaps"
+
+        msg = (
+            f"Forcing data has {len(missing)} missing timesteps across {len(gap_runs)} gap(s) "
+            f"(expected {expected_freq_seconds}s interval, {report['coverage_pct']:.1f}% coverage). "
+            f"Gaps: {gap_summary}"
+        )
+
+        if max_gap_found_hours > max_gap_hours:
+            raise ValueError(
+                f"{msg}\nLargest gap ({max_gap_found_hours:.1f}h) exceeds FORCING_MAX_GAP_HOURS "
+                f"({max_gap_hours}h). This gap is too large to safely fill — please fix the source data."
+            )
+
+        if strategy == 'error':
+            raise ValueError(
+                f"{msg}\nSet FORCING_MISSING_DATA_STRATEGY to 'warn', 'interpolate', or "
+                f"'fill_forward' to handle gaps, or fix the source data."
+            )
+        elif strategy == 'warn':
+            self.logger.warning(msg)
+        elif strategy in ('interpolate', 'fill_forward'):
+            self.logger.warning(f"{msg} — filling with strategy='{strategy}'")
+            ds = self._fill_temporal_gaps(
+                ds, expected_freq, times_sorted[0], times_sorted[-1],
+                method=strategy, time_var=time_var
+            )
+            report['filled'] = True
+        else:
+            raise ValueError(f"Unknown missing data strategy: {strategy}")
+
+        return ds, report
+
+    def _identify_gap_runs(
+        self, missing: List[pd.Timestamp], expected_freq: pd.Timedelta
+    ) -> List[Dict[str, Any]]:
+        """Group consecutive missing timesteps into gap runs."""
+        if not missing:
+            return []
+
+        runs: List[Dict[str, Any]] = []
+        run_start = missing[0]
+        prev = missing[0]
+
+        for ts in missing[1:]:
+            if ts - prev > expected_freq * 1.5:
+                runs.append({
+                    'start': str(run_start),
+                    'end': str(prev),
+                    'missing_count': int((prev - run_start) / expected_freq) + 1,
+                    'duration_hours': (prev - run_start + expected_freq).total_seconds() / 3600,
+                })
+                run_start = ts
+            prev = ts
+
+        runs.append({
+            'start': str(run_start),
+            'end': str(prev),
+            'missing_count': int((prev - run_start) / expected_freq) + 1,
+            'duration_hours': (prev - run_start + expected_freq).total_seconds() / 3600,
+        })
+        return runs
+
+    def _fill_temporal_gaps(
+        self,
+        ds: xr.Dataset,
+        freq: pd.Timedelta,
+        start: pd.Timestamp,
+        end: pd.Timestamp,
+        method: str = 'interpolate',
+        time_var: str = 'time'
+    ) -> xr.Dataset:
+        """Reindex to complete time axis and fill gaps."""
+        complete_index = pd.date_range(start=start, end=end, freq=freq)
+        ds = ds.reindex({time_var: complete_index})
+        if method == 'interpolate':
+            ds = ds.interpolate_na(dim=time_var, method='linear')
+        elif method == 'fill_forward':
+            ds = ds.ffill(dim=time_var)
+        return ds
+
     def resample_to_frequency(
         self,
         ds: xr.Dataset,
@@ -280,12 +439,16 @@ class ForcingDataProcessor:
         end_time: pd.Timestamp,
         target_freq: str = 'D',
         variable_mapping: Optional[Dict[str, str]] = None,
-        unit_conversions: Optional[Dict[str, str]] = None
+        unit_conversions: Optional[Dict[str, str]] = None,
+        missing_data_strategy: Optional[str] = None,
+        max_gap_hours: Optional[int] = None,
+        expected_freq_seconds: Optional[int] = None
     ) -> xr.Dataset:
         """
         Complete forcing preparation pipeline.
 
-        Combines loading, subsetting, resampling, and variable mapping.
+        Combines loading, subsetting, temporal validation, resampling,
+        and variable mapping.
 
         Args:
             forcing_path: Path to forcing files
@@ -294,6 +457,11 @@ class ForcingDataProcessor:
             target_freq: Target temporal frequency
             variable_mapping: Variable name mapping dict
             unit_conversions: Dict mapping variable names to conversion keys
+            missing_data_strategy: Gap handling ('error', 'warn',
+                'interpolate', 'fill_forward'). Falls back to config then 'error'.
+            max_gap_hours: Maximum gap before forced error. Falls back to
+                config then 24.
+            expected_freq_seconds: Expected timestep. If None, inferred.
 
         Returns:
             Prepared forcing dataset
@@ -303,6 +471,20 @@ class ForcingDataProcessor:
 
         # Subset
         ds = self.subset_to_time_window(ds, start_time, end_time)
+
+        # Validate temporal completeness before resampling
+        strategy = missing_data_strategy or self._get_config_str(
+            'FORCING_MISSING_DATA_STRATEGY', 'error'
+        )
+        gap_limit = max_gap_hours or self._get_config_int(
+            'FORCING_MAX_GAP_HOURS', 24
+        )
+        ds, _report = self.validate_temporal_completeness(
+            ds,
+            expected_freq_seconds=expected_freq_seconds,
+            strategy=strategy,
+            max_gap_hours=gap_limit,
+        )
 
         # Resample
         ds = self.resample_to_frequency(ds, target_freq)
@@ -316,6 +498,30 @@ class ForcingDataProcessor:
                 ds = self.apply_unit_conversion(ds, var, conversion)
 
         return ds
+
+    def _get_config_str(self, key: str, default: str) -> str:
+        """Extract a string config value from config dict or typed config."""
+        if isinstance(self.config, dict):
+            return str(self.config.get(key, default))
+        # Typed config: try forcing subsection
+        forcing = getattr(self.config, 'forcing', None)
+        if forcing is not None:
+            field_map = {
+                'FORCING_MISSING_DATA_STRATEGY': 'missing_data_strategy',
+                'FORCING_MAX_GAP_HOURS': 'max_gap_hours',
+            }
+            attr = field_map.get(key)
+            if attr and hasattr(forcing, attr):
+                return str(getattr(forcing, attr))
+        return default
+
+    def _get_config_int(self, key: str, default: int) -> int:
+        """Extract an int config value from config dict or typed config."""
+        val = self._get_config_str(key, str(default))
+        try:
+            return int(val)
+        except (ValueError, TypeError):
+            return default
 
     def get_spatial_mean(
         self,

--- a/src/symfluence/resources/config_templates/config_template_comprehensive.yaml
+++ b/src/symfluence/resources/config_templates/config_template_comprehensive.yaml
@@ -3589,6 +3589,20 @@ SUPPLEMENT_FORCING: false
 #   Usage:      1
 KEEP_RAW_FORCING: true
 
+# FORCING_MISSING_DATA_STRATEGY
+#   Type:        Literal['error', 'warn', 'interpolate', 'fill_forward']
+#   Default:     error
+#   Source:      ForcingConfig (forcing.py)
+#   Usage:      2
+FORCING_MISSING_DATA_STRATEGY: "error"
+
+# FORCING_MAX_GAP_HOURS
+#   Type:        int
+#   Default:     24
+#   Source:      ForcingConfig (forcing.py)
+#   Usage:      2
+FORCING_MAX_GAP_HOURS: 24
+
 # EM_PRCP
 #   Type:        str
 #   Default:     prcp

--- a/tests/unit/models/test_temporal_completeness.py
+++ b/tests/unit/models/test_temporal_completeness.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Tests for temporal completeness validation in ForcingDataProcessor."""
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from symfluence.models.utilities.forcing_data_processor import ForcingDataProcessor
+
+
+def _make_hourly_dataset(
+    start: str = "2019-01-01",
+    hours: int = 48,
+    drop_indices: list | None = None,
+) -> xr.Dataset:
+    """Create a simple hourly forcing dataset, optionally dropping timesteps."""
+    times = pd.date_range(start, periods=hours, freq="h")
+    if drop_indices:
+        times = times.delete(drop_indices)
+    return xr.Dataset(
+        {"temperature": ("time", np.random.default_rng(42).standard_normal(len(times)))},
+        coords={"time": times},
+    )
+
+
+class TestValidateTemporalCompleteness:
+    """Tests for ForcingDataProcessor.validate_temporal_completeness."""
+
+    def setup_method(self):
+        self.fdp = ForcingDataProcessor(config={})
+
+    # -- complete data ---------------------------------------------------------
+
+    def test_complete_data_passes(self):
+        ds = _make_hourly_dataset(hours=48)
+        result, report = self.fdp.validate_temporal_completeness(ds)
+        assert report["valid"] is True
+        assert report["missing_timesteps"] == 0
+        assert report["coverage_pct"] == 100.0
+
+    # -- strategy='error' (default) --------------------------------------------
+
+    def test_error_strategy_raises_on_gap(self):
+        ds = _make_hourly_dataset(hours=48, drop_indices=[10, 11, 12])
+        with pytest.raises(ValueError, match="3 missing timesteps"):
+            self.fdp.validate_temporal_completeness(ds, strategy="error")
+
+    def test_error_strategy_message_includes_gap_details(self):
+        ds = _make_hourly_dataset(hours=48, drop_indices=[10])
+        with pytest.raises(ValueError, match="FORCING_MISSING_DATA_STRATEGY"):
+            self.fdp.validate_temporal_completeness(ds, strategy="error")
+
+    # -- strategy='warn' -------------------------------------------------------
+
+    def test_warn_strategy_continues(self):
+        ds = _make_hourly_dataset(hours=48, drop_indices=[10, 11])
+        result, report = self.fdp.validate_temporal_completeness(ds, strategy="warn")
+        assert report["valid"] is False
+        assert report["missing_timesteps"] == 2
+        assert len(result.time) == 46  # still has the gap
+
+    # -- strategy='interpolate' ------------------------------------------------
+
+    def test_interpolate_fills_gap(self):
+        ds = _make_hourly_dataset(hours=48, drop_indices=[10, 11])
+        result, report = self.fdp.validate_temporal_completeness(
+            ds, strategy="interpolate"
+        )
+        assert report["filled"] is True
+        assert len(result.time) == 48  # gap filled
+        assert not result["temperature"].isnull().any()
+
+    # -- strategy='fill_forward' -----------------------------------------------
+
+    def test_fill_forward_fills_gap(self):
+        ds = _make_hourly_dataset(hours=48, drop_indices=[10, 11])
+        result, report = self.fdp.validate_temporal_completeness(
+            ds, strategy="fill_forward"
+        )
+        assert report["filled"] is True
+        assert len(result.time) == 48
+
+    # -- max_gap_hours safety limit --------------------------------------------
+
+    def test_max_gap_hours_overrides_strategy(self):
+        # Drop 25 consecutive hours (indices 10-34)
+        ds = _make_hourly_dataset(hours=72, drop_indices=list(range(10, 35)))
+        with pytest.raises(ValueError, match="exceeds FORCING_MAX_GAP_HOURS"):
+            self.fdp.validate_temporal_completeness(
+                ds, strategy="interpolate", max_gap_hours=24
+            )
+
+    def test_gap_within_limit_allowed(self):
+        ds = _make_hourly_dataset(hours=48, drop_indices=[10, 11, 12])
+        result, report = self.fdp.validate_temporal_completeness(
+            ds, strategy="interpolate", max_gap_hours=24
+        )
+        assert report["filled"] is True
+        assert len(result.time) == 48
+
+    # -- dec 31 scenario (the NWM3 bug) ----------------------------------------
+
+    def test_dec31_missing_hours_detected(self):
+        """Reproduce the exact NWM3 bug: Dec 31 has only 00Z, rest is missing."""
+        times_before = pd.date_range("2019-12-30", periods=24, freq="h")
+        times_dec31_00z = pd.DatetimeIndex(["2019-12-31"])
+        times_after = pd.date_range("2020-01-01", periods=24, freq="h")
+        times = times_before.append(times_dec31_00z).append(times_after)
+        ds = xr.Dataset(
+            {"temperature": ("time", np.ones(len(times)))},
+            coords={"time": times},
+        )
+        with pytest.raises(ValueError, match="23 missing timesteps"):
+            self.fdp.validate_temporal_completeness(ds, strategy="error")
+
+    def test_dec31_gap_can_be_filled(self):
+        """Same scenario but with interpolate strategy and small enough gap."""
+        times_before = pd.date_range("2019-12-30", periods=24, freq="h")
+        times_dec31_00z = pd.DatetimeIndex(["2019-12-31"])
+        times_after = pd.date_range("2020-01-01", periods=24, freq="h")
+        times = times_before.append(times_dec31_00z).append(times_after)
+        ds = xr.Dataset(
+            {"temperature": ("time", np.ones(len(times)))},
+            coords={"time": times},
+        )
+        result, report = self.fdp.validate_temporal_completeness(
+            ds, strategy="interpolate", max_gap_hours=24
+        )
+        assert report["filled"] is True
+        assert report["missing_timesteps"] == 23
+        expected_total = 24 + 24 + 24  # 3 full days
+        assert len(result.time) == expected_total
+
+    # -- edge cases ------------------------------------------------------------
+
+    def test_single_timestep_passes(self):
+        ds = xr.Dataset(
+            {"temperature": ("time", [1.0])},
+            coords={"time": pd.DatetimeIndex(["2019-01-01"])},
+        )
+        _, report = self.fdp.validate_temporal_completeness(ds)
+        assert report["valid"] is True
+
+    def test_explicit_freq_overrides_inference(self):
+        ds = _make_hourly_dataset(hours=48, drop_indices=[10])
+        with pytest.raises(ValueError, match="1 missing timesteps"):
+            self.fdp.validate_temporal_completeness(
+                ds, expected_freq_seconds=3600, strategy="error"
+            )
+
+    def test_no_time_coordinate_skips(self):
+        ds = xr.Dataset({"temperature": ("x", [1.0, 2.0, 3.0])})
+        result, report = self.fdp.validate_temporal_completeness(ds)
+        assert report["valid"] is True
+
+    # -- gap report structure --------------------------------------------------
+
+    def test_gap_report_has_expected_fields(self):
+        ds = _make_hourly_dataset(hours=48, drop_indices=[10, 11, 30])
+        with pytest.raises(ValueError):
+            self.fdp.validate_temporal_completeness(ds, strategy="error")
+
+    def test_gap_runs_identified_correctly(self):
+        # Two separate gaps: indices 10-11 and 30
+        ds = _make_hourly_dataset(hours=48, drop_indices=[10, 11, 30])
+        _, report = self.fdp.validate_temporal_completeness(ds, strategy="warn")
+        assert len(report["gaps"]) == 2
+        assert report["gaps"][0]["missing_count"] == 2
+        assert report["gaps"][1]["missing_count"] == 1
+
+
+class TestValidateTemporalCompletenessConfig:
+    """Test config-driven behavior via prepare_forcing_for_model."""
+
+    def test_config_dict_strategy_used(self):
+        fdp = ForcingDataProcessor(
+            config={"FORCING_MISSING_DATA_STRATEGY": "warn", "FORCING_MAX_GAP_HOURS": "48"}
+        )
+        assert fdp._get_config_str("FORCING_MISSING_DATA_STRATEGY", "error") == "warn"
+        assert fdp._get_config_int("FORCING_MAX_GAP_HOURS", 24) == 48
+
+    def test_config_defaults(self):
+        fdp = ForcingDataProcessor(config={})
+        assert fdp._get_config_str("FORCING_MISSING_DATA_STRATEGY", "error") == "error"
+        assert fdp._get_config_int("FORCING_MAX_GAP_HOURS", 24) == 24


### PR DESCRIPTION
## Summary
- Adds `validate_temporal_completeness()` to `ForcingDataProcessor` — detects missing timesteps in forcing data before any model preprocessing, preventing cryptic downstream crashes (e.g. NGEN index-out-of-range errors from NWM3 data missing Dec 31 hours)
- Wires validation into the NGEN preprocessor's `prepare_forcing_data()` and into the shared `prepare_forcing_for_model()` pipeline used by all models
- Two new config options: `FORCING_MISSING_DATA_STRATEGY` (error/warn/interpolate/fill_forward, default `error`) and `FORCING_MAX_GAP_HOURS` (safety limit, default 24h — gaps exceeding this always error regardless of strategy)

## Motivation
NWM3 AORC forcing data has a systematic bug: Dec 31 each year has only 00Z, with the remaining 23 hourly timesteps missing. This silently propagated through preprocessing and caused index-out-of-range crashes in NGEN. The same class of bug can occur with any forcing dataset that has gaps.

## Test plan
- [x] 17 unit tests covering all strategies, the exact Dec 31 NWM3 scenario, max gap safety limits, edge cases, gap run identification, and config integration
- [x] Config authority test passes (template settings documented)
- [x] Full unit test suite: 5314 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)