### PR TITLE
feat(ignacio): FWI-only analysis mode + Iceland configs

### DIFF
--- a/examples/iceland_national_model/config_iceland_ignacio_fwi.yaml
+++ b/examples/iceland_national_model/config_iceland_ignacio_fwi.yaml
@@ -1,0 +1,156 @@
+# Iceland National Fire Weather Index Analysis — IGNACIO
+#
+# FWI-focused configuration using ERA5 forcing across Iceland.
+# Computes FFMC, DMC, DC, ISI, BUI, and FWI from ERA5 temperature,
+# humidity, wind speed, and precipitation.  No fuel raster or ignition
+# shapefile is needed for pure FWI mapping — IGNACIO will calculate
+# the moisture codes and danger indices from weather alone.
+#
+# Iceland context:
+#   - Subarctic vegetation: heathland, moss, grassland, sparse birch
+#   - Fire season is short (May–August) but increasing with climate change
+#   - FWI latitude correction matters at 65°N (long summer days)
+
+# ── System ──────────────────────────────────────────────────────────
+SYMFLUENCE_DATA_DIR: default
+SYMFLUENCE_CODE_DIR: default
+MPI_PROCESSES: 1
+FORCE_RUN_ALL_STEPS: false
+LOG_LEVEL: INFO
+LOG_TO_FILE: true
+LOG_FORMAT: detailed
+
+# ── Domain identification ───────────────────────────────────────────
+DOMAIN_NAME: Iceland_National
+EXPERIMENT_ID: iceland_ignacio_fwi_v1
+
+# ── Temporal extent ─────────────────────────────────────────────────
+# Match the hydrology configs: full decade, but FWI is most meaningful
+# during the fire season (May–August).  The preprocessor will convert
+# the entire ERA5 record so seasonal analysis is possible in post.
+EXPERIMENT_TIME_START: 2001-01-01 01:00
+EXPERIMENT_TIME_END:   2010-12-31 23:00
+
+# ── Spatial domain ──────────────────────────────────────────────────
+# Full Iceland bounding box — same as HYPE / SUMMA configs
+BOUNDING_BOX_COORDS: 66.6/-24.6/63.2/-13.2
+POUR_POINT_COORDS: 64.5/-18.5
+
+# Semi-distributed: reuse the same TauDEM delineation
+DOMAIN_DEFINITION_METHOD: delineate
+ROUTING_DELINEATION: distributed
+GEOFABRIC_TYPE: na
+DELINEATION_METHOD: stream_threshold
+STREAM_THRESHOLD: 5000
+LUMPED_WATERSHED_METHOD: TauDEM
+
+DELINEATE_COASTAL_WATERSHEDS: true
+DELINEATE_BY_POURPOINT: false
+MOVE_OUTLETS_MAX_DISTANCE: 200
+CLEANUP_INTERMEDIATE_FILES: false
+
+# ── Sub-grid discretization ────────────────────────────────────────
+DOMAIN_DISCRETIZATION: GRUs
+SUB_GRID_DISCRETIZATION: elevation
+ELEVATION_BAND_SIZE: 200
+MIN_HRU_SIZE: 4
+MIN_GRU_SIZE: 0
+
+# ── DEM & land surface data ────────────────────────────────────────
+DATA_ACCESS: cloud
+DEM_SOURCE: copdem90
+SOILGRIDS_LAYER: wrb_0-5cm_mode
+
+# ── Forcing ─────────────────────────────────────────────────────────
+# ERA5 provides the four variables IGNACIO needs for FWI:
+#   air_temperature  → TEMP (K → °C in preprocessor)
+#   specific_humidity + surface_air_pressure → RH (derived)
+#   wind_speed       → WS (m/s → km/h in preprocessor)
+#   precipitation_flux → PRECIP (mm/s → mm/h in preprocessor)
+FORCING_DATASET: ERA5
+FORCING_VARIABLES: default
+FORCING_MEASUREMENT_HEIGHT: 2
+FORCING_TIME_STEP_SIZE: 3600
+APPLY_LAPSE_RATE: true
+LAPSE_RATE: 0.0065
+SUPPLEMENT_FORCING: false
+
+# ── Model: IGNACIO (FWI mode) ──────────────────────────────────────
+HYDROLOGICAL_MODEL: IGNACIO
+
+# Project
+IGNACIO_PROJECT_NAME: iceland_fwi_analysis
+IGNACIO_OUTPUT_DIR: default
+IGNACIO_RANDOM_SEED: 42
+
+# CRS — ISN93 / Lambert 1993 for Iceland
+IGNACIO_WORKING_CRS: EPSG:3057
+IGNACIO_OUTPUT_CRS: EPSG:3057
+
+# FWI calculation from ERA5 weather data
+IGNACIO_CALCULATE_FWI: true
+IGNACIO_FWI_LATITUDE: 65.0
+IGNACIO_TIME_VARYING_WEATHER: true
+
+# Fuel types — derived from MODIS IGBP land cover raster acquired
+# during the attributes step.  The preprocessor discovers the land
+# class raster automatically and maps IGBP codes → FBP fuel types.
+# Iceland's IGBP breakdown (land only):
+#   10  Grasslands        56%  → O-1b (standing grass)
+#   16  Barren/lava       27%  → NF   (non-fuel)
+#    9  Savannas/heath     3%  → O-1a (matted grass / heathland)
+#   15  Snow/Ice          11%  → NF   (non-fuel)
+#   11  Wetlands           2%  → NF   (non-fuel, too wet to carry fire)
+IGNACIO_FUEL_SOURCE_TYPE: raster
+IGNACIO_DEFAULT_FUEL: O-1b
+
+# FBP defaults — conservative starting moisture codes for spring onset.
+# These are overridden once ERA5 weather data feeds the FWI calculator,
+# but set sensible Iceland values in case of data gaps.
+IGNACIO_DEFAULT_FFMC: 85.0
+IGNACIO_DEFAULT_DMC: 20.0
+IGNACIO_DEFAULT_DC: 100.0
+IGNACIO_DEFAULT_ISI: 4.0
+IGNACIO_DEFAULT_BUI: 30.0
+IGNACIO_FMC: 120.0
+IGNACIO_CURING: 60.0
+
+# Non-fuel codes — IGBP classes that cannot carry fire in Iceland:
+#   0   = Water (background)
+#   11  = Wetlands (too saturated)
+#   13  = Urban (not present but excluded for safety)
+#   15  = Snow/Ice (glaciers: Vatnajökull, Langjökull, etc.)
+#   16  = Barren (lava fields, bare rock)
+#   17  = Water Bodies (ocean, lakes, rivers)
+#   255 = NoData
+IGNACIO_NON_FUEL_CODES: [0, 11, 13, 15, 16, 17, 255, -9999]
+
+# Simulation parameters — long duration for seasonal FWI tracking
+IGNACIO_DT: 60.0
+IGNACIO_MAX_DURATION: 43200
+IGNACIO_N_VERTICES: 300
+IGNACIO_INITIAL_RADIUS: 10.0
+IGNACIO_MIN_ROS: 0.01
+
+# Output
+IGNACIO_SAVE_PERIMETERS: false
+IGNACIO_SAVE_ROS_GRIDS: true
+IGNACIO_PERIMETER_FORMAT: gpkg
+IGNACIO_GENERATE_PLOTS: true
+
+# No ignition or spread — this is a FWI analysis, not a fire simulation
+# Leave IGNACIO_IGNITION_SHAPEFILE unset; preprocessor handles gracefully.
+
+# ── Shapefile field mappings ────────────────────────────────────────
+CATCHMENT_SHP_LAT: center_lat
+CATCHMENT_SHP_LON: center_lon
+CATCHMENT_SHP_AREA: HRU_area
+CATCHMENT_SHP_HRUID: HRU_ID
+CATCHMENT_SHP_GRUID: GRU_ID
+RIVER_BASIN_SHP_RM_GRUID: GRU_ID
+RIVER_BASIN_SHP_HRU_TO_SEG: gru_to_seg
+RIVER_BASIN_SHP_AREA: GRU_area
+RIVER_NETWORK_SHP_LENGTH: Length
+RIVER_NETWORK_SHP_SEGID: LINKNO
+RIVER_NETWORK_SHP_DOWNSEGID: DSLINKNO
+RIVER_NETWORK_SHP_SLOPE: Slope

--- a/examples/iceland_national_model/config_iceland_ignacio_fwi_carra.yaml
+++ b/examples/iceland_national_model/config_iceland_ignacio_fwi_carra.yaml
@@ -1,0 +1,137 @@
+# Iceland National Fire Weather Index Analysis — IGNACIO + CARRA
+#
+# FWI analysis using CARRA (Copernicus Arctic Regional Reanalysis) at
+# 2.5 km resolution — a major upgrade over the 31 km ERA5 version.
+# Full CARRA period: 1991–2024, covering 33+ fire seasons.
+#
+# CARRA advantages for Iceland:
+#   - 2.5 km grid resolves individual valleys, fjords, and glaciers
+#   - 3-hourly native timestep captures diurnal wind/temp cycles
+#   - Arctic-optimised data assimilation (better for high-latitude)
+#   - Direct RH output (no specific-humidity approximation needed)
+
+# ── System ──────────────────────────────────────────────────────────
+SYMFLUENCE_DATA_DIR: default
+SYMFLUENCE_CODE_DIR: default
+NUM_PROCESSES: 1
+FORCE_RUN_ALL_STEPS: false
+LOG_LEVEL: INFO
+LOG_TO_FILE: true
+LOG_FORMAT: detailed
+
+# ── Domain identification ───────────────────────────────────────────
+DOMAIN_NAME: Iceland_National
+EXPERIMENT_ID: iceland_ignacio_fwi_carra_v1
+
+# ── Temporal extent ─────────────────────────────────────────────────
+# Full CARRA period — 1991 start avoids the 1990 spinup year.
+# Extends to end of 2024 for the most recent fire seasons.
+EXPERIMENT_TIME_START: 1991-01-01 03:00
+EXPERIMENT_TIME_END:   2024-12-31 21:00
+
+# ── Spatial domain ──────────────────────────────────────────────────
+# Full Iceland bounding box
+BOUNDING_BOX_COORDS: 66.6/-24.6/63.2/-13.2
+POUR_POINT_COORDS: 64.5/-18.5
+
+# Reuse existing TauDEM delineation
+DOMAIN_DEFINITION_METHOD: delineate
+ROUTING_DELINEATION: distributed
+GEOFABRIC_TYPE: na
+DELINEATION_METHOD: stream_threshold
+STREAM_THRESHOLD: 5000
+LUMPED_WATERSHED_METHOD: TauDEM
+
+DELINEATE_COASTAL_WATERSHEDS: true
+DELINEATE_BY_POURPOINT: false
+MOVE_OUTLETS_MAX_DISTANCE: 200
+CLEANUP_INTERMEDIATE_FILES: false
+
+# ── Sub-grid discretization ────────────────────────────────────────
+DOMAIN_DISCRETIZATION: GRUs
+SUB_GRID_DISCRETIZATION: elevation
+ELEVATION_BAND_SIZE: 200
+MIN_HRU_SIZE: 4
+MIN_GRU_SIZE: 0
+
+# ── DEM & land surface data ────────────────────────────────────────
+DATA_ACCESS: cloud
+DEM_SOURCE: copdem90
+SOILGRIDS_LAYER: wrb_0-5cm_mode
+
+# ── Forcing: CARRA ─────────────────────────────────────────────────
+# CARRA west_domain covers all of Iceland + Greenland + N Atlantic.
+# 3-hourly native resolution, 2.5 km grid.
+# Variables acquired:
+#   Analysis:  2m_temperature, 2m_relative_humidity, 10m u/v wind, surface_pressure
+#   Forecast:  total_precipitation, SW/LW radiation
+# Handler converts to standard names: air_temperature, specific_humidity,
+# wind_speed, precipitation_flux, surface_air_pressure
+FORCING_DATASET: CARRA
+CARRA_DOMAIN: west_domain
+FORCING_VARIABLES: default
+FORCING_MEASUREMENT_HEIGHT: 2
+FORCING_TIME_STEP_SIZE: 10800
+APPLY_LAPSE_RATE: true
+LAPSE_RATE: 0.0065
+SUPPLEMENT_FORCING: false
+
+# ── Model: IGNACIO (FWI mode) ──────────────────────────────────────
+HYDROLOGICAL_MODEL: IGNACIO
+
+# Project
+IGNACIO_PROJECT_NAME: iceland_fwi_carra
+IGNACIO_OUTPUT_DIR: default
+IGNACIO_RANDOM_SEED: 42
+
+# CRS — ISN93 / Lambert 1993 for Iceland
+IGNACIO_WORKING_CRS: EPSG:3057
+IGNACIO_OUTPUT_CRS: EPSG:3057
+
+# FWI calculation from CARRA weather data
+IGNACIO_CALCULATE_FWI: true
+IGNACIO_FWI_LATITUDE: 65.0
+IGNACIO_TIME_VARYING_WEATHER: true
+
+# Fuel types — from MODIS IGBP land cover raster
+IGNACIO_FUEL_SOURCE_TYPE: raster
+IGNACIO_DEFAULT_FUEL: O-1b
+
+# FBP defaults — conservative spring-onset values
+IGNACIO_DEFAULT_FFMC: 85.0
+IGNACIO_DEFAULT_DMC: 20.0
+IGNACIO_DEFAULT_DC: 100.0
+IGNACIO_DEFAULT_ISI: 4.0
+IGNACIO_DEFAULT_BUI: 30.0
+IGNACIO_FMC: 120.0
+IGNACIO_CURING: 60.0
+
+# Non-fuel codes
+IGNACIO_NON_FUEL_CODES: [0, 11, 13, 15, 16, 17, 255, -9999]
+
+# Simulation parameters
+IGNACIO_DT: 60.0
+IGNACIO_MAX_DURATION: 43200
+IGNACIO_N_VERTICES: 300
+IGNACIO_INITIAL_RADIUS: 10.0
+IGNACIO_MIN_ROS: 0.01
+
+# Output
+IGNACIO_SAVE_PERIMETERS: false
+IGNACIO_SAVE_ROS_GRIDS: true
+IGNACIO_PERIMETER_FORMAT: gpkg
+IGNACIO_GENERATE_PLOTS: true
+
+# ── Shapefile field mappings ────────────────────────────────────────
+CATCHMENT_SHP_LAT: center_lat
+CATCHMENT_SHP_LON: center_lon
+CATCHMENT_SHP_AREA: HRU_area
+CATCHMENT_SHP_HRUID: HRU_ID
+CATCHMENT_SHP_GRUID: GRU_ID
+RIVER_BASIN_SHP_RM_GRUID: GRU_ID
+RIVER_BASIN_SHP_HRU_TO_SEG: gru_to_seg
+RIVER_BASIN_SHP_AREA: GRU_area
+RIVER_NETWORK_SHP_LENGTH: Length
+RIVER_NETWORK_SHP_SEGID: LINKNO
+RIVER_NETWORK_SHP_DOWNSEGID: DSLINKNO
+RIVER_NETWORK_SHP_SLOPE: Slope

--- a/src/symfluence/models/ignacio/preprocessor.py
+++ b/src/symfluence/models/ignacio/preprocessor.py
@@ -149,22 +149,18 @@ class IGNACIOPreProcessor(BaseModelPreProcessor):
 
         # Try default DEM locations
         if terrain_paths['dem_path'] is None:
-            # Try RHESSys fire DEM first (most likely for fire simulations)
-            fire_dem = self.project_dir / 'settings' / 'RHESSys' / 'fire' / 'dem_grid.tif'
-            if fire_dem.exists():
-                terrain_paths['dem_path'] = fire_dem
-                self.logger.info(f"Using RHESSys fire DEM: {fire_dem}")
-            else:
-                # Try standard attribute location
-                default_dem = self.project_attributes_dir / 'dem' / f"{self.config.domain.name}_dem.tif"
-                if default_dem.exists():
-                    terrain_paths['dem_path'] = default_dem
-                    self.logger.info(f"Using default DEM: {default_dem}")
-                else:
-                    # Try alternative location
-                    alt_dem = self.project_dir / 'shapefiles' / 'dem' / 'dem.tif'
-                    if alt_dem.exists():
-                        terrain_paths['dem_path'] = alt_dem
+            default_dem_paths = [
+                self.project_attributes_dir / 'elevation' / 'dem' / f"domain_{self.config.domain.name}_elv.tif",
+                self.project_attributes_dir / 'elevation' / 'dem' / f"{self.config.domain.name}_elv.tif",
+                self.project_attributes_dir / 'dem' / f"{self.config.domain.name}_dem.tif",
+                self.project_dir / 'settings' / 'RHESSys' / 'fire' / 'dem_grid.tif',
+                self.project_dir / 'shapefiles' / 'dem' / 'dem.tif',
+            ]
+            for candidate in default_dem_paths:
+                if candidate.exists():
+                    terrain_paths['dem_path'] = candidate
+                    self.logger.info(f"Using DEM: {candidate}")
+                    break
 
         # Check for pre-computed slope/aspect
         slope_path = ignacio_config.get('slope_path')
@@ -259,7 +255,8 @@ class IGNACIOPreProcessor(BaseModelPreProcessor):
             import pandas as pd
             import xarray as xr
 
-            # Find ERA5 forcing files
+            # Find forcing files — prefer basin-averaged (1-D) over
+            # multi-HRU files that require spatial averaging.
             forcing_dirs = [
                 self.project_forcing_dir / 'basin_averaged_data',
                 self.project_forcing_dir / 'merged_path',
@@ -269,92 +266,77 @@ class IGNACIOPreProcessor(BaseModelPreProcessor):
             nc_files = []
             for forcing_dir in forcing_dirs:
                 if forcing_dir.exists():
-                    nc_files.extend(list(forcing_dir.glob('*.nc')))
+                    found = list(forcing_dir.glob('*.nc'))
+                    if found:
+                        nc_files = found
+                        self.logger.info(f"Using forcing from: {forcing_dir.name}")
+                        break
 
             if not nc_files:
-                self.logger.warning("No ERA5 forcing files found")
+                self.logger.warning("No forcing files found")
                 return None
 
-            self.logger.info(f"Found {len(nc_files)} ERA5 forcing files")
+            self.logger.info(f"Found {len(nc_files)} forcing files")
 
-            # Load and concatenate if multiple files
-            datasets = []
-            for nc_file in sorted(nc_files)[:12]:  # Limit to 12 files for memory
+            chunks = []
+            for nc_file in sorted(nc_files):
                 try:
                     ds = xr.open_dataset(nc_file)
-                    datasets.append(ds)
+
+                    if 'hru' in ds.dims:
+                        ds = ds.mean(dim='hru')
+
+                    times = pd.to_datetime(ds.time.values)
+                    n = len(times)
+
+                    temp_c = (ds['air_temperature'].values - 273.15
+                              if 'air_temperature' in ds
+                              else np.full(n, 20.0))
+
+                    if 'specific_humidity' in ds and 'surface_air_pressure' in ds:
+                        q = ds['specific_humidity'].values
+                        p = ds['surface_air_pressure'].values
+                        e = q * p / (0.622 + 0.378 * q)
+                        es = 611.2 * np.exp(17.67 * temp_c / (temp_c + 243.5))
+                        rh = np.clip(100.0 * e / es, 0, 100)
+                    else:
+                        rh = np.full(n, 50.0)
+
+                    ws_kmh = (ds['wind_speed'].values * 3.6
+                              if 'wind_speed' in ds
+                              else np.full(n, 10.0))
+
+                    wd = np.random.uniform(0, 360, n)
+
+                    precip_mm = (ds['precipitation_flux'].values * 3600
+                                 if 'precipitation_flux' in ds
+                                 else np.zeros(n))
+
+                    chunks.append(pd.DataFrame({
+                        'HOURLY': times.strftime('%d/%m/%Y %H:%M'),
+                        'TEMP': temp_c,
+                        'RH': rh,
+                        'WS': ws_kmh,
+                        'WD': wd,
+                        'PRECIP': precip_mm,
+                    }))
+
+                    ds.close()
                 except Exception as exc:  # noqa: BLE001 — model execution resilience
                     self.logger.warning(f"Could not load {nc_file}: {exc}")
 
-            if not datasets:
+            if not chunks:
                 return None
 
-            # Concatenate datasets
-            if len(datasets) > 1:
-                ds = xr.concat(datasets, dim='time')
-            else:
-                ds = datasets[0]
-
-            # Average across HRUs if spatial data
-            if 'hru' in ds.dims:
-                ds = ds.mean(dim='hru')
-
-            # Extract variables
-            times = pd.to_datetime(ds.time.values)
-
-            # Temperature: Convert K to C
-            if 'air_temperature' in ds:
-                temp_c = ds['air_temperature'].values - 273.15
-            else:
-                temp_c = np.full(len(times), 20.0)  # Default
-
-            # Relative Humidity: Calculate from specific humidity and pressure
-            if 'specific_humidity' in ds and 'surface_air_pressure' in ds:
-                spechum = ds['specific_humidity'].values
-                airpres = ds['surface_air_pressure'].values
-                # Convert specific humidity to relative humidity
-                # e = q * P / (0.622 + 0.378 * q)
-                # es = 611.2 * exp(17.67 * T / (T + 243.5))
-                # RH = 100 * e / es
-                e = spechum * airpres / (0.622 + 0.378 * spechum)
-                es = 611.2 * np.exp(17.67 * temp_c / (temp_c + 243.5))
-                rh = 100.0 * e / es
-                rh = np.clip(rh, 0, 100)
-            else:
-                rh = np.full(len(times), 50.0)  # Default
-
-            # Wind speed: m/s to km/h
-            if 'wind_speed' in ds:
-                ws_kmh = ds['wind_speed'].values * 3.6
-            else:
-                ws_kmh = np.full(len(times), 10.0)  # Default
-
-            # Wind direction: Not in ERA5, use random or constant
-            # Could derive from u10/v10 if available
-            wd = np.random.uniform(0, 360, len(times))
-
-            # Precipitation: mm/s to mm (hourly accumulation)
-            if 'precipitation_flux' in ds:
-                precip_mm = ds['precipitation_flux'].values * 3600  # mm/s to mm/hour
-            else:
-                precip_mm = np.zeros(len(times))
-
-            # Create DataFrame
-            weather_df = pd.DataFrame({
-                'HOURLY': times.strftime('%d/%m/%Y %H:%M'),
-                'TEMP': temp_c,
-                'RH': rh,
-                'WS': ws_kmh,
-                'WD': wd,
-                'PRECIP': precip_mm,
-            })
+            weather_df = pd.concat(chunks, ignore_index=True)
 
             # Save to CSV
             weather_csv = self.ignacio_input_dir / 'era5_weather_stations.csv'
             weather_df.to_csv(weather_csv, index=False)
 
-            self.logger.info(f"Converted ERA5 to weather CSV: {weather_csv}")
-            self.logger.info(f"  Time range: {times[0]} to {times[-1]}")
+            all_times = pd.to_datetime(weather_df['HOURLY'], dayfirst=True)
+            self.logger.info(f"Converted forcing to weather CSV: {weather_csv}")
+            self.logger.info(f"  Time range: {all_times.iloc[0]} to {all_times.iloc[-1]}")
             self.logger.info(f"  Records: {len(weather_df)}")
 
             return weather_csv
@@ -599,8 +581,8 @@ class IGNACIOPreProcessor(BaseModelPreProcessor):
                 },
             },
             'ignition': {
-                'source_type': 'shapefile' if ignition_path else 'point',
-                'point_path': str(ignition_path) if ignition_path else None,
+                'source_type': 'shapefile' if ignition_path else 'fwi_only',
+                **(  {'point_path': str(ignition_path)} if ignition_path else {}),
                 'cause': ignacio_config.get('ignition_cause', 'Lightning'),
                 'season': self._get_season_from_date(ignacio_config.get('ignition_date')),
                 'n_iterations': ignacio_config.get('n_iterations', 1),
@@ -651,13 +633,16 @@ class IGNACIOPreProcessor(BaseModelPreProcessor):
                 'store_every': ignacio_config.get('store_every', 30),
                 'min_ros': ignacio_config.get('min_ros', 0.01),
                 'time_varying_weather': ignacio_config.get('time_varying_weather', True),
-                'start_datetime': ignacio_config.get('ignition_date', '2014-08-15 12:00:00'),
+                'start_datetime': ignacio_config.get('ignition_date'),
                 'default_start_hour': 12,
             },
             'output': {
                 'save_perimeters': ignacio_config.get('save_perimeters', True),
                 'save_ros_grids': ignacio_config.get('save_ros_grids', True),
-                'perimeter_format': ignacio_config.get('perimeter_format', 'shapefile'),
+                'perimeter_format': {
+                    'gpkg': 'geopackage',
+                }.get(ignacio_config.get('perimeter_format', 'shapefile'),
+                      ignacio_config.get('perimeter_format', 'shapefile')),
                 'generate_plots': ignacio_config.get('generate_plots', True),
                 'log_level': 'INFO',
             },

--- a/src/symfluence/models/ignacio/runner.py
+++ b/src/symfluence/models/ignacio/runner.py
@@ -50,12 +50,23 @@ class IGNACIORunner(BaseModelRunner):
         self.ignacio_input_dir = self.project_dir / "IGNACIO_input"
         self.ignacio_config_path = self.ignacio_input_dir / "ignacio_config.yaml"
 
+    def _is_fwi_only(self) -> bool:
+        """Check if this is an FWI-only run (no ignition configured)."""
+        import yaml
+        if not self.ignacio_config_path.exists():
+            return False
+        with open(self.ignacio_config_path, encoding='utf-8') as f:
+            cfg = yaml.safe_load(f)
+        ignition = cfg.get('ignition', {})
+        return ignition.get('source_type') == 'fwi_only'
+
     def run_ignacio(self, **kwargs) -> Optional[Path]:
         """
-        Execute the IGNACIO fire spread simulation.
+        Execute the IGNACIO fire spread simulation or FWI-only analysis.
 
-        Attempts to run IGNACIO via its Python API first, falling back
-        to CLI if the API is unavailable.
+        For FWI-only mode (no ignition), calculates FWI components from
+        weather data without running fire spread.  Otherwise attempts
+        the full simulation via Python API, falling back to CLI.
 
         Returns:
             Path to output directory on success, None on failure
@@ -81,19 +92,134 @@ class IGNACIORunner(BaseModelRunner):
                     f"Run preprocessing first: symfluence workflow step preprocessing"
                 )
 
-            # Try Python API first
-            success = self._run_via_api()
-
-            if not success:
-                # Fall back to CLI
-                self.logger.info("Falling back to IGNACIO CLI...")
-                success = self._run_via_cli()
+            if self._is_fwi_only():
+                success = self._run_fwi_only()
+            else:
+                # Try Python API first
+                success = self._run_via_api()
+                if not success:
+                    self.logger.info("Falling back to IGNACIO CLI...")
+                    success = self._run_via_cli()
 
             if success:
-                self.logger.info(f"IGNACIO simulation completed. Output: {self.output_dir}")
+                self.logger.info(f"IGNACIO completed. Output: {self.output_dir}")
                 return self.output_dir
             else:
                 raise ModelExecutionError("IGNACIO simulation failed")
+
+    def _run_fwi_only(self) -> bool:
+        """
+        Calculate FWI components from weather data without fire spread.
+
+        Reads the preprocessed weather CSV and computes daily FWI
+        components (FFMC, DMC, DC, ISI, BUI, FWI, DSR).
+
+        Returns:
+            True if successful, False otherwise
+        """
+        try:
+            import pandas as pd
+            import yaml
+            from ignacio.fwi import calculate_fwi_from_weather
+
+            with open(self.ignacio_config_path, encoding='utf-8') as f:
+                cfg = yaml.safe_load(f)
+
+            weather_path = cfg.get('weather', {}).get('station_path')
+            if not weather_path or not Path(weather_path).exists():
+                self.logger.error(f"Weather CSV not found: {weather_path}")
+                return False
+
+            latitude = cfg.get('weather', {}).get('fwi_latitude', 65.0)
+
+            self.logger.info(f"FWI-only mode: calculating from {weather_path}")
+            self.logger.info(f"  Latitude for day-length adjustment: {latitude}")
+
+            weather_df = pd.read_csv(weather_path)
+            self.logger.info(f"  Weather records: {len(weather_df)}")
+
+            fwi_df = calculate_fwi_from_weather(
+                weather_df,
+                latitude=latitude,
+            )
+
+            fwi_csv = self.output_dir / 'fwi_results.csv'
+            fwi_df.to_csv(fwi_csv, index=False)
+            self.logger.info(f"  FWI results: {len(fwi_df)} days → {fwi_csv}")
+
+            if len(fwi_df) > 0:
+                self.logger.info(
+                    f"  FFMC range: {fwi_df['FFMC'].min():.1f} – {fwi_df['FFMC'].max():.1f}"
+                )
+                self.logger.info(
+                    f"  DMC  range: {fwi_df['DMC'].min():.1f} – {fwi_df['DMC'].max():.1f}"
+                )
+                self.logger.info(
+                    f"  DC   range: {fwi_df['DC'].min():.1f} – {fwi_df['DC'].max():.1f}"
+                )
+                self.logger.info(
+                    f"  ISI  range: {fwi_df['ISI'].min():.2f} – {fwi_df['ISI'].max():.2f}"
+                )
+                self.logger.info(
+                    f"  BUI  range: {fwi_df['BUI'].min():.1f} – {fwi_df['BUI'].max():.1f}"
+                )
+                self.logger.info(
+                    f"  FWI  range: {fwi_df['FWI'].min():.2f} – {fwi_df['FWI'].max():.2f}"
+                )
+
+                if cfg.get('output', {}).get('generate_plots', True):
+                    self._generate_fwi_plots(fwi_df)
+
+            return True
+
+        except ImportError as e:
+            self.logger.warning(f"IGNACIO FWI package not available: {e}")
+            return False
+        except Exception as e:  # noqa: BLE001 — model execution resilience
+            self.logger.error(f"FWI calculation failed: {e}")
+            import traceback
+            self.logger.debug(traceback.format_exc())
+            return False
+
+    def _generate_fwi_plots(self, fwi_df) -> None:
+        """Generate FWI time series plots."""
+        try:
+            import matplotlib
+            matplotlib.use('Agg')
+            import matplotlib.dates as mdates
+            import matplotlib.pyplot as plt
+            import pandas as pd
+
+            dates = pd.to_datetime(fwi_df['DATE'])
+
+            fig, axes = plt.subplots(3, 2, figsize=(14, 10), sharex=True)
+            fig.suptitle(f'Fire Weather Index — {self.config.domain.name}', fontsize=14)
+
+            components = [
+                ('FFMC', 'Fine Fuel Moisture Code', 'tab:orange'),
+                ('DMC', 'Duff Moisture Code', 'tab:brown'),
+                ('DC', 'Drought Code', 'tab:red'),
+                ('ISI', 'Initial Spread Index', 'tab:purple'),
+                ('BUI', 'Buildup Index', 'tab:green'),
+                ('FWI', 'Fire Weather Index', 'tab:blue'),
+            ]
+
+            for ax, (col, title, color) in zip(axes.flat, components):
+                ax.plot(dates, fwi_df[col], color=color, linewidth=0.5)
+                ax.set_ylabel(col)
+                ax.set_title(title)
+                ax.grid(True, alpha=0.3)
+                ax.xaxis.set_major_locator(mdates.YearLocator())
+                ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y'))
+
+            plt.tight_layout()
+            plot_path = self.output_dir / 'fwi_timeseries.png'
+            fig.savefig(plot_path, dpi=150)
+            plt.close(fig)
+            self.logger.info(f"  FWI plot saved: {plot_path}")
+
+        except Exception as e:  # noqa: BLE001
+            self.logger.warning(f"Could not generate FWI plots: {e}")
 
     def _run_via_api(self) -> bool:
         """

--- a/tools/quality/broad_exception_allowlist.txt
+++ b/tools/quality/broad_exception_allowlist.txt
@@ -784,6 +784,8 @@ src/symfluence/models/ignacio/preprocessor.py:IGNACIOPreProcessor._convert_era5_
 src/symfluence/models/ignacio/preprocessor.py:IGNACIOPreProcessor._convert_era5_to_weather_csv:except Exception as exc:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/ignacio/preprocessor.py:IGNACIOPreProcessor._get_season_from_date:except Exception as e:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/ignacio/preprocessor.py:IGNACIOPreProcessor.run_preprocessing:except Exception as e:  # noqa: BLE001 — model execution resilience
+src/symfluence/models/ignacio/runner.py:IGNACIORunner._generate_fwi_plots:except Exception as e:  # noqa: BLE001
+src/symfluence/models/ignacio/runner.py:IGNACIORunner._run_fwi_only:except Exception as e:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/ignacio/runner.py:IGNACIORunner._run_via_api:except Exception as e:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/ignacio/runner.py:IGNACIORunner._run_via_cli:except Exception as e:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/lstm/calibration/worker.py:LSTMWorker.calculate_metrics:except Exception as e:  # noqa: BLE001 — calibration resilience


### PR DESCRIPTION
## Summary

- Add FWI-only analysis mode to IGNACIO runner — calculates Fire Weather Index components from reanalysis forcing data without requiring ignition shapefiles, DEM, or fire spread simulation
- Fix preprocessor DEM discovery, year-by-year forcing conversion (removes 12-file memory cap), and basin_averaged_data preference
- Add Iceland national FWI example configs for ERA5 (2001–2010) and CARRA 2.5km (1991–2024)

## Changes

**Runner** (`runner.py`):
- `_is_fwi_only()` — detects FWI-only configs via `source_type: fwi_only`
- `_run_fwi_only()` — calls `ignacio.fwi.calculate_fwi_from_weather` directly
- `_generate_fwi_plots()` — time series visualization with proper multi-year date axes

**Preprocessor** (`preprocessor.py`):
- DEM path search now includes `elevation/dem/domain_*_elv.tif` layout
- Forcing files processed one-at-a-time (stream → DataFrame chunks → concat), no memory cap
- Prefers `basin_averaged_data/` over multi-HRU `merged_path/` files
- Sets `fwi_only` ignition source type when no ignition shapefile exists
- Maps `gpkg` → `geopackage` for Ignacio's OutputConfig validation

**Examples**:
- `config_iceland_ignacio_fwi.yaml` — ERA5 forcing, 2001–2010
- `config_iceland_ignacio_fwi_carra.yaml` — CARRA 2.5km Arctic reanalysis, 1991–2024

## Test plan

- [x] Validated IGNACIOConfig Pydantic parsing with FWI config
- [x] Full workflow run: preprocessing finds DEM + land cover + ERA5 forcing
- [x] FWI calculation produces 3,652 daily records (2001–2010) with correct ranges
- [x] Time series plot renders with proper year axis
- [ ] CARRA config: download in progress (34 years from CDS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)