### PR TITLE
fix: co-author feedback round 2 — FUSE flat-key gap, binary info, benchmark configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,10 +176,7 @@ Makefile
 config_semi_distributed_troute.yaml
 
 # Local test/development domain directories
-domain_bow_test/
-domain_gssurgo_test/
-domain_polaris_test/
-domain_standalone/
+domain_*/
 
 # Paper working directories (local)
 papers/

--- a/examples/paper_case_studies/configs/configs_orig/05_benchmarking/config_Bow_benchmark_era5_fuse.yaml
+++ b/examples/paper_case_studies/configs/configs_orig/05_benchmarking/config_Bow_benchmark_era5_fuse.yaml
@@ -1,0 +1,151 @@
+### ============================================= SYMFLUENCE configuration file ============================================================
+# Benchmarking Configuration for Bow at Banff - FUSE variant (Section 4.5)
+# Calibrates FUSE and evaluates against HydroBM statistical benchmarks.
+# Mirrors config_Bow_benchmark_era5.yaml (SUMMA) so users can reproduce
+# Figure 8's FUSE point.
+### ============================================= 1. Global settings: =====================================================================
+
+# Main paths
+SYMFLUENCE_DATA_DIR: "/Users/darrieythorsson/compHydro/code/SYMFLUENCE_data/"
+SYMFLUENCE_CODE_DIR: "/Users/darrieythorsson/compHydro/code/SYMFLUENCE"
+
+# Experiment settings
+DOMAIN_NAME: Bow_at_Banff_lumped_era5
+EXPERIMENT_ID: benchmark_fuse
+EXPERIMENT_TIME_START: 2002-01-01 01:00
+EXPERIMENT_TIME_END: 2009-12-31 23:00
+CALIBRATION_PERIOD: 2004-01-01, 2007-12-31
+EVALUATION_PERIOD:  2008-01-01, 2009-12-31
+SPINUP_PERIOD: 2002-01-01, 2003-12-31
+
+# Computational settings
+MPI_PROCESSES: 1
+FORCE_RUN_ALL_STEPS: False
+
+### ============================================= 2. Geospatial settings: =================================================================
+# Coordinate settings
+POUR_POINT_COORDS: 51.1722/-115.5717
+BOUNDING_BOX_COORDS: 51.76/-116.55/50.95/-115.5
+
+# Pour point shapefile path
+POUR_POINT_SHP_PATH: default
+POUR_POINT_SHP_NAME: default
+
+# Domain representation settings
+DOMAIN_DEFINITION_METHOD: lumped
+ROUTING_DELINEATION: lumped
+
+GEOFABRIC_TYPE: TDX
+STREAM_THRESHOLD: 5000
+LUMPED_WATERSHED_METHOD: TauDEM
+CLEANUP_INTERMEDIATE_FILES: True
+DELINEATE_BY_POURPOINT: True
+MOVE_OUTLETS_MAX_DISTANCE: 200
+MIN_GRU_SIZE: 1
+
+# Domain discretization settings
+SUB_GRID_DISCRETIZATION: GRUS
+ELEVATION_BAND_SIZE: 200
+MIN_HRU_SIZE: 4
+RADIATION_CLASS_NUMBER: 5
+ASPECT_CLASS_NUMBER: 8
+ASPECT_PATH: default
+
+# Shapefile settings - Catchment shape
+CATCHMENT_PATH: default
+CATCHMENT_SHP_NAME: default
+CATCHMENT_SHP_LAT: center_lat
+CATCHMENT_SHP_LON: center_lon
+CATCHMENT_SHP_AREA: HRU_area
+CATCHMENT_SHP_HRUID: HRU_ID
+CATCHMENT_SHP_GRUID: GRU_ID
+
+# Shapefile settings - Basins shape
+RIVER_BASINS_PATH: default
+RIVER_BASINS_NAME: default
+RIVER_BASIN_SHP_RM_GRUID: GRU_ID
+RIVER_BASIN_SHP_HRU_TO_SEG: gru_to_seg
+RIVER_BASIN_SHP_AREA: GRU_area
+
+# Shapefile settings - River network shape
+RIVER_NETWORK_SHP_PATH: default
+RIVER_NETWORK_SHP_NAME: default
+RIVER_NETWORK_SHP_LENGTH: Length
+RIVER_NETWORK_SHP_SEGID: LINKNO
+RIVER_NETWORK_SHP_DOWNSEGID: DSLINKNO
+RIVER_NETWORK_SHP_SLOPE: Slope
+
+# Geospatial data paths
+OUTPUT_BASINS_PATH: default
+OUTPUT_RIVERS_PATH: default
+DEM_PATH: default
+DEM_NAME: default
+TAUDEM_DIR: default
+OUTPUT_DIR: default
+CATCHMENT_PLOT_DIR: default
+SOIL_CLASS_PATH: default
+SOIL_CLASS_NAME: default
+LAND_CLASS_PATH: default
+LAND_CLASS_NAME: default
+RADIATION_PATH: default
+
+# Tool paths
+DATATOOL_PATH: default
+GISTOOL_PATH: default
+EASYMORE_CLIENT: easymore cli
+
+### ============================================= 3. Model Agnostic settings: =============================================================
+
+# Forcing data settings
+FORCING_DATASET: ERA5
+FORCING_VARIABLES: default
+FORCING_MEASUREMENT_HEIGHT: 2
+FORCING_TIME_STEP_SIZE: 3600
+APPLY_LAPSE_RATE: True
+LAPSE_RATE: 0.0065
+FORCING_SHAPE_LAT_NAME: lat
+FORCING_SHAPE_LON_NAME: lon
+FORCING_PATH: default
+
+# Intersection paths
+INTERSECT_SOIL_PATH: default
+INTERSECT_SOIL_NAME: catchment_with_soilclass.shp
+INTERSECT_ROUTING_PATH: default
+INTERSECT_ROUTING_NAME: catchment_with_routing_basins.shp
+INTERSECT_DEM_PATH: default
+INTERSECT_DEM_NAME: catchment_with_dem.shp
+INTERSECT_LAND_PATH: default
+INTERSECT_LAND_NAME: catchment_with_landclass.shp
+
+### ============================================= 4. Model Specific settings: =============================================================
+
+# Model settings
+HYDROLOGICAL_MODEL: FUSE
+ROUTING_MODEL: none
+
+# FUSE settings
+FUSE_SPATIAL_MODE: lumped
+SETTINGS_FUSE_PARAMS_TO_CALIBRATE: MAXWATR_1,MAXWATR_2,BASERTE,QB_POWR,TIMEDELAY,PERCRTE,FRACTEN,RTFRAC1,MBASE,MFMAX,MFMIN,PXTEMP,LAPSE
+
+### ============================================= 5. Evaluation settings: =================================================================
+
+# Observation data settings
+STREAMFLOW_DATA_PROVIDER: WSC
+DOWNLOAD_WSC_DATA: True
+STATION_ID: 05BB001
+STREAMFLOW_RAW_PATH: default
+STREAMFLOW_RAW_NAME: default
+STREAMFLOW_PROCESSED_PATH: default
+
+### ============================================= 6. Optimization settings: ===============================================================
+
+OPTIMIZATION_METHODS: [iteration]
+ITERATIVE_OPTIMIZATION_ALGORITHM: DDS
+NUMBER_OF_ITERATIONS: 1000
+DDS_R: 0.2
+OPTIMIZATION_METRIC: KGE
+TARGET_METRIC: KGE
+
+### ============================================= 7. Analysis settings: ==================================================================
+
+ANALYSES: [benchmarking]

--- a/examples/paper_case_studies/configs/configs_orig/05_benchmarking/config_Bow_benchmark_era5_gr4j.yaml
+++ b/examples/paper_case_studies/configs/configs_orig/05_benchmarking/config_Bow_benchmark_era5_gr4j.yaml
@@ -1,0 +1,153 @@
+### ============================================= SYMFLUENCE configuration file ============================================================
+# Benchmarking Configuration for Bow at Banff - GR4J variant (Section 4.5)
+# Calibrates GR4J and evaluates against HydroBM statistical benchmarks.
+# Mirrors config_Bow_benchmark_era5.yaml (SUMMA) so users can reproduce
+# Figure 8's GR4J point.
+#
+# Requires R + rpy2 (the bootstrap installer attempts rpy2 by default;
+# if R is not on the system, GR4J will not run — see other variants).
+### ============================================= 1. Global settings: =====================================================================
+
+# Main paths
+SYMFLUENCE_DATA_DIR: "/Users/darrieythorsson/compHydro/code/SYMFLUENCE_data/"
+SYMFLUENCE_CODE_DIR: "/Users/darrieythorsson/compHydro/code/SYMFLUENCE"
+
+# Experiment settings
+DOMAIN_NAME: Bow_at_Banff_lumped_era5
+EXPERIMENT_ID: benchmark_gr4j
+EXPERIMENT_TIME_START: 2002-01-01 01:00
+EXPERIMENT_TIME_END: 2009-12-31 23:00
+CALIBRATION_PERIOD: 2004-01-01, 2007-12-31
+EVALUATION_PERIOD:  2008-01-01, 2009-12-31
+SPINUP_PERIOD: 2002-01-01, 2003-12-31
+
+# Computational settings
+MPI_PROCESSES: 1
+FORCE_RUN_ALL_STEPS: False
+
+### ============================================= 2. Geospatial settings: =================================================================
+# Coordinate settings
+POUR_POINT_COORDS: 51.1722/-115.5717
+BOUNDING_BOX_COORDS: 51.76/-116.55/50.95/-115.5
+
+# Pour point shapefile path
+POUR_POINT_SHP_PATH: default
+POUR_POINT_SHP_NAME: default
+
+# Domain representation settings
+DOMAIN_DEFINITION_METHOD: lumped
+ROUTING_DELINEATION: lumped
+
+GEOFABRIC_TYPE: TDX
+STREAM_THRESHOLD: 5000
+LUMPED_WATERSHED_METHOD: TauDEM
+CLEANUP_INTERMEDIATE_FILES: True
+DELINEATE_BY_POURPOINT: True
+MOVE_OUTLETS_MAX_DISTANCE: 200
+MIN_GRU_SIZE: 1
+
+# Domain discretization settings
+SUB_GRID_DISCRETIZATION: GRUS
+ELEVATION_BAND_SIZE: 200
+MIN_HRU_SIZE: 4
+RADIATION_CLASS_NUMBER: 5
+ASPECT_CLASS_NUMBER: 8
+ASPECT_PATH: default
+
+# Shapefile settings - Catchment shape
+CATCHMENT_PATH: default
+CATCHMENT_SHP_NAME: default
+CATCHMENT_SHP_LAT: center_lat
+CATCHMENT_SHP_LON: center_lon
+CATCHMENT_SHP_AREA: HRU_area
+CATCHMENT_SHP_HRUID: HRU_ID
+CATCHMENT_SHP_GRUID: GRU_ID
+
+# Shapefile settings - Basins shape
+RIVER_BASINS_PATH: default
+RIVER_BASINS_NAME: default
+RIVER_BASIN_SHP_RM_GRUID: GRU_ID
+RIVER_BASIN_SHP_HRU_TO_SEG: gru_to_seg
+RIVER_BASIN_SHP_AREA: GRU_area
+
+# Shapefile settings - River network shape
+RIVER_NETWORK_SHP_PATH: default
+RIVER_NETWORK_SHP_NAME: default
+RIVER_NETWORK_SHP_LENGTH: Length
+RIVER_NETWORK_SHP_SEGID: LINKNO
+RIVER_NETWORK_SHP_DOWNSEGID: DSLINKNO
+RIVER_NETWORK_SHP_SLOPE: Slope
+
+# Geospatial data paths
+OUTPUT_BASINS_PATH: default
+OUTPUT_RIVERS_PATH: default
+DEM_PATH: default
+DEM_NAME: default
+TAUDEM_DIR: default
+OUTPUT_DIR: default
+CATCHMENT_PLOT_DIR: default
+SOIL_CLASS_PATH: default
+SOIL_CLASS_NAME: default
+LAND_CLASS_PATH: default
+LAND_CLASS_NAME: default
+RADIATION_PATH: default
+
+# Tool paths
+DATATOOL_PATH: default
+GISTOOL_PATH: default
+EASYMORE_CLIENT: easymore cli
+
+### ============================================= 3. Model Agnostic settings: =============================================================
+
+# Forcing data settings
+FORCING_DATASET: ERA5
+FORCING_VARIABLES: default
+FORCING_MEASUREMENT_HEIGHT: 2
+FORCING_TIME_STEP_SIZE: 3600
+APPLY_LAPSE_RATE: True
+LAPSE_RATE: 0.0065
+FORCING_SHAPE_LAT_NAME: lat
+FORCING_SHAPE_LON_NAME: lon
+FORCING_PATH: default
+
+# Intersection paths
+INTERSECT_SOIL_PATH: default
+INTERSECT_SOIL_NAME: catchment_with_soilclass.shp
+INTERSECT_ROUTING_PATH: default
+INTERSECT_ROUTING_NAME: catchment_with_routing_basins.shp
+INTERSECT_DEM_PATH: default
+INTERSECT_DEM_NAME: catchment_with_dem.shp
+INTERSECT_LAND_PATH: default
+INTERSECT_LAND_NAME: catchment_with_landclass.shp
+
+### ============================================= 4. Model Specific settings: =============================================================
+
+# Model settings
+HYDROLOGICAL_MODEL: GR4J
+ROUTING_MODEL: none
+
+# GR settings
+SETTINGS_GR_PARAMS_TO_CALIBRATE: X1,X2,X3,X4,CTG,Kf,Gratio,Albedo_diff
+
+### ============================================= 5. Evaluation settings: =================================================================
+
+# Observation data settings
+STREAMFLOW_DATA_PROVIDER: WSC
+DOWNLOAD_WSC_DATA: True
+STATION_ID: 05BB001
+STREAMFLOW_RAW_PATH: default
+STREAMFLOW_RAW_NAME: default
+STREAMFLOW_PROCESSED_PATH: default
+
+### ============================================= 6. Optimization settings: ===============================================================
+
+OPTIMIZATION_METHODS: [iteration]
+ITERATIVE_OPTIMIZATION_ALGORITHM: DDS
+NUMBER_OF_ITERATIONS: 1000
+DDS_R: 0.2
+OPTIMIZATION_METRIC: KGE
+TARGET_METRIC: KGE
+
+### ============================================= 7. Analysis settings: ==================================================================
+
+ANALYSES: [benchmarking]

--- a/examples/paper_case_studies/configs/configs_orig/05_benchmarking/config_Bow_benchmark_era5_hbv.yaml
+++ b/examples/paper_case_studies/configs/configs_orig/05_benchmarking/config_Bow_benchmark_era5_hbv.yaml
@@ -1,0 +1,152 @@
+### ============================================= SYMFLUENCE configuration file ============================================================
+# Benchmarking Configuration for Bow at Banff - HBV variant (Section 4.5)
+# Calibrates HBV and evaluates against HydroBM statistical benchmarks.
+# Mirrors config_Bow_benchmark_era5.yaml (SUMMA) so users can reproduce
+# Figure 8's HBV point.
+### ============================================= 1. Global settings: =====================================================================
+
+# Main paths
+SYMFLUENCE_DATA_DIR: "/Users/darrieythorsson/compHydro/code/SYMFLUENCE_data/"
+SYMFLUENCE_CODE_DIR: "/Users/darrieythorsson/compHydro/code/SYMFLUENCE"
+
+# Experiment settings
+DOMAIN_NAME: Bow_at_Banff_lumped_era5
+EXPERIMENT_ID: benchmark_hbv
+EXPERIMENT_TIME_START: 2002-01-01 01:00
+EXPERIMENT_TIME_END: 2009-12-31 23:00
+CALIBRATION_PERIOD: 2004-01-01, 2007-12-31
+EVALUATION_PERIOD:  2008-01-01, 2009-12-31
+SPINUP_PERIOD: 2002-01-01, 2003-12-31
+
+# Computational settings
+MPI_PROCESSES: 1
+FORCE_RUN_ALL_STEPS: False
+
+### ============================================= 2. Geospatial settings: =================================================================
+# Coordinate settings
+POUR_POINT_COORDS: 51.1722/-115.5717
+BOUNDING_BOX_COORDS: 51.76/-116.55/50.95/-115.5
+
+# Pour point shapefile path
+POUR_POINT_SHP_PATH: default
+POUR_POINT_SHP_NAME: default
+
+# Domain representation settings
+DOMAIN_DEFINITION_METHOD: lumped
+ROUTING_DELINEATION: lumped
+
+GEOFABRIC_TYPE: TDX
+STREAM_THRESHOLD: 5000
+LUMPED_WATERSHED_METHOD: TauDEM
+CLEANUP_INTERMEDIATE_FILES: True
+DELINEATE_BY_POURPOINT: True
+MOVE_OUTLETS_MAX_DISTANCE: 200
+MIN_GRU_SIZE: 1
+
+# Domain discretization settings
+SUB_GRID_DISCRETIZATION: GRUS
+ELEVATION_BAND_SIZE: 200
+MIN_HRU_SIZE: 4
+RADIATION_CLASS_NUMBER: 5
+ASPECT_CLASS_NUMBER: 8
+ASPECT_PATH: default
+
+# Shapefile settings - Catchment shape
+CATCHMENT_PATH: default
+CATCHMENT_SHP_NAME: default
+CATCHMENT_SHP_LAT: center_lat
+CATCHMENT_SHP_LON: center_lon
+CATCHMENT_SHP_AREA: HRU_area
+CATCHMENT_SHP_HRUID: HRU_ID
+CATCHMENT_SHP_GRUID: GRU_ID
+
+# Shapefile settings - Basins shape
+RIVER_BASINS_PATH: default
+RIVER_BASINS_NAME: default
+RIVER_BASIN_SHP_RM_GRUID: GRU_ID
+RIVER_BASIN_SHP_HRU_TO_SEG: gru_to_seg
+RIVER_BASIN_SHP_AREA: GRU_area
+
+# Shapefile settings - River network shape
+RIVER_NETWORK_SHP_PATH: default
+RIVER_NETWORK_SHP_NAME: default
+RIVER_NETWORK_SHP_LENGTH: Length
+RIVER_NETWORK_SHP_SEGID: LINKNO
+RIVER_NETWORK_SHP_DOWNSEGID: DSLINKNO
+RIVER_NETWORK_SHP_SLOPE: Slope
+
+# Geospatial data paths
+OUTPUT_BASINS_PATH: default
+OUTPUT_RIVERS_PATH: default
+DEM_PATH: default
+DEM_NAME: default
+TAUDEM_DIR: default
+OUTPUT_DIR: default
+CATCHMENT_PLOT_DIR: default
+SOIL_CLASS_PATH: default
+SOIL_CLASS_NAME: default
+LAND_CLASS_PATH: default
+LAND_CLASS_NAME: default
+RADIATION_PATH: default
+
+# Tool paths
+DATATOOL_PATH: default
+GISTOOL_PATH: default
+EASYMORE_CLIENT: easymore cli
+
+### ============================================= 3. Model Agnostic settings: =============================================================
+
+# Forcing data settings
+FORCING_DATASET: ERA5
+FORCING_VARIABLES: default
+FORCING_MEASUREMENT_HEIGHT: 2
+FORCING_TIME_STEP_SIZE: 3600
+APPLY_LAPSE_RATE: True
+LAPSE_RATE: 0.0065
+FORCING_SHAPE_LAT_NAME: lat
+FORCING_SHAPE_LON_NAME: lon
+FORCING_PATH: default
+
+# Intersection paths
+INTERSECT_SOIL_PATH: default
+INTERSECT_SOIL_NAME: catchment_with_soilclass.shp
+INTERSECT_ROUTING_PATH: default
+INTERSECT_ROUTING_NAME: catchment_with_routing_basins.shp
+INTERSECT_DEM_PATH: default
+INTERSECT_DEM_NAME: catchment_with_dem.shp
+INTERSECT_LAND_PATH: default
+INTERSECT_LAND_NAME: catchment_with_landclass.shp
+
+### ============================================= 4. Model Specific settings: =============================================================
+
+# Model settings
+HYDROLOGICAL_MODEL: HBV
+ROUTING_MODEL: none
+
+# HBV settings
+HBV_BACKEND: jax
+HBV_TIMESTEP_HOURS: 24
+SETTINGS_HBV_PARAMS_TO_CALIBRATE: tt,cfmax,sfcf,cfr,cwh,fc,lp,beta,k0,k1,k2,uzl,perc,maxbas
+
+### ============================================= 5. Evaluation settings: =================================================================
+
+# Observation data settings
+STREAMFLOW_DATA_PROVIDER: WSC
+DOWNLOAD_WSC_DATA: True
+STATION_ID: 05BB001
+STREAMFLOW_RAW_PATH: default
+STREAMFLOW_RAW_NAME: default
+STREAMFLOW_PROCESSED_PATH: default
+
+### ============================================= 6. Optimization settings: ===============================================================
+
+OPTIMIZATION_METHODS: [iteration]
+ITERATIVE_OPTIMIZATION_ALGORITHM: DDS
+NUMBER_OF_ITERATIONS: 1000
+DDS_R: 0.2
+OPTIMIZATION_METRIC: KGE
+TARGET_METRIC: KGE
+
+### ============================================= 7. Analysis settings: ==================================================================
+
+ANALYSES: [benchmarking]

--- a/examples/paper_case_studies/configs/configs_orig/05_benchmarking/config_Bow_benchmark_era5_hype.yaml
+++ b/examples/paper_case_studies/configs/configs_orig/05_benchmarking/config_Bow_benchmark_era5_hype.yaml
@@ -1,0 +1,150 @@
+### ============================================= SYMFLUENCE configuration file ============================================================
+# Benchmarking Configuration for Bow at Banff - HYPE variant (Section 4.5)
+# Calibrates HYPE and evaluates against HydroBM statistical benchmarks.
+# Mirrors config_Bow_benchmark_era5.yaml (SUMMA) so users can reproduce
+# Figure 8's HYPE point.
+### ============================================= 1. Global settings: =====================================================================
+
+# Main paths
+SYMFLUENCE_DATA_DIR: "/Users/darrieythorsson/compHydro/code/SYMFLUENCE_data/"
+SYMFLUENCE_CODE_DIR: "/Users/darrieythorsson/compHydro/code/SYMFLUENCE"
+
+# Experiment settings
+DOMAIN_NAME: Bow_at_Banff_lumped_era5
+EXPERIMENT_ID: benchmark_hype
+EXPERIMENT_TIME_START: 2002-01-01 01:00
+EXPERIMENT_TIME_END: 2009-12-31 23:00
+CALIBRATION_PERIOD: 2004-01-01, 2007-12-31
+EVALUATION_PERIOD:  2008-01-01, 2009-12-31
+SPINUP_PERIOD: 2002-01-01, 2003-12-31
+
+# Computational settings
+MPI_PROCESSES: 1
+FORCE_RUN_ALL_STEPS: False
+
+### ============================================= 2. Geospatial settings: =================================================================
+# Coordinate settings
+POUR_POINT_COORDS: 51.1722/-115.5717
+BOUNDING_BOX_COORDS: 51.76/-116.55/50.95/-115.5
+
+# Pour point shapefile path
+POUR_POINT_SHP_PATH: default
+POUR_POINT_SHP_NAME: default
+
+# Domain representation settings
+DOMAIN_DEFINITION_METHOD: lumped
+ROUTING_DELINEATION: lumped
+
+GEOFABRIC_TYPE: TDX
+STREAM_THRESHOLD: 5000
+LUMPED_WATERSHED_METHOD: TauDEM
+CLEANUP_INTERMEDIATE_FILES: True
+DELINEATE_BY_POURPOINT: True
+MOVE_OUTLETS_MAX_DISTANCE: 200
+MIN_GRU_SIZE: 1
+
+# Domain discretization settings
+SUB_GRID_DISCRETIZATION: GRUS
+ELEVATION_BAND_SIZE: 200
+MIN_HRU_SIZE: 4
+RADIATION_CLASS_NUMBER: 5
+ASPECT_CLASS_NUMBER: 8
+ASPECT_PATH: default
+
+# Shapefile settings - Catchment shape
+CATCHMENT_PATH: default
+CATCHMENT_SHP_NAME: default
+CATCHMENT_SHP_LAT: center_lat
+CATCHMENT_SHP_LON: center_lon
+CATCHMENT_SHP_AREA: HRU_area
+CATCHMENT_SHP_HRUID: HRU_ID
+CATCHMENT_SHP_GRUID: GRU_ID
+
+# Shapefile settings - Basins shape
+RIVER_BASINS_PATH: default
+RIVER_BASINS_NAME: default
+RIVER_BASIN_SHP_RM_GRUID: GRU_ID
+RIVER_BASIN_SHP_HRU_TO_SEG: gru_to_seg
+RIVER_BASIN_SHP_AREA: GRU_area
+
+# Shapefile settings - River network shape
+RIVER_NETWORK_SHP_PATH: default
+RIVER_NETWORK_SHP_NAME: default
+RIVER_NETWORK_SHP_LENGTH: Length
+RIVER_NETWORK_SHP_SEGID: LINKNO
+RIVER_NETWORK_SHP_DOWNSEGID: DSLINKNO
+RIVER_NETWORK_SHP_SLOPE: Slope
+
+# Geospatial data paths
+OUTPUT_BASINS_PATH: default
+OUTPUT_RIVERS_PATH: default
+DEM_PATH: default
+DEM_NAME: default
+TAUDEM_DIR: default
+OUTPUT_DIR: default
+CATCHMENT_PLOT_DIR: default
+SOIL_CLASS_PATH: default
+SOIL_CLASS_NAME: default
+LAND_CLASS_PATH: default
+LAND_CLASS_NAME: default
+RADIATION_PATH: default
+
+# Tool paths
+DATATOOL_PATH: default
+GISTOOL_PATH: default
+EASYMORE_CLIENT: easymore cli
+
+### ============================================= 3. Model Agnostic settings: =============================================================
+
+# Forcing data settings
+FORCING_DATASET: ERA5
+FORCING_VARIABLES: default
+FORCING_MEASUREMENT_HEIGHT: 2
+FORCING_TIME_STEP_SIZE: 3600
+APPLY_LAPSE_RATE: True
+LAPSE_RATE: 0.0065
+FORCING_SHAPE_LAT_NAME: lat
+FORCING_SHAPE_LON_NAME: lon
+FORCING_PATH: default
+
+# Intersection paths
+INTERSECT_SOIL_PATH: default
+INTERSECT_SOIL_NAME: catchment_with_soilclass.shp
+INTERSECT_ROUTING_PATH: default
+INTERSECT_ROUTING_NAME: catchment_with_routing_basins.shp
+INTERSECT_DEM_PATH: default
+INTERSECT_DEM_NAME: catchment_with_dem.shp
+INTERSECT_LAND_PATH: default
+INTERSECT_LAND_NAME: catchment_with_landclass.shp
+
+### ============================================= 4. Model Specific settings: =============================================================
+
+# Model settings
+HYDROLOGICAL_MODEL: HYPE
+ROUTING_MODEL: none
+
+# HYPE settings
+SETTINGS_HYPE_PARAMS_TO_CALIBRATE: ttmp,cmlt,cevp,lp,epotdist,rrcs1,rrcs2,rcgrw,rivvel,damp,wcwp,wcfc,wcep,srrcs
+
+### ============================================= 5. Evaluation settings: =================================================================
+
+# Observation data settings
+STREAMFLOW_DATA_PROVIDER: WSC
+DOWNLOAD_WSC_DATA: True
+STATION_ID: 05BB001
+STREAMFLOW_RAW_PATH: default
+STREAMFLOW_RAW_NAME: default
+STREAMFLOW_PROCESSED_PATH: default
+
+### ============================================= 6. Optimization settings: ===============================================================
+
+OPTIMIZATION_METHODS: [iteration]
+ITERATIVE_OPTIMIZATION_ALGORITHM: DDS
+NUMBER_OF_ITERATIONS: 1000
+DDS_R: 0.2
+OPTIMIZATION_METRIC: KGE
+TARGET_METRIC: KGE
+
+### ============================================= 7. Analysis settings: ==================================================================
+
+ANALYSES: [benchmarking]

--- a/src/symfluence/cli/services/system_diagnostics.py
+++ b/src/symfluence/cli/services/system_diagnostics.py
@@ -8,7 +8,6 @@ Provides system health checks, toolchain information, and library detection.
 """
 
 import json
-import os
 import shutil
 import subprocess
 import sys
@@ -148,13 +147,36 @@ class SystemDiagnostics(BaseService):
 
     def get_tools_info(self) -> bool:
         """
-        Display installed tools information from toolchain metadata.
+        Display installed tools information: binary status and toolchain metadata.
 
         Returns:
-            True if tools info was displayed, False if no metadata found.
+            True if at least one binary was found, False otherwise.
         """
-        symfluence_data = os.getenv("SYMFLUENCE_DATA")
+        config = self._load_config()
+        symfluence_data = str(self._get_data_dir(config))
         npm_bin_dir = self.detect_npm_binaries()
+
+        if npm_bin_dir:
+            self._console.info(f"npm binaries: {npm_bin_dir}")
+        if symfluence_data:
+            self._console.info(f"Source installs: {symfluence_data}")
+
+        binary_rows = self._check_binary_status(symfluence_data, npm_bin_dir)
+        found = sum(1 for row in binary_rows if "[green]OK[/green]" in row[1])
+        total = len(binary_rows)
+
+        if binary_rows:
+            self._console.newline()
+            self._console.table(
+                columns=["Tool", "Status", "Location"],
+                rows=binary_rows,
+                title="Binary Status",
+            )
+            self._console.newline()
+            self._console.info(f"Binaries: {found}/{total} found")
+        else:
+            self._console.newline()
+            self._console.warning("No binaries found.")
 
         toolchain_locations = []
         if symfluence_data:
@@ -170,18 +192,18 @@ class SystemDiagnostics(BaseService):
                 toolchain_path = path
                 break
 
-        if not toolchain_path:
-            self._console.warning("No binaries installed yet.")
+        if toolchain_path:
             self._console.newline()
-            self._console.info("Model binaries (SUMMA, mizuRoute, FUSE, etc.) must be installed")
-            self._console.info("before 'symfluence binary info' can report on them.")
+            self._read_toolchain_metadata(toolchain_path)
+
+        if found == 0:
             self._console.newline()
             self._console.indent("Install binaries with one of:")
             self._console.indent("  npm install -g symfluence        # pre-built binaries")
             self._console.indent("  symfluence binary install         # build from source")
             return False
 
-        return self._read_toolchain_metadata(toolchain_path)
+        return True
 
     def detect_npm_binaries(self) -> Optional[Path]:
         """

--- a/src/symfluence/optimization/optimization_manager.py
+++ b/src/symfluence/optimization/optimization_manager.py
@@ -295,8 +295,11 @@ class OptimizationManager(BaseManager):
             # Multi-gauge calibration always needs the external worker because
             # FUSE-internal SCE is single-basin only.
             if 'FUSE' in hydrological_models:
-                fuse_cfg = self.config.model.fuse if self.config.model else None
-                use_internal = fuse_cfg.run_internal_calibration if fuse_cfg else True
+                use_internal = self._get_config_value(
+                    lambda: self.config.model.fuse.run_internal_calibration,
+                    default=True,
+                    dict_key='FUSE_RUN_INTERNAL_CALIBRATION'
+                )
                 multi_gauge = self._get_config_value(
                     lambda: self.config.calibration.multi_gauge,
                     default=False,


### PR DESCRIPTION
## Summary
- **FUSE external calibration flat-key gap**: `FUSE_RUN_INTERNAL_CALIBRATION: false` set as a flat key was silently ignored because the typed config (`config.model.fuse`) was `None`. Now uses `_get_config_value` with `dict_key` fallback so both nested and flat-key configs are honoured.
- **`symfluence binary info` improvement**: Now shows the full binary status table (found/missing with paths) instead of only toolchain metadata or a vague error when no metadata exists.
- **Benchmark flat configs**: Added FUSE, HBV, GR4J, HYPE flat-format configs to `configs_orig/05_benchmarking/` to match the nested variants.
- **Gitignore cleanup**: Replaced four individual `domain_*` entries with a single `domain_*/` glob; removed accidental `domain_domain/` artifact.

## Test plan
- [x] 322 optimization unit tests pass
- [x] 222 CLI/evaluation tests pass
- [x] `symfluence binary info` verified — shows binary table + toolchain metadata
- [x] Pre-commit hooks (ruff, mypy, bandit) pass on all commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)