### PR TITLE
feat(attributes): wire profile-driven attribute processing into workflow

### DIFF
--- a/examples/camels_spat_attributes/config_camels_spat_north_america.yaml
+++ b/examples/camels_spat_attributes/config_camels_spat_north_america.yaml
@@ -1,0 +1,146 @@
+################################################################################
+#
+#  CAMELS-SPAT Attribute Acquisition — Bow at Banff (test domain)
+#
+#  Acquires geospatial attribute data matching the CAMELS-SPAT dataset
+#  (Knoben et al., 2025, HESS).  Uses the Bow at Banff catchment as a
+#  small test domain before scaling to continental North America.
+#
+#  CAMELS-SPAT uses 11 geospatial datasets across 5 categories.
+#  SYMFLUENCE supports 10 of 11 natively via ATTRIBUTE_PROFILE: camels_spat
+#  (LGRIP30 agriculture is not yet integrated).
+#
+#  The profile acquires:
+#    Core (always):  Copernicus DEM, SoilGrids WRB soil class, MODIS IGBP
+#    Extended:       WorldClim 2.1, SoilGrids properties (6 depths),
+#                    Pelletier soil/regolith depth, GLHYMPS hydrogeology,
+#                    HydroLAKES, MODIS LAI, GLAD forest height, GLCLU 2019
+#
+#  Workflow:
+#    symfluence workflow step setup_project -c <this_file>
+#    symfluence workflow step acquire_attributes
+#
+#  To scale to full North America, change:
+#    DOMAIN_NAME: CAMELS_SPAT_North_America
+#    BOUNDING_BOX_COORDS: 66.0/-141.0/24.0/-52.0
+#    DOMAIN_DEFINITION_METHOD: distributed
+#    GRID_SOURCE: native
+#    NATIVE_GRID_DATASET: era5
+#    (~170 GB of data)
+#
+################################################################################
+
+
+# =============================================================================
+# 1. System Settings
+# =============================================================================
+
+SYMFLUENCE_DATA_DIR: /Users/darri.eythorsson/compHydro/SYMFLUENCE_data
+SYMFLUENCE_CODE_DIR: /Users/darri.eythorsson/compHydro/SYMFLUENCE
+NUM_PROCESSES: 1
+DEBUG_MODE: false
+LOG_LEVEL: INFO
+LOG_TO_FILE: true
+LOG_FORMAT: detailed
+FORCE_RUN_ALL_STEPS: false
+USE_LOCAL_SCRATCH: false
+STOP_ON_ERROR: true
+RECORD_PROVENANCE: true
+
+
+# =============================================================================
+# 2. Domain Definition — Bow at Banff (test domain)
+# =============================================================================
+
+DOMAIN_NAME: Bow_at_Banff_camels_spat
+EXPERIMENT_ID: camels_spat_attributes
+DOMAIN_DEFINITION_METHOD: lumped
+SUB_GRID_DISCRETIZATION: GRUs
+POUR_POINT_COORDS: 51.1722/-115.5717
+BOUNDING_BOX_COORDS: 51.76/-116.55/50.95/-115.5
+
+EXPERIMENT_TIME_START: 2000-01-01 01:00
+EXPERIMENT_TIME_END: 2020-12-31 23:00
+
+
+# =============================================================================
+# 3. Attribute Acquisition
+# =============================================================================
+
+DATA_ACCESS: cloud
+FORCE_DOWNLOAD: false
+MAX_ACQUISITION_WORKERS: 3
+
+# --- Attribute profile ---
+# 'core'        = DEM + soil class + land cover only (default)
+# 'camels_spat' = core + WorldClim + SoilGrids properties + Pelletier +
+#                 GLHYMPS + HydroLAKES + MODIS LAI + forest height + GLCLU
+ATTRIBUTE_PROFILE: camels_spat
+
+# --- Core datasets (always acquired) ---
+DOWNLOAD_DEM: true
+DEM_SOURCE: copdem90
+DOWNLOAD_SOIL: true
+SOILGRIDS_LAYER: wrb_0-5cm_mode
+DOWNLOAD_LAND_COVER: true
+LAND_CLASS_SOURCE: modis
+
+# --- Individual overrides (uncomment to skip specific datasets) ---
+# DOWNLOAD_WORLDCLIM: false
+# DOWNLOAD_SOILGRIDS_PROPERTIES: false
+# DOWNLOAD_PELLETIER: false
+# DOWNLOAD_GLHYMPS: false
+# DOWNLOAD_HYDROLAKES: false
+# DOWNLOAD_MODIS_LAI: false
+# DOWNLOAD_FOREST_HEIGHT: false
+# DOWNLOAD_GLCLU: false
+
+
+# =============================================================================
+# 4. Attribute Data Paths (default = standard project layout)
+# =============================================================================
+
+ATTRIBUTES_DATA_DIR: default
+ATTRIBUTES_OUTPUT_DIR: default
+ATTRIBUTES_WORLDCLIM_PATH: default
+ATTRIBUTES_SOILGRIDS_PATH: default
+ATTRIBUTES_PELLETIER_PATH: default
+ATTRIBUTES_MERIT_PATH: default
+ATTRIBUTES_MODIS_PATH: default
+ATTRIBUTES_GLCLU_PATH: default
+ATTRIBUTES_FOREST_HEIGHT_PATH: default
+ATTRIBUTES_GLIM_PATH: default
+ATTRIBUTES_HYDROLAKES_PATH: default
+
+
+# =============================================================================
+# 5. Processing
+# =============================================================================
+
+DEM_CONDITIONING_METHOD: none
+BUILD_MODEL_READY_STORE: true
+MODEL_READY_FORCING_STRATEGY: symlink
+
+
+# =============================================================================
+# 6. Forcing (minimal — for framework compatibility)
+# =============================================================================
+
+FORCING_DATASET: ERA5
+
+
+# =============================================================================
+# 7. Observation & Evaluation (disabled — attributes only)
+# =============================================================================
+
+DOWNLOAD_USGS_DATA: false
+DOWNLOAD_WSC_DATA: false
+DOWNLOAD_ISMN: false
+DOWNLOAD_GRACE: false
+DOWNLOAD_MODIS_SNOW: false
+DOWNLOAD_MODIS_ET: false
+DOWNLOAD_FLUXNET: false
+DOWNLOAD_SNOTEL: false
+DOWNLOAD_GLACIER_DATA: false
+DOWNLOAD_LAMAH_ICE_DATA: false
+DOWNLOAD_SMAP: false

--- a/src/symfluence/core/config/models/domain.py
+++ b/src/symfluence/core/config/models/domain.py
@@ -169,6 +169,24 @@ class DomainConfig(BaseModel):
     land_class_name: str = Field(default='default', alias='LAND_CLASS_NAME')
     soilgrids_layer: str = Field(default='wrb_0-5cm_mode', alias='SOILGRIDS_LAYER')
 
+    # Attribute acquisition profile ('core' or 'camels_spat')
+    attribute_profile: str = Field(default='core', alias='ATTRIBUTE_PROFILE')
+
+    @field_validator('attribute_profile', mode='before')
+    @classmethod
+    def normalize_attribute_profile(cls, v):
+        """Validate attribute profile name."""
+        if not isinstance(v, str):
+            return v
+        v = v.lower().strip()
+        from symfluence.data.acquisition.attribute_profiles import PROFILES
+        if v not in PROFILES:
+            valid = ', '.join(sorted(PROFILES.keys()))
+            raise ValueError(
+                f"ATTRIBUTE_PROFILE must be one of [{valid}], got '{v}'"
+            )
+        return v
+
     @field_validator('min_gru_size', 'min_hru_size', 'elevation_band_size')
     @classmethod
     def validate_positive_thresholds(cls, v, info):

--- a/src/symfluence/data/acquisition/acquisition_service.py
+++ b/src/symfluence/data/acquisition/acquisition_service.py
@@ -476,7 +476,7 @@ class AcquisitionService(ConfigurableMixin):
                     self.logger.info("Skipping land cover acquisition (DOWNLOAD_LAND_COVER is False)")
 
                 # --- Glacier task (optional, failure is non-fatal) ---
-                if self._get_config_value(lambda: self.config.data.download_glacier_data, default=False):
+                if self._get_config_value(lambda: self.config.data.download_glacier_data, default=False, dict_key='DOWNLOAD_GLACIER_DATA'):
                     attr_tasks.append(('glacier', downloader.download_glacier_data))
 
                 # Run attribute downloads concurrently

--- a/src/symfluence/data/acquisition/acquisition_service.py
+++ b/src/symfluence/data/acquisition/acquisition_service.py
@@ -126,6 +126,7 @@ from symfluence.core.mixins import ConfigurableMixin
 from symfluence.core.mixins.project import resolve_data_subdir
 from symfluence.data.acquisition.cloud_downloader import CloudForcingDownloader, check_cloud_access_availability
 from symfluence.data.acquisition.maf_pipeline import datatoolRunner, gistoolRunner
+from symfluence.data.acquisition.registry import AcquisitionRegistry
 from symfluence.data.cache import RawForcingCache
 from symfluence.data.utils.variable_utils import VariableHandler
 from symfluence.geospatial.raster_utils import calculate_landcover_mode
@@ -513,6 +514,8 @@ class AcquisitionService(ConfigurableMixin):
                 self.logger.error(f"Error during cloud attribute acquisition: {e}")
                 raise
 
+            self._acquire_profile_datasets()
+
         else:
             self.logger.info("Using traditional MAF attribute acquisition workflow")
             gr = gistoolRunner(self.config, self.logger)
@@ -551,6 +554,90 @@ class AcquisitionService(ConfigurableMixin):
             except (ImportError, AttributeError, IndexError) as e:
                 self.logger.error(f"Error during attribute acquisition: {e}")
                 raise
+
+            self._acquire_profile_datasets()
+
+    def _acquire_profile_datasets(self):
+        """Acquire extended datasets based on ATTRIBUTE_PROFILE config.
+
+        Reads the profile name from config and downloads all datasets
+        listed in the profile that haven't been individually disabled
+        via DOWNLOAD_* override flags.  Failures are non-fatal by
+        default (warns and continues).
+        """
+        from symfluence.data.acquisition.attribute_profiles import PROFILES
+
+        profile_name = self._get_config_value(
+            lambda: self.config.domain.attribute_profile,
+            default='core',
+            dict_key='ATTRIBUTE_PROFILE',
+        )
+        if isinstance(profile_name, str):
+            profile_name = profile_name.lower().strip()
+
+        profile_datasets = PROFILES.get(profile_name, [])
+        if not profile_datasets:
+            return
+
+        self.logger.info(
+            f"Attribute profile '{profile_name}': "
+            f"{len(profile_datasets)} extended datasets to acquire"
+        )
+
+        tasks: List[Tuple[str, Callable]] = []
+        for ds in profile_datasets:
+            if ds.config_override_key:
+                override = self._get_config_value(
+                    lambda: None,
+                    default=True,
+                    dict_key=ds.config_override_key,
+                )
+                if isinstance(override, str):
+                    override = override.lower() not in ('false', '0', 'no')
+                if not override:
+                    self.logger.info(
+                        f"Skipping {ds.description} "
+                        f"({ds.config_override_key} is False)"
+                    )
+                    continue
+
+            def _make_task(dataset=ds):
+                handler = AcquisitionRegistry.get_handler(
+                    dataset.handler_name, self.config, self.logger,
+                )
+                out_dir = (
+                    resolve_data_subdir(self.project_dir, 'attributes')
+                    / dataset.output_subdir
+                )
+                out_dir.mkdir(parents=True, exist_ok=True)
+                return handler.download(out_dir)
+
+            tasks.append((ds.description, _make_task))
+
+        if not tasks:
+            return
+
+        results = self._run_parallel_tasks(
+            tasks, desc=f"Acquiring '{profile_name}' profile datasets",
+        )
+
+        for name, result in results.items():
+            if isinstance(result, Exception):
+                ds_info = next(
+                    (d for d in profile_datasets if d.description == name),
+                    None,
+                )
+                if ds_info and ds_info.fatal:
+                    self.logger.error(
+                        f"Required profile dataset failed: {name}: {result}"
+                    )
+                    raise result
+                self.logger.warning(
+                    f"Optional profile dataset failed (non-fatal): "
+                    f"{name}: {result}"
+                )
+            else:
+                self.logger.info(f"Profile dataset acquired: {name}")
 
     def _acquire_elevation_data(self, gistool_runner, output_dir: Path, lat_lims: str, lon_lims: str):
         self.logger.info("Acquiring elevation data")

--- a/src/symfluence/data/acquisition/attribute_profiles.py
+++ b/src/symfluence/data/acquisition/attribute_profiles.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""
+Attribute acquisition profiles for SYMFLUENCE.
+
+Profiles define which geospatial datasets are acquired by the
+acquire_attributes workflow step beyond the core three (DEM, soil class,
+land cover).  The ``ATTRIBUTE_PROFILE`` config flag selects a profile;
+individual ``DOWNLOAD_*`` flags can override datasets within it.
+
+Available profiles:
+
+core
+    Default.  No extended datasets — only DEM, soil class, and land cover
+    (handled by the existing ``acquire_attributes`` logic).
+
+camels_spat
+    All 11 geospatial datasets from the CAMELS-SPAT dataset (Knoben
+    et al., 2025, HESS).  Adds WorldClim climate normals, SoilGrids
+    soil properties at 6 depths, Pelletier soil/regolith depth, GLHYMPS
+    hydrogeology, HydroLAKES open water, MODIS LAI, forest canopy
+    height, and GLCLU 2019 land cover.
+
+full
+    Everything in ``camels_spat`` plus every additional geospatial
+    attribute handler available in SYMFLUENCE: glaciers (RGI), GLWD
+    wetlands, depth to bedrock, aridity index, MODIS NDVI, root-zone
+    storage capacity, JRC Global Surface Water, karst aquifer map
+    (WOKAM), and MERIT Hydro river network attributes.
+
+References
+----------
+Knoben, W. J. M., et al. (2025). Catchment Attributes and MEteorology
+for Large-Sample SPATially distributed analysis (CAMELS-SPAT). Hydrol.
+Earth Syst. Sci., 29, 5791-5833.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class ProfileDataset:
+    """A single dataset within an attribute profile.
+
+    Parameters
+    ----------
+    handler_name
+        Key in ``AcquisitionRegistry`` (case-insensitive).
+    description
+        Human-readable label for log messages.
+    output_subdir
+        Subdirectory under ``{project_dir}/attributes/`` where the
+        handler should write its output.
+    config_override_key
+        Optional flat config key (e.g. ``DOWNLOAD_WORLDCLIM``).  When
+        set to ``False`` in the user's config, this dataset is skipped
+        even if the profile includes it.
+    fatal
+        If ``True``, acquisition failure raises an exception.
+        If ``False`` (default), failure logs a warning and continues.
+    """
+
+    handler_name: str
+    description: str
+    output_subdir: str
+    config_override_key: Optional[str] = None
+    fatal: bool = False
+
+
+_CORE_DATASETS: List[ProfileDataset] = []
+
+_CAMELS_SPAT_DATASETS: List[ProfileDataset] = [
+    ProfileDataset(
+        handler_name='SOILGRIDS_PROPERTIES',
+        description='SoilGrids v2.0 soil properties (6 depths)',
+        output_subdir='soilclass/soilgrids',
+        config_override_key='DOWNLOAD_SOILGRIDS_PROPERTIES',
+    ),
+    ProfileDataset(
+        handler_name='PELLETIER',
+        description='Pelletier soil/regolith depth',
+        output_subdir='soilclass/pelletier',
+        config_override_key='DOWNLOAD_PELLETIER',
+    ),
+    ProfileDataset(
+        handler_name='GLHYMPS',
+        description='GLHYMPS v2 hydrogeology (permeability, porosity)',
+        output_subdir='geology/glhymps',
+        config_override_key='DOWNLOAD_GLHYMPS',
+    ),
+    ProfileDataset(
+        handler_name='HYDROLAKES',
+        description='HydroLAKES v1.0 open water',
+        output_subdir='lakes',
+        config_override_key='DOWNLOAD_HYDROLAKES',
+    ),
+    ProfileDataset(
+        handler_name='MODIS_LAI',
+        description='MODIS MCD15A2H LAI/FPAR (8-day, 500m)',
+        output_subdir='vegetation/modis_lai',
+        config_override_key='DOWNLOAD_MODIS_LAI',
+    ),
+    ProfileDataset(
+        handler_name='GLAD_TREE_HEIGHT',
+        description='GLAD/GLCLUC forest canopy height',
+        output_subdir='vegetation/canopy_height/glad',
+        config_override_key='DOWNLOAD_FOREST_HEIGHT',
+    ),
+    ProfileDataset(
+        handler_name='WORLDCLIM',
+        description='WorldClim 2.1 monthly climate normals (30 arcsec)',
+        output_subdir='climate/worldclim',
+        config_override_key='DOWNLOAD_WORLDCLIM',
+    ),
+    ProfileDataset(
+        handler_name='GLCLU_2019',
+        description='GLAD GLCLU 2019 land cover/land use (30m)',
+        output_subdir='landclass/glclu',
+        config_override_key='DOWNLOAD_GLCLU',
+    ),
+]
+
+_FULL_EXTRA_DATASETS: List[ProfileDataset] = [
+    ProfileDataset(
+        handler_name='GLACIER',
+        description='Randolph Glacier Inventory (RGI)',
+        output_subdir='glaciers',
+        config_override_key='DOWNLOAD_GLACIER_DATA',
+    ),
+    ProfileDataset(
+        handler_name='GLWD',
+        description='GLWD v2 global lakes and wetlands',
+        output_subdir='water/glwd',
+        config_override_key='DOWNLOAD_GLWD',
+    ),
+    ProfileDataset(
+        handler_name='BEDROCK_DEPTH',
+        description='SoilGrids depth to bedrock (BDTICM)',
+        output_subdir='soilclass/bedrock',
+        config_override_key='DOWNLOAD_BEDROCK_DEPTH',
+    ),
+    ProfileDataset(
+        handler_name='ARIDITY_INDEX',
+        description='CGIAR Global Aridity Index and PET',
+        output_subdir='climate/aridity',
+        config_override_key='DOWNLOAD_ARIDITY_INDEX',
+    ),
+    ProfileDataset(
+        handler_name='MODIS_NDVI',
+        description='MODIS NDVI/EVI vegetation index',
+        output_subdir='landcover/modis_ndvi',
+        config_override_key='DOWNLOAD_MODIS_NDVI',
+    ),
+    ProfileDataset(
+        handler_name='ROOT_ZONE_STORAGE',
+        description='Root-zone storage capacity',
+        output_subdir='soilclass/root_zone',
+        config_override_key='DOWNLOAD_ROOT_ZONE_STORAGE',
+    ),
+    ProfileDataset(
+        handler_name='JRC_WATER',
+        description='JRC Global Surface Water occurrence/extent',
+        output_subdir='water/jrc',
+        config_override_key='DOWNLOAD_JRC_WATER',
+    ),
+    ProfileDataset(
+        handler_name='WOKAM',
+        description='World Karst Aquifer Map (WOKAM)',
+        output_subdir='geology/karst',
+        config_override_key='DOWNLOAD_WOKAM',
+    ),
+    ProfileDataset(
+        handler_name='MERIT_HYDRO',
+        description='MERIT Hydro river network (elv, dir, upa)',
+        output_subdir='elevation/merit_hydro',
+        config_override_key='DOWNLOAD_MERIT_HYDRO',
+    ),
+]
+
+_FULL_DATASETS = _CAMELS_SPAT_DATASETS + _FULL_EXTRA_DATASETS
+
+PROFILES: Dict[str, List[ProfileDataset]] = {
+    'core': _CORE_DATASETS,
+    'camels_spat': _CAMELS_SPAT_DATASETS,
+    'full': _FULL_DATASETS,
+}

--- a/src/symfluence/data/acquisition/handlers/__init__.py
+++ b/src/symfluence/data/acquisition/handlers/__init__.py
@@ -83,6 +83,9 @@ _handler_modules = [
     'wokam',
     # NWM retrospective
     'nwm3_retrospective',
+    # CAMELS-SPAT profile handlers
+    'worldclim',
+    'glclu',
 ]
 
 for _module_name in _handler_modules:

--- a/src/symfluence/data/acquisition/handlers/glclu.py
+++ b/src/symfluence/data/acquisition/handlers/glclu.py
@@ -1,0 +1,279 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""
+GLCLU 2020 Land Cover / Land Use Acquisition Handler
+
+Cloud-based acquisition of the Global Land Cover and Land Use (GLCLU)
+dataset from the GLAD laboratory at the University of Maryland.
+
+Available layers (each as 10°×10° tiles at 30 m):
+    Forest_extent_2020      — binary forest mask
+    Forest_height_2020      — canopy height (m)
+    Forest_extent_2000      — baseline forest mask
+    Forest_height_2000      — baseline canopy height
+    Built-up_change_2000_2020 — urban expansion
+    Snow-Ice_2020           — permanent snow/ice mask
+
+Data Source:
+    https://glad.umd.edu/users/Potapov/GLCLUC2020/
+    Licensed under CC-BY 4.0
+
+Tile naming:
+    {NN}N_{NNN}W.tif  (lower-left corner of 10° tile)
+    Example: 50N_120W.tif covers 50-60°N, 120-110°W
+
+References:
+    Hansen, M.C., et al. (2022). Global land use extent and dispersion
+    within natural land cover using Landsat data. Environ. Res. Lett.,
+    17, 034050.
+"""
+
+import math
+from pathlib import Path
+from typing import List, Optional
+
+import rasterio
+from rasterio.merge import merge as rio_merge
+from rasterio.windows import from_bounds
+
+from ..base import BaseAcquisitionHandler
+from ..mixins import RetryMixin
+from ..registry import AcquisitionRegistry
+from ..utils import create_robust_session
+
+_BASE_URL = "https://glad.umd.edu/users/Potapov/GLCLUC2020"
+
+_LAYERS = {
+    'forest_extent_2020': 'Forest_extent_2020',
+    'forest_height_2020': 'Forest_height_2020',
+    'forest_extent_2000': 'Forest_extent_2000',
+    'forest_height_2000': 'Forest_height_2000',
+    'built_up_change': 'Built-up_change_2000_2020',
+    'snow_ice_2020': 'Snow-Ice_2020',
+}
+
+_DEFAULT_LAYERS = ['forest_extent_2020']
+
+
+@AcquisitionRegistry.register('GLCLU_2019')
+@AcquisitionRegistry.register('GLCLU')
+class GLCLUAcquirer(BaseAcquisitionHandler, RetryMixin):
+    """
+    GLAD GLCLU 2020 land cover acquisition.
+
+    Downloads 10°×10° tiles from UMD, mosaics them, and clips to the
+    domain bounding box.
+
+    Output:
+        {project_dir}/attributes/landclass/glclu/
+            domain_{name}_glclu_{layer}.tif
+    """
+
+    def download(self, output_dir: Path) -> Path:
+        glclu_dir = self._attribute_dir("landclass") / "glclu"
+        glclu_dir.mkdir(parents=True, exist_ok=True)
+
+        layers = self._get_config_value(
+            lambda: None,
+            default=_DEFAULT_LAYERS,
+            dict_key='GLCLU_LAYERS',
+        )
+        if isinstance(layers, str):
+            layers = [layers]
+        layers = [l for l in layers if l in _LAYERS]
+        if not layers:
+            layers = _DEFAULT_LAYERS
+
+        session = create_robust_session(max_retries=5, backoff_factor=2.0)
+        cache_dir = glclu_dir / "cache"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+
+        for layer_key in layers:
+            layer_subdir = _LAYERS[layer_key]
+            output_file = (
+                glclu_dir / f"domain_{self.domain_name}_glclu_{layer_key}.tif"
+            )
+
+            if self._skip_if_exists(output_file):
+                continue
+
+            self.logger.info(
+                f"Acquiring GLCLU {layer_key} for bbox: {self.bbox}"
+            )
+
+            tile_paths = self._download_layer_tiles(
+                session, layer_subdir, cache_dir
+            )
+
+            if not tile_paths:
+                self.logger.warning(
+                    f"No GLCLU {layer_key} tiles found for bbox"
+                )
+                continue
+
+            if len(tile_paths) == 1:
+                self._subset_to_bbox(tile_paths[0], output_file)
+            else:
+                self._merge_and_clip(tile_paths, output_file)
+
+            self.logger.info(f"GLCLU {layer_key}: {output_file}")
+
+        return glclu_dir
+
+    def _download_layer_tiles(
+        self, session, layer_subdir: str, cache_dir: Path
+    ) -> List[Path]:
+        """Download all tiles for a layer that intersect the bbox."""
+        lat_min = self._snap_to_grid(self.bbox['lat_min'], 10, 'floor')
+        lat_max = self._snap_to_grid(self.bbox['lat_max'], 10, 'ceil')
+        lon_min = self._snap_to_grid(self.bbox['lon_min'], 10, 'floor')
+        lon_max = self._snap_to_grid(self.bbox['lon_max'], 10, 'ceil')
+
+        tile_paths: List[Path] = []
+        layer_cache = cache_dir / layer_subdir
+        layer_cache.mkdir(parents=True, exist_ok=True)
+
+        for lat in range(lat_min, lat_max, 10):
+            for lon in range(lon_min, lon_max, 10):
+                tile_path = self._download_tile(
+                    session, lat, lon, layer_subdir, layer_cache
+                )
+                if tile_path:
+                    tile_paths.append(tile_path)
+
+        return tile_paths
+
+    def _snap_to_grid(
+        self, value: float, grid_size: int, mode: str
+    ) -> int:
+        if mode == 'floor':
+            return int(math.floor(value / grid_size) * grid_size)
+        return int(math.ceil(value / grid_size) * grid_size)
+
+    def _tile_name(self, lat: int, lon: int, layer_subdir: str) -> str:
+        """Generate the tile filename.
+
+        GLAD tiles are named by the *top* edge of the tile, not the
+        lower-left corner.  A tile labeled ``50N_120W`` covers
+        40-50°N, 120-110°W.  So for a grid cell starting at lat=50,
+        we need the tile labeled (lat+10)N.
+        """
+        tile_lat = lat + 10
+        lat_str = f"{abs(tile_lat):02d}N" if tile_lat >= 0 else f"{abs(tile_lat):02d}S"
+        lon_str = f"{abs(lon):03d}E" if lon >= 0 else f"{abs(lon):03d}W"
+
+        prefix = ""
+        if "height_2020" in layer_subdir.lower():
+            prefix = "2020_"
+        elif "height_2000" in layer_subdir.lower():
+            prefix = "2000_"
+        elif "change" in layer_subdir.lower():
+            prefix = "Change_"
+
+        return f"{prefix}{lat_str}_{lon_str}.tif"
+
+    def _download_tile(
+        self, session, lat: int, lon: int,
+        layer_subdir: str, cache_dir: Path,
+    ) -> Optional[Path]:
+        tile_name = self._tile_name(lat, lon, layer_subdir)
+        url = f"{_BASE_URL}/{layer_subdir}/{tile_name}"
+        local_tile = cache_dir / tile_name
+
+        if local_tile.exists() and local_tile.stat().st_size > 1000:
+            return local_tile
+
+        self.logger.info(f"  Fetching GLCLU tile: {tile_name}")
+
+        def do_download():
+            with session.get(
+                url, stream=True, timeout=600, allow_redirects=True
+            ) as r:
+                if r.status_code == 200:
+                    with open(local_tile, 'wb') as f:
+                        for chunk in r.iter_content(chunk_size=65536):
+                            if chunk:
+                                f.write(chunk)
+                    return local_tile
+                elif r.status_code == 404:
+                    self.logger.info(
+                        f"  GLCLU tile {tile_name} not available"
+                    )
+                    return None
+                else:
+                    raise IOError(f"HTTP {r.status_code} for {tile_name}")
+
+        try:
+            return self.execute_with_retry(
+                do_download,
+                max_retries=3,
+                base_delay=2,
+                backoff_factor=2.0,
+                retryable_exceptions=(IOError, ConnectionError, OSError),
+            )
+        except (OSError, IOError, RuntimeError) as e:
+            self.logger.warning(f"  Failed to download {tile_name}: {e}")
+            if local_tile.exists():
+                local_tile.unlink()
+            return None
+
+    def _subset_to_bbox(self, src_path: Path, dst_path: Path):
+        with rasterio.open(src_path) as src:
+            # Clamp bbox to tile bounds to avoid empty intersections
+            tb = src.bounds
+            clamp_lon_min = max(self.bbox['lon_min'], tb.left)
+            clamp_lat_min = max(self.bbox['lat_min'], tb.bottom)
+            clamp_lon_max = min(self.bbox['lon_max'], tb.right)
+            clamp_lat_max = min(self.bbox['lat_max'], tb.top)
+
+            if clamp_lon_min >= clamp_lon_max or clamp_lat_min >= clamp_lat_max:
+                raise ValueError(
+                    f"Bbox does not overlap tile {src_path.name}"
+                )
+
+            window = from_bounds(
+                clamp_lon_min, clamp_lat_min,
+                clamp_lon_max, clamp_lat_max,
+                transform=src.transform,
+            )
+
+            data = src.read(1, window=window)
+            transform = src.window_transform(window)
+
+            meta = src.meta.copy()
+            meta.update({
+                'height': data.shape[0],
+                'width': data.shape[1],
+                'transform': transform,
+                'compress': 'lzw',
+            })
+
+            with rasterio.open(dst_path, 'w', **meta) as dst:
+                dst.write(data, 1)
+
+    def _merge_and_clip(
+        self, tile_paths: List[Path], output_file: Path
+    ):
+        self.logger.info(f"  Merging {len(tile_paths)} GLCLU tiles")
+
+        src_files = [rasterio.open(p) for p in tile_paths]
+        try:
+            mosaic, out_trans = rio_merge(src_files)
+            meta = src_files[0].meta.copy()
+            meta.update({
+                'height': mosaic.shape[1],
+                'width': mosaic.shape[2],
+                'transform': out_trans,
+                'compress': 'lzw',
+            })
+
+            tmp_merged = output_file.parent / f"_merged_{output_file.name}"
+            with rasterio.open(tmp_merged, 'w', **meta) as dst:
+                dst.write(mosaic)
+        finally:
+            for src in src_files:
+                src.close()
+
+        self._subset_to_bbox(tmp_merged, output_file)
+        tmp_merged.unlink(missing_ok=True)

--- a/src/symfluence/data/acquisition/handlers/glhymps.py
+++ b/src/symfluence/data/acquisition/handlers/glhymps.py
@@ -35,11 +35,21 @@ from ..base import BaseAcquisitionHandler
 from ..registry import AcquisitionRegistry
 from ..utils import create_robust_session, download_file_streaming
 
-# GLHYMPS 2.0 download URLs (Borealis Data)
-_GLHYMPS_URLS = {
-    '2.0': 'https://borealisdata.ca/api/access/datafile/71909',  # GLHYMPS.zip (2.4 GB)
-    '1.0': 'https://borealisdata.ca/api/access/datafile/72026',  # GLHYMPS.zip (1.1 GB)
-}
+# GLHYMPS download sources — tried in order until one succeeds
+_GLHYMPS_SOURCES = [
+    {
+        'name': 'Borealis Data (primary)',
+        'url': 'https://borealisdata.ca/api/access/datafile/71909',
+        'size_hint': '~2.4 GB',
+        'format': 'shapefile',
+    },
+]
+
+# CONUS-only fallback (GeoPackage from Hugging Face / pygeoglim)
+_GLHYMPS_CONUS_URL = (
+    "https://huggingface.co/datasets/mgalib/GLIM_GLHYMPS/"
+    "resolve/main/GLHYMP_CONUS.gpkg"
+)
 
 # Key attribute columns
 _KEEP_COLUMNS = [
@@ -155,37 +165,82 @@ class GLHYMPSAcquirer(BaseAcquisitionHandler):
                 self.logger.info(f"Found local GLHYMPS: {shp}")
                 return shp
 
-        # Download from Borealis Data
-        version = self._get_config_value(lambda: None, default='2.0', dict_key='GLHYMPS_VERSION')
-        url = _GLHYMPS_URLS.get(version, _GLHYMPS_URLS['2.0'])
-
-        zip_path = cache_dir / "GLHYMPS.zip"
-        self.logger.info(f"Downloading GLHYMPS v{version} from Borealis Data")
-        self.logger.info("This is a ~2.4 GB download and may take several minutes...")
-
+        # Try each source until one works
         session = create_robust_session(max_retries=3, backoff_factor=2.0)
+        zip_path = cache_dir / "GLHYMPS.zip"
 
-        try:
-            download_file_streaming(url, zip_path, session=session, timeout=1800)
-
-            self.logger.info("Download complete, extracting...")
-            with zipfile.ZipFile(zip_path, 'r') as zf:
-                zf.extractall(cache_dir)
-
-            zip_path.unlink(missing_ok=True)
-
-            for shp in cache_dir.rglob("*.shp"):
-                self.logger.info(f"Extracted GLHYMPS shapefile: {shp}")
-                return shp
-
-            self.logger.error("No shapefile found in extracted archive")
-            return None
-
-        except Exception as e:  # noqa: BLE001 — preprocessing resilience
-            self.logger.error(f"Failed to download GLHYMPS: {e}")
+        for source in _GLHYMPS_SOURCES:
             self.logger.info(
-                "Manual download: visit https://borealisdata.ca/dataset.xhtml"
-                "?persistentId=doi:10.5683/SP2/TTJNIU\n"
-                f"  Place the extracted shapefile in: {cache_dir}"
+                f"Downloading GLHYMPS from {source['name']} "
+                f"({source['size_hint']})"
             )
-            return None
+
+            try:
+                download_file_streaming(
+                    source['url'], zip_path, session=session, timeout=1800
+                )
+
+                # Detect placeholder responses (Borealis maintenance mode)
+                if zip_path.stat().st_size < 10000:
+                    content = zip_path.read_bytes()
+                    if b'"status"' in content or b'<html' in content.lower():
+                        zip_path.unlink(missing_ok=True)
+                        self.logger.warning(
+                            f"{source['name']} returned a placeholder — "
+                            f"service may be in maintenance"
+                        )
+                        continue
+
+                self.logger.info("Download complete, extracting...")
+                with zipfile.ZipFile(zip_path, 'r') as zf:
+                    zf.extractall(cache_dir)
+
+                zip_path.unlink(missing_ok=True)
+
+                for shp in cache_dir.rglob("*.shp"):
+                    if 'glhymps' in shp.name.lower() or 'GLHYMPS' in shp.name:
+                        self.logger.info(f"Extracted GLHYMPS shapefile: {shp}")
+                        return shp
+
+                # Bundle may contain GLHYMPS in a subdirectory
+                for shp in cache_dir.rglob("*.shp"):
+                    self.logger.info(f"Extracted shapefile: {shp}")
+                    return shp
+
+                self.logger.warning("No shapefile found in archive")
+                continue
+
+            except Exception as e:  # noqa: BLE001
+                self.logger.warning(
+                    f"Failed from {source['name']}: {e}"
+                )
+                zip_path.unlink(missing_ok=True)
+                continue
+
+        # Fallback: CONUS-only GeoPackage from Hugging Face
+        if (self.bbox['lat_min'] >= 24 and self.bbox['lat_max'] <= 50
+                and self.bbox['lon_min'] >= -125 and self.bbox['lon_max'] <= -66):
+            self.logger.info(
+                "Trying CONUS-only GLHYMPS from Hugging Face (~546 MB)"
+            )
+            gpkg_path = cache_dir / "GLHYMP_CONUS.gpkg"
+            try:
+                download_file_streaming(
+                    _GLHYMPS_CONUS_URL, gpkg_path,
+                    session=session, timeout=600,
+                )
+                if gpkg_path.exists() and gpkg_path.stat().st_size > 10000:
+                    self.logger.info(f"Downloaded CONUS GLHYMPS: {gpkg_path}")
+                    return gpkg_path
+            except Exception as e:  # noqa: BLE001
+                self.logger.warning(f"CONUS fallback failed: {e}")
+
+        self.logger.error(
+            "All GLHYMPS download sources failed. Borealis Data "
+            "(the only global source) may be in maintenance. "
+            "Download manually from "
+            "https://borealisdata.ca/dataset.xhtml"
+            "?persistentId=doi:10.5683/SP2/TTJNIU "
+            f"and place the shapefile in {cache_dir}"
+        )
+        return None

--- a/src/symfluence/data/acquisition/handlers/pelletier.py
+++ b/src/symfluence/data/acquisition/handlers/pelletier.py
@@ -5,19 +5,19 @@
 Pelletier Soil/Regolith Depth Data Acquisition Handler
 
 Cloud-based acquisition of the global soil and regolith depth dataset from
-Pelletier et al. (2016) via NASA ORNL DAAC.
+Pelletier et al. (2016) via NASA Earthdata Cloud (ORNL DAAC).
 
 Provides 6 GeoTIFF grids at ~1km (30 arcsecond) resolution:
 - Upland hillslope soil thickness (m)
 - Upland hillslope regolith thickness (m)
 - Lowland sedimentary deposit thickness (m)
-- Upland valley-bottom sedimentary deposit thickness (m)
 - Average soil and sedimentary-deposit thickness (m)
 - Hillslope and valley-bottom average thickness (m)
+- Land cover mask
 
 Data Source:
     ORNL DAAC: https://doi.org/10.3334/ORNLDAAC/1304
-    Requires NASA Earthdata Login
+    Requires NASA Earthdata Login (via earthaccess, .netrc, or env vars)
 
 References:
     Pelletier, J.D., et al. (2016). A gridded global data set of soil,
@@ -26,7 +26,7 @@ References:
 
 Configuration:
     PELLETIER_VARIABLES: List of variables to download
-        (default: all 6 grids)
+        (default: all grids)
 """
 
 from pathlib import Path
@@ -38,15 +38,20 @@ from rasterio.windows import from_bounds
 from ..base import BaseAcquisitionHandler
 from ..mixins import RetryMixin
 from ..registry import AcquisitionRegistry
-from ..utils import create_robust_session, download_file_streaming
+from ..utils import create_robust_session
 
-# ORNL DAAC data URL (requires Earthdata auth)
-_ORNL_BASE = (
+# Cloud-hosted ORNL DAAC (replaces legacy daac.ornl.gov which is intermittent)
+_ORNL_CLOUD_BASE = (
+    "https://data.ornldaac.earthdata.nasa.gov/protected/global_soil/"
+    "Global_Soil_Regolith_Sediment/data"
+)
+
+# Legacy URL kept as fallback
+_ORNL_LEGACY_BASE = (
     "https://daac.ornl.gov/daacdata/global_soil/"
     "Global_Soil_Regolith_Sediment/data"
 )
 
-# Available files and their descriptions
 _PELLETIER_FILES = {
     'soil_thickness': {
         'filename': 'upland_hill-slope_soil_thickness.tif',
@@ -60,16 +65,12 @@ _PELLETIER_FILES = {
         'filename': 'upland_valley-bottom_and_lowland_sedimentary_deposit_thickness.tif',
         'description': 'Valley-bottom and lowland sedimentary deposit thickness (m)',
     },
-    'valley_bottom_thickness': {
-        'filename': 'upland_valley-bottom_sedimentary_deposit_thickness.tif',
-        'description': 'Upland valley-bottom sedimentary deposit thickness (m)',
-    },
     'average_thickness': {
         'filename': 'average_soil_and_sedimentary-deposit_thickness.tif',
         'description': 'Average soil and sedimentary-deposit thickness (m)',
     },
     'hillslope_valley_average': {
-        'filename': 'hill-slope_and_valley-bottom_average_soil_and_sedimentary-deposit_thickness.tif',
+        'filename': 'hill-slope_valley-bottom.tif',
         'description': 'Hillslope and valley-bottom average thickness (m)',
     },
 }
@@ -84,8 +85,8 @@ class PelletierAcquirer(BaseAcquisitionHandler, RetryMixin):
     """
     Pelletier et al. (2016) global soil/regolith depth acquisition.
 
-    Downloads global GeoTIFF grids from ORNL DAAC and subsets to the
-    domain bounding box. Requires NASA Earthdata credentials.
+    Downloads global GeoTIFF grids from NASA Earthdata Cloud (ORNL DAAC)
+    and subsets to the domain bounding box.
 
     Output:
         {project_dir}/attributes/soilclass/pelletier/
@@ -109,11 +110,7 @@ class PelletierAcquirer(BaseAcquisitionHandler, RetryMixin):
             f"variables: {variables}"
         )
 
-        # Set up authenticated session
-        username, password = self._get_earthdata_credentials()
-        session = create_robust_session(max_retries=3, backoff_factor=2.0)
-        if username and password:
-            session.auth = (username, password)
+        session = self._create_earthdata_session()
 
         cache_dir = pelletier_dir / "cache"
         cache_dir.mkdir(parents=True, exist_ok=True)
@@ -130,16 +127,12 @@ class PelletierAcquirer(BaseAcquisitionHandler, RetryMixin):
             self.logger.info(f"[{i+1}/{len(variables)}] Downloading Pelletier {var}")
 
             try:
-                # Download full global file to cache
                 cached_file = cache_dir / info['filename']
                 if not cached_file.exists():
-                    url = f"{_ORNL_BASE}/{info['filename']}"
-                    self.logger.info(f"  Downloading from ORNL DAAC: {info['filename']}")
-                    download_file_streaming(
-                        url, cached_file, session=session, timeout=600
-                    )
+                    url = f"{_ORNL_CLOUD_BASE}/{info['filename']}"
+                    self.logger.info(f"  Downloading from NASA Earthdata Cloud: {info['filename']}")
+                    self._download_with_session(session, url, cached_file)
 
-                # Subset to bbox
                 self._subset_to_bbox(cached_file, out_path)
                 output_paths[var] = out_path
                 self.logger.info(f"  Saved: {out_path}")
@@ -149,12 +142,60 @@ class PelletierAcquirer(BaseAcquisitionHandler, RetryMixin):
                 continue
 
         if not output_paths:
-            raise RuntimeError("No Pelletier soil depth data could be downloaded")
+            raise RuntimeError(
+                "No Pelletier soil depth data could be downloaded. "
+                "Check NASA Earthdata credentials and network connectivity."
+            )
 
         self.logger.info(
             f"Pelletier soil/regolith acquisition complete: {len(output_paths)} files"
         )
         return pelletier_dir
+
+    def _create_earthdata_session(self):
+        """Create an authenticated session for NASA Earthdata Cloud."""
+        try:
+            import earthaccess
+            auth = earthaccess.login()
+            if auth:
+                self.logger.info("  Authenticated via earthaccess")
+                return earthaccess.get_requests_https_session()
+        except ImportError:
+            pass
+        except Exception as e:  # noqa: BLE001
+            self.logger.warning(f"  earthaccess login failed: {e}")
+
+        session = create_robust_session(max_retries=3, backoff_factor=2.0)
+
+        token = self._get_earthdata_token()
+        if token:
+            session.headers.update({'Authorization': f'Bearer {token}'})
+            self.logger.info("  Authenticated via EARTHDATA_TOKEN")
+            return session
+
+        username, password = self._get_earthdata_credentials()
+        if username and password:
+            session.auth = (username, password)
+            self.logger.info("  Authenticated via .netrc / env vars")
+            return session
+
+        raise RuntimeError(
+            "NASA Earthdata credentials required for Pelletier data. "
+            "Set up authentication using one of:\n"
+            "  1. pip install earthaccess && python -c "
+            "'import earthaccess; earthaccess.login(persist=True)'\n"
+            "  2. Set EARTHDATA_TOKEN environment variable\n"
+            "  3. Add entry to ~/.netrc for urs.earthdata.nasa.gov"
+        )
+
+    def _download_with_session(self, session, url: str, dst: Path):
+        """Download a file using the authenticated session with redirect handling."""
+        with session.get(url, stream=True, timeout=600, allow_redirects=True) as r:
+            r.raise_for_status()
+            with open(dst, 'wb') as f:
+                for chunk in r.iter_content(chunk_size=65536):
+                    if chunk:
+                        f.write(chunk)
 
     def _subset_to_bbox(self, src_path: Path, dst_path: Path):
         """Subset a global GeoTIFF to the domain bounding box."""
@@ -165,7 +206,6 @@ class PelletierAcquirer(BaseAcquisitionHandler, RetryMixin):
                 transform=src.transform
             )
 
-            # Clamp window to raster bounds
             window = window.intersection(
                 rasterio.windows.Window(0, 0, src.width, src.height)
             )

--- a/src/symfluence/data/acquisition/handlers/worldclim.py
+++ b/src/symfluence/data/acquisition/handlers/worldclim.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""
+WorldClim 2.1 Climate Data Acquisition Handler
+
+Cloud-based acquisition of WorldClim v2.1 monthly climate normals at
+30 arcsecond (~1 km) resolution (Fick & Hijmans, 2017).
+
+Variables:
+    prec  — precipitation (mm)
+    tavg  — mean temperature (°C)
+    tmin  — minimum temperature (°C)
+    tmax  — maximum temperature (°C)
+    srad  — solar radiation (kJ m⁻² day⁻¹)
+    wind  — wind speed (m s⁻¹)
+    vapr  — water vapour pressure (kPa)
+
+Each variable has 12 monthly GeoTIFF files (global, 30 arcsecond).
+Files are downloaded, then subsetted to the domain bounding box.
+
+Data Source:
+    https://www.worldclim.org/data/worldclim21.html
+    Available under CC-BY-SA 4.0 (derived statistics redistributable,
+    raw grids are not)
+
+References:
+    Fick, S.E. and Hijmans, R.J. (2017). WorldClim 2: new 1-km spatial
+    resolution climate surfaces for global climate land areas. Int. J.
+    Climatol., 37, 4302-4315.
+"""
+
+import zipfile
+from pathlib import Path
+
+import numpy as np
+import rasterio
+from rasterio.windows import from_bounds
+
+from ..base import BaseAcquisitionHandler
+from ..mixins import RetryMixin
+from ..registry import AcquisitionRegistry
+from ..utils import create_robust_session, download_file_streaming
+
+_MIRRORS = [
+    "https://geodata.ucdavis.edu/climate/worldclim/2_1/base",
+    "https://biogeo.ucdavis.edu/data/worldclim/v2.1/base",
+]
+
+_VARIABLES = {
+    'prec': 'Precipitation (mm)',
+    'tavg': 'Mean temperature (°C)',
+    'tmin': 'Minimum temperature (°C)',
+    'tmax': 'Maximum temperature (°C)',
+    'srad': 'Solar radiation (kJ m⁻² day⁻¹)',
+    'wind': 'Wind speed (m s⁻¹)',
+    'vapr': 'Water vapour pressure (kPa)',
+}
+
+_DEFAULT_VARIABLES = list(_VARIABLES.keys())
+
+
+@AcquisitionRegistry.register('WORLDCLIM')
+@AcquisitionRegistry.register('WORLDCLIM_V21')
+class WorldClimAcquirer(BaseAcquisitionHandler, RetryMixin):
+    """
+    WorldClim v2.1 monthly climate normals acquisition.
+
+    Downloads global GeoTIFF archives from the UC Davis mirror and
+    subsets each monthly raster to the domain bounding box.
+
+    Output:
+        {project_dir}/attributes/climate/worldclim/
+            wc2.1_30s_{variable}_{month:02d}.tif  (bbox-clipped)
+    """
+
+    def download(self, output_dir: Path) -> Path:
+        worldclim_dir = self._attribute_dir("climate") / "worldclim"
+        worldclim_dir.mkdir(parents=True, exist_ok=True)
+
+        variables = self._get_config_value(
+            lambda: None,
+            default=_DEFAULT_VARIABLES,
+            dict_key='WORLDCLIM_VARIABLES',
+        )
+        variables = [v for v in variables if v in _VARIABLES]
+
+        if not variables:
+            raise ValueError(
+                f"No valid WorldClim variables. "
+                f"Choose from: {list(_VARIABLES.keys())}"
+            )
+
+        self.logger.info(
+            f"Acquiring WorldClim 2.1 for bbox: {self.bbox}, "
+            f"variables: {variables}"
+        )
+
+        session = create_robust_session(max_retries=3, backoff_factor=2.0)
+        cache_dir = worldclim_dir / "cache"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+
+        total_files = 0
+        for i, var in enumerate(variables):
+            self.logger.info(
+                f"[{i+1}/{len(variables)}] WorldClim {var}: "
+                f"{_VARIABLES[var]}"
+            )
+
+            zip_name = f"wc2.1_30s_{var}.zip"
+            zip_path = cache_dir / zip_name
+
+            if not zip_path.exists():
+                downloaded = False
+                for mirror in _MIRRORS:
+                    url = f"{mirror}/{zip_name}"
+                    try:
+                        self.logger.info(f"  Trying {mirror.split('/')[2]}")
+                        download_file_streaming(
+                            url, zip_path, session=session, timeout=1200
+                        )
+                        downloaded = True
+                        break
+                    except Exception as e:  # noqa: BLE001
+                        self.logger.warning(f"  Mirror failed: {e}")
+                        zip_path.unlink(missing_ok=True)
+                        continue
+                if not downloaded:
+                    raise RuntimeError(
+                        f"All WorldClim mirrors unreachable for {zip_name}. "
+                        f"Download manually from https://www.worldclim.org/"
+                        f"data/worldclim21.html and place zip files in "
+                        f"{cache_dir}"
+                    )
+
+            extract_dir = cache_dir / var
+            if not extract_dir.exists():
+                self.logger.info(f"  Extracting {zip_name}")
+                with zipfile.ZipFile(zip_path, 'r') as zf:
+                    zf.extractall(extract_dir)
+
+            for month in range(1, 13):
+                out_name = f"wc2.1_30s_{var}_{month:02d}.tif"
+                out_path = worldclim_dir / out_name
+
+                if self._skip_if_exists(out_path):
+                    total_files += 1
+                    continue
+
+                src_name = f"wc2.1_30s_{var}_{month:02d}.tif"
+                src_path = self._find_tif(extract_dir, src_name)
+
+                if src_path is None:
+                    self.logger.warning(
+                        f"  Missing: {src_name} in archive"
+                    )
+                    continue
+
+                self._subset_to_bbox(src_path, out_path)
+                total_files += 1
+
+        if total_files == 0:
+            raise RuntimeError("No WorldClim files could be processed")
+
+        self.logger.info(
+            f"WorldClim acquisition complete: {total_files} files "
+            f"in {worldclim_dir}"
+        )
+        return worldclim_dir
+
+    def _find_tif(self, search_dir: Path, filename: str) -> Path | None:
+        """Find a TIF file in a directory tree (zip may have subdirs)."""
+        matches = list(search_dir.rglob(filename))
+        if matches:
+            return matches[0]
+        return None
+
+    def _subset_to_bbox(self, src_path: Path, dst_path: Path):
+        """Subset a global GeoTIFF to the domain bounding box."""
+        with rasterio.open(src_path) as src:
+            window = from_bounds(
+                self.bbox['lon_min'], self.bbox['lat_min'],
+                self.bbox['lon_max'], self.bbox['lat_max'],
+                transform=src.transform,
+            )
+
+            window = window.intersection(
+                rasterio.windows.Window(0, 0, src.width, src.height)
+            )
+
+            data = src.read(1, window=window)
+            transform = src.window_transform(window)
+
+            meta = src.meta.copy()
+            meta.update({
+                'height': data.shape[0],
+                'width': data.shape[1],
+                'transform': transform,
+                'compress': 'lzw',
+                'dtype': 'float32',
+            })
+
+            with rasterio.open(dst_path, 'w', **meta) as dst:
+                dst.write(data.astype(np.float32), 1)

--- a/src/symfluence/data/data_manager.py
+++ b/src/symfluence/data/data_manager.py
@@ -407,15 +407,29 @@ class DataManager(BaseManager):
             self.logger,
             error_type=DataAcquisitionError
         ):
-            # Run geospatial statistics
+            # Run geospatial statistics (core: DEM, soil class, land cover)
             self.logger.debug("Running geospatial statistics")
             gs = GeospatialStatistics(self.config, self.logger)
             gs.run_statistics()
 
-            # Run forcing resampling
-            self.logger.debug("Running forcing resampling")
-            fr = ForcingResampler(self.config, self.logger)
-            fr.run_resampling()
+            # Run extended attribute processing based on profile
+            attribute_profile = self._get_config_value(
+                lambda: self.config.domain.attribute_profile,
+                default='core',
+                dict_key='ATTRIBUTE_PROFILE',
+            )
+            if isinstance(attribute_profile, str) and attribute_profile.lower() != 'core':
+                from symfluence.data.preprocessing.attribute_processor import attributeProcessor
+                ap = attributeProcessor(self.config, self.logger)
+                ap.process_profile_attributes(attribute_profile.lower())
+
+            # Run forcing resampling (non-fatal when no forcing data available)
+            try:
+                self.logger.debug("Running forcing resampling")
+                fr = ForcingResampler(self.config, self.logger)
+                fr.run_resampling()
+            except (FileNotFoundError, DataAcquisitionError) as e:
+                self.logger.warning(f"Forcing resampling skipped (no forcing data): {e}")
 
             # Apply model-agnostic elevation corrections
             from symfluence.data.preprocessing import ElevationCorrectionProcessor

--- a/src/symfluence/data/model_ready/attributes_builder.py
+++ b/src/symfluence/data/model_ready/attributes_builder.py
@@ -135,6 +135,12 @@ class AttributesNetCDFBuilder:
                 groups_written += 1
             if self._build_hydrogeology_group(root):
                 groups_written += 1
+            if self._build_csv_group(root, 'soil_extended', 'soilclass'):
+                groups_written += 1
+            if self._build_csv_group(root, 'vegetation', 'vegetation'):
+                groups_written += 1
+            if self._build_csv_group(root, 'landcover_extended', 'landclass'):
+                groups_written += 1
 
         if groups_written == 0:
             logger.info("No attribute data found; removing empty file")
@@ -385,6 +391,40 @@ class AttributesNetCDFBuilder:
             return True
         except Exception as e:  # noqa: BLE001 — preprocessing resilience
             logger.debug("Could not build hydrogeology group: %s", e)
+            return False
+
+    def _build_csv_group(self, root, group_name: str, subdir: str) -> bool:
+        """Build a NetCDF group from CSV files in an attributes subdirectory."""
+        attr_dir = resolve_data_subdir(self.project_dir, 'attributes') / subdir
+        if not attr_dir.exists():
+            return False
+
+        csvs = list(attr_dir.glob('*_attributes.csv'))
+        if not csvs:
+            return False
+
+        try:
+            import pandas as pd
+            frames = [pd.read_csv(c) for c in csvs]
+            df = pd.concat(frames, axis=1)
+            df = df.loc[:, ~df.columns.duplicated()]
+
+            if df.empty:
+                return False
+
+            grp = root.createGroup(group_name)
+            n = len(df)
+            grp.createDimension('hru', n)
+
+            for col in df.select_dtypes(include=[np.number]).columns:
+                v = grp.createVariable(col, 'f4', ('hru',))
+                v[:] = df[col].values.astype('f4')
+
+            meta = SourceMetadata(source=f'{group_name} attributes')
+            grp.setncatts(meta.to_netcdf_attrs())
+            return True
+        except Exception as e:  # noqa: BLE001
+            logger.debug("Could not build %s group: %s", group_name, e)
             return False
 
     # ------------------------------------------------------------------

--- a/src/symfluence/data/model_ready/store_builder.py
+++ b/src/symfluence/data/model_ready/store_builder.py
@@ -207,6 +207,27 @@ class ModelReadyStoreBuilder:
             except Exception:  # noqa: BLE001
                 logger.debug("Could not load elevation from shapefile")
 
+            # ── Enrich with glacier fraction from domain_type intersection ──
+            df['glacier_fraction'] = 0.0
+            try:
+                import geopandas as gpd
+
+                glacier_shp = (
+                    self.project_dir / 'shapefiles' / 'catchment_intersection'
+                    / 'with_domain_type' / 'catchment_with_domain_type.shp'
+                )
+                if glacier_shp.exists():
+                    gdf_gl = gpd.read_file(glacier_shp)
+                    # domType_2=clean accum, domType_3=clean ablation, domType_4=debris
+                    gl_cols = [c for c in gdf_gl.columns if c.startswith('domType_') and c != 'domType_1']
+                    if gl_cols and len(gdf_gl) == n_hru:
+                        df['glacier_fraction'] = gdf_gl[gl_cols].sum(axis=1).values
+                        logger.debug("Loaded glacier_fraction from %s (mean=%.3f)", glacier_shp, df['glacier_fraction'].mean())
+                    elif gl_cols:
+                        logger.debug("Glacier shapefile row count mismatch (%d vs %d HRUs)", len(gdf_gl), n_hru)
+            except Exception:  # noqa: BLE001
+                logger.debug("Could not load glacier fraction")
+
             out_dir = self.project_dir / 'data' / 'attributes' / 'climate'
             out_dir.mkdir(parents=True, exist_ok=True)
             df.to_csv(out_dir / 'climate_statistics.csv', index=False)

--- a/src/symfluence/data/preprocessing/attribute_processor.py
+++ b/src/symfluence/data/preprocessing/attribute_processor.py
@@ -192,3 +192,54 @@ class attributeProcessor(ConfigMixin):
         except Exception as e:  # noqa: BLE001 — wrap-and-raise to domain error
             self.logger.error(f"Error in attribute processing: {str(e)}")
             raise
+
+    def process_profile_attributes(self, profile_name: str = 'core'):
+        """Run attribute processors enabled by the given profile.
+
+        Writes results as CSVs to ``data/attributes/{category}/`` for
+        each processor category.  The ``AttributesNetCDFBuilder`` picks
+        up these CSVs during ``build_model_ready_store``.
+
+        Parameters
+        ----------
+        profile_name : str
+            One of 'core', 'camels_spat', 'full'.
+        """
+        from symfluence.core.mixins.project import resolve_data_subdir
+
+        _PROFILE_CATEGORIES = {
+            'core': [],
+            'camels_spat': ['climate', 'soil', 'geology', 'landcover'],
+            'full': ['climate', 'soil', 'geology', 'landcover', 'hydrology'],
+        }
+
+        categories = _PROFILE_CATEGORIES.get(profile_name, [])
+        if not categories:
+            return
+
+        self.logger.info(
+            f"Processing extended attributes (profile: {profile_name}, "
+            f"categories: {categories})"
+        )
+
+        attrs_dir = resolve_data_subdir(self.project_dir, 'attributes')
+
+        _PROCESSOR_MAP = {
+            'climate': (self.climate, attrs_dir / 'climate', 'worldclim_attributes.csv'),
+            'soil': (self.soil, attrs_dir / 'soilclass', 'soil_extended_attributes.csv'),
+            'geology': (self.geology, attrs_dir / 'geology', 'glhymps_attributes.csv'),
+            'landcover': (self.landcover, attrs_dir / 'landclass', 'landcover_extended_attributes.csv'),
+            'hydrology': (self.hydrology, attrs_dir / 'hydrology', 'hydrology_attributes.csv'),
+        }
+
+        for cat in categories:
+            processor, out_dir, filename = _PROCESSOR_MAP[cat]
+            try:
+                self.logger.info(f"Processing {cat} attributes")
+                results = processor.process()
+                if results:
+                    processor._write_results_csv(results, out_dir, filename)
+                else:
+                    self.logger.info(f"No {cat} attributes produced (data may not be available)")
+            except Exception as e:  # noqa: BLE001
+                self.logger.warning(f"{cat} attribute processing failed (non-fatal): {e}")

--- a/src/symfluence/data/preprocessing/attribute_processors/base.py
+++ b/src/symfluence/data/preprocessing/attribute_processors/base.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 import geopandas as gpd
+import numpy as np
 
 from symfluence.core.config.coercion import coerce_config
 from symfluence.core.mixins import ConfigMixin
@@ -84,7 +85,6 @@ class BaseAttributeProcessor(ConfigMixin):
             catchment_path = Path(catchment_path)
 
         if catchment_name == 'default':
-            # Find the catchment shapefile based on domain discretization
             discretization = self._get_config_value(
                 lambda: self.config.domain.discretization,
                 dict_key='SUB_GRID_DISCRETIZATION'
@@ -93,7 +93,22 @@ class BaseAttributeProcessor(ConfigMixin):
         else:
             catchment_file = catchment_name
 
-        return catchment_path / catchment_file
+        # Direct path first
+        direct = catchment_path / catchment_file
+        if direct.exists():
+            return direct
+
+        # Search subdirectories (discretize_domain writes to {method}/{experiment_id}/)
+        matches = list(catchment_path.rglob(catchment_file))
+        if matches:
+            return matches[0]
+
+        # Fallback: any HRU shapefile
+        fallback = list(catchment_path.rglob(f"{self.domain_name}_HRUs_*.shp"))
+        if fallback:
+            return fallback[0]
+
+        return direct
 
     def _get_data_path(self, config_key: str, default_subfolder: str) -> Path:
         """
@@ -160,3 +175,36 @@ class BaseAttributeProcessor(ConfigMixin):
         # For distributed catchments, results are already formatted by
         # individual processors with HRU prefixes
         return results
+
+    def _write_results_csv(
+        self,
+        results: Dict[str, Any],
+        output_dir: Path,
+        filename: str,
+    ) -> Optional[Path]:
+        """Write processor results as CSV for AttributesNetCDFBuilder.
+
+        Converts the result dict into a single-row DataFrame (lumped)
+        and writes it to ``output_dir/filename``.  The builder reads
+        CSVs from ``data/attributes/{category}/`` and stores numeric
+        columns as NetCDF variables.
+        """
+        if not results:
+            return None
+
+        import pandas as pd
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        out_path = output_dir / filename
+
+        numeric = {
+            k: v for k, v in results.items()
+            if isinstance(v, (int, float, np.integer, np.floating))
+        }
+        if not numeric:
+            return None
+
+        df = pd.DataFrame([numeric])
+        df.to_csv(out_path, index=False)
+        self.logger.info(f"Wrote {len(numeric)} attributes to {out_path}")
+        return out_path

--- a/src/symfluence/data/preprocessing/attribute_processors/climate.py
+++ b/src/symfluence/data/preprocessing/attribute_processors/climate.py
@@ -37,7 +37,7 @@ class ClimateProcessor(BaseAttributeProcessor):
         results: Dict[str, Any] = {}
 
         # Find WorldClim data path
-        worldclim_path = self._get_data_path('ATTRIBUTES_WORLDCLIM_PATH', 'worldclim')
+        worldclim_path = self._get_data_path('ATTRIBUTES_WORLDCLIM_PATH', 'data/attributes/climate/worldclim')
 
         if not worldclim_path.exists():
             self.logger.warning(f"WorldClim path not found: {worldclim_path}")
@@ -98,16 +98,13 @@ class ClimateProcessor(BaseAttributeProcessor):
 
         # Process each climate variable
         for var, var_info in raw_variables.items():
-            var_path = worldclim_path / 'raw' / var
-
-            if not var_path.exists():
-                self.logger.warning(f"WorldClim {var} directory not found: {var_path}")
-                continue
-
             self.logger.info(f"Processing WorldClim {var_info['description']} ({var})")
 
-            # Find all monthly files for this variable
-            monthly_files = sorted(var_path.glob(f"wc2.1_30s_{var}_*.tif"))
+            # Search for monthly files: flat layout (acquisition) or nested (legacy)
+            monthly_files = sorted(worldclim_path.glob(f"wc2.1_30s_{var}_*.tif"))
+            if not monthly_files:
+                var_path = worldclim_path / 'raw' / var
+                monthly_files = sorted(var_path.glob(f"wc2.1_30s_{var}_*.tif"))
 
             if not monthly_files:
                 self.logger.warning(f"No {var} files found in {var_path}")

--- a/src/symfluence/data/preprocessing/attribute_processors/geology.py
+++ b/src/symfluence/data/preprocessing/attribute_processors/geology.py
@@ -57,12 +57,10 @@ class GeologyProcessor(BaseAttributeProcessor):
         results: Dict[str, Any] = {}
 
         # Define path to GLHYMPS data (configurable via GLHYMPS_PATH)
-        glhymps_path = Path(self._get_config_value(lambda: None, default=str(self.data_dir / 'geospatial' / 'glhymps' / 'raw' / 'glhymps.shp'), dict_key='GLHYMPS_PATH')
-        )
+        glhymps_path = self._find_glhymps_file()
 
-        # Check if GLHYMPS file exists
-        if not glhymps_path.exists():
-            self.logger.warning(f"GLHYMPS file not found: {glhymps_path}")
+        if glhymps_path is None:
+            self.logger.warning("GLHYMPS data not found")
             return results
 
         # Create cache directory and define cache file
@@ -323,6 +321,33 @@ class GeologyProcessor(BaseAttributeProcessor):
             self.logger.error(traceback.format_exc())
 
         return results
+
+    def _find_glhymps_file(self):
+        """Find GLHYMPS file, checking acquisition output then legacy paths."""
+        from pathlib import Path
+
+        # Acquisition output: domain_{name}_glhymps.gpkg
+        acq_dir = self.project_dir / 'data' / 'attributes' / 'geology' / 'glhymps'
+        for ext in ('*.gpkg', '*.shp'):
+            matches = list(acq_dir.glob(f"*glhymps{ext[1:]}")) if acq_dir.exists() else []
+            if matches:
+                return matches[0]
+
+        # Config-specified path
+        config_path = self._get_config_value(
+            lambda: None, default=None, dict_key='GLHYMPS_PATH'
+        )
+        if config_path and config_path != 'default':
+            p = Path(config_path)
+            if p.exists():
+                return p
+
+        # Legacy path
+        legacy = self.data_dir / 'geospatial' / 'glhymps' / 'raw' / 'glhymps.shp'
+        if legacy.exists():
+            return legacy
+
+        return None
 
     def _process_lithology_data(self) -> Dict[str, Any]:
         """

--- a/src/symfluence/data/preprocessing/attribute_processors/landcover.py
+++ b/src/symfluence/data/preprocessing/attribute_processors/landcover.py
@@ -62,14 +62,23 @@ class LandCoverProcessor(BaseAttributeProcessor):
         """
         results: Dict[str, Any] = {}
 
-        # Define path to GLCLU2019 data (configurable via GLCLU2019_DIR)
-        glclu_path = Path(self._get_config_value(lambda: None, default=str(self.data_dir / 'geospatial' / 'glclu2019' / 'raw'), dict_key='GLCLU2019_DIR')
-        )
-        main_tif = glclu_path / "glclu2019_map.tif"
+        # Define path to GLCLU data (configurable via GLCLU2019_DIR)
+        glclu_path = Path(self._get_config_value(
+            lambda: None,
+            default=str(self.project_dir / 'data' / 'attributes' / 'landclass' / 'glclu'),
+            dict_key='GLCLU2019_DIR',
+        ))
 
-        # Check if file exists
-        if not main_tif.exists():
-            self.logger.warning(f"GLCLU2019 file not found: {main_tif}")
+        # Find GLCLU raster: acquisition naming or legacy
+        main_tif = None
+        for pattern in ("*glclu*.tif", "glclu2019_map.tif"):
+            matches = list(glclu_path.glob(pattern)) if glclu_path.exists() else []
+            if matches:
+                main_tif = matches[0]
+                break
+
+        if main_tif is None:
+            self.logger.warning(f"GLCLU file not found in {glclu_path}")
             return results
 
         # Create cache directory
@@ -205,19 +214,29 @@ class LandCoverProcessor(BaseAttributeProcessor):
         """
         results: Dict[str, Any] = {}
 
-        # Configurable via LAI_DIR
-        lai_path = Path(self._get_config_value(lambda: None, default=str(self.data_dir / 'geospatial' / 'lai' / 'monthly_average_2013_2023'), dict_key='LAI_DIR')
-        )
+        # Configurable via LAI_DIR — check acquisition output first
+        lai_path = Path(self._get_config_value(
+            lambda: None,
+            default=str(self.project_dir / 'data' / 'attributes' / 'vegetation' / 'modis_lai'),
+            dict_key='LAI_DIR',
+        ))
         use_water_mask = self._get_config_value(lambda: None, default=True, dict_key='USE_WATER_MASKED_LAI')
 
-        lai_folder = lai_path / ('monthly_lai_with_water_mask' if use_water_mask else 'monthly_lai_no_water_mask')
+        # Try acquisition NetCDF first, then legacy monthly TIF folders
+        lai_nc = list(lai_path.glob("*MODIS_LAI*.nc")) if lai_path.exists() else []
+        if lai_nc:
+            return self._process_lai_from_netcdf(lai_nc[0])
 
+        lai_folder = lai_path / ('monthly_lai_with_water_mask' if use_water_mask else 'monthly_lai_no_water_mask')
         if not lai_folder.exists():
-            # Try alternative
             lai_folder = lai_path / ('monthly_lai_no_water_mask' if use_water_mask else 'monthly_lai_with_water_mask')
             if not lai_folder.exists():
-                self.logger.warning("LAI folder not found")
-                return results
+                # Also try legacy path
+                legacy = self.data_dir / 'geospatial' / 'lai' / 'monthly_average_2013_2023'
+                lai_folder = legacy / ('monthly_lai_with_water_mask' if use_water_mask else 'monthly_lai_no_water_mask')
+                if not lai_folder.exists():
+                    self.logger.warning("LAI folder not found")
+                    return results
 
         # Cache
         cache_dir = self.project_dir / 'cache' / 'lai'
@@ -308,6 +327,34 @@ class LandCoverProcessor(BaseAttributeProcessor):
 
         return results
 
+    def _process_lai_from_netcdf(self, nc_path) -> Dict[str, Any]:
+        """Process LAI from acquisition NetCDF (MODIS MCD15A2H)."""
+        results: Dict[str, Any] = {}
+        try:
+            import xarray as xr
+            ds = xr.open_dataset(nc_path)
+            if 'lai_mean' in ds:
+                lai = ds['lai_mean'].values
+                results['vegetation.lai_annual_mean'] = float(np.nanmean(lai))
+                results['vegetation.lai_annual_min'] = float(np.nanmin(lai))
+                results['vegetation.lai_annual_max'] = float(np.nanmax(lai))
+                results['vegetation.lai_seasonal_amplitude'] = float(
+                    np.nanmax(lai) - np.nanmin(lai)
+                )
+            elif 'Lai_500m' in ds:
+                lai = ds['Lai_500m'].values
+                results['vegetation.lai_annual_mean'] = float(np.nanmean(lai))
+                results['vegetation.lai_annual_min'] = float(np.nanmin(lai))
+                results['vegetation.lai_annual_max'] = float(np.nanmax(lai))
+                results['vegetation.lai_seasonal_amplitude'] = float(
+                    np.nanmax(lai) - np.nanmin(lai)
+                )
+            ds.close()
+            self.logger.info(f"Processed LAI from NetCDF: {nc_path.name}")
+        except Exception as e:  # noqa: BLE001
+            self.logger.warning(f"Error processing LAI NetCDF: {e}")
+        return results
+
     def _process_forest_height(self) -> Dict[str, Any]:
         """
         Process forest height data.
@@ -317,13 +364,32 @@ class LandCoverProcessor(BaseAttributeProcessor):
         """
         results = {}
 
-        # Configurable via FOREST_HEIGHT_DIR
-        forest_dir = Path(self._get_config_value(lambda: None, default=str(self.data_dir / 'geospatial' / 'forest_height' / 'raw'), dict_key='FOREST_HEIGHT_DIR')
-        )
-        forest_files = {
-            "2000": forest_dir / "forest_height_2000.tif",
-            "2020": forest_dir / "forest_height_2020.tif"
-        }
+        # Check acquisition output first, then legacy path
+        acq_dir = self.project_dir / 'data' / 'attributes' / 'vegetation' / 'canopy_height' / 'glad'
+        forest_dir = Path(self._get_config_value(
+            lambda: None,
+            default=str(acq_dir),
+            dict_key='FOREST_HEIGHT_DIR',
+        ))
+
+        # Find forest height files — acquisition naming or legacy
+        forest_files = {}
+        if forest_dir.exists():
+            for tif in forest_dir.glob("*.tif"):
+                if 'tree_height' in tif.name or 'treecover' in tif.name:
+                    forest_files['acquired'] = tif
+                    break
+                elif 'forest_height_2020' in tif.name:
+                    forest_files['2020'] = tif
+                elif 'forest_height_2000' in tif.name:
+                    forest_files['2000'] = tif
+
+        if not forest_files:
+            legacy_dir = self.data_dir / 'geospatial' / 'forest_height' / 'raw'
+            if (legacy_dir / 'forest_height_2020.tif').exists():
+                forest_files['2020'] = legacy_dir / 'forest_height_2020.tif'
+            if (legacy_dir / 'forest_height_2000.tif').exists():
+                forest_files['2000'] = legacy_dir / 'forest_height_2000.tif'
 
         # Cache
         cache_dir = self.project_dir / 'cache' / 'forest_height'

--- a/src/symfluence/data/preprocessing/attribute_processors/soil.py
+++ b/src/symfluence/data/preprocessing/attribute_processors/soil.py
@@ -62,8 +62,11 @@ class SoilProcessor(BaseAttributeProcessor):
         results = {}
 
         # Define paths to SOILGRIDS data (configurable via SOILGRIDS_DIR)
-        soilgrids_dir = Path(self._get_config_value(lambda: None, default=str(self.data_dir / 'geospatial' / 'soilgrids' / 'raw'), dict_key='SOILGRIDS_DIR')
-        )
+        soilgrids_dir = Path(self._get_config_value(
+            lambda: None,
+            default=str(self.project_dir / 'data' / 'attributes' / 'soilclass' / 'soilgrids'),
+            dict_key='SOILGRIDS_DIR',
+        ))
 
         # Define soil components and depths to process
         components = ['clay', 'sand', 'silt']
@@ -73,12 +76,12 @@ class SoilProcessor(BaseAttributeProcessor):
         # Process each soil component at each depth
         for component in components:
             for depth in depths:
-                # Define file path for mean values
-                tif_path = soilgrids_dir / component / f"{component}_{depth}_mean.tif"
+                # Try acquisition naming first, then legacy nested layout
+                tif_path = self._find_soilgrids_file(
+                    soilgrids_dir, component, depth
+                )
 
-                # Skip if file doesn't exist
-                if not tif_path.exists():
-                    self.logger.warning(f"Soil component file not found: {tif_path}")
+                if tif_path is None:
                     continue
 
                 self.logger.info(f"Processing soil {component} at depth {depth}")
@@ -132,6 +135,54 @@ class SoilProcessor(BaseAttributeProcessor):
         self._calculate_usda_texture_classes(results)
 
         return results
+
+    def _find_pelletier_file(
+        self, pelletier_dir: Path, attr_key: str
+    ) -> Optional[Path]:
+        """Find a Pelletier TIF file, checking acquisition and legacy naming."""
+        # Acquisition naming: domain_{name}_pelletier_{attr_key}.tif
+        matches = list(pelletier_dir.glob(f"*pelletier_{attr_key}.tif"))
+        if matches:
+            return matches[0]
+
+        # Legacy naming maps
+        _LEGACY_NAMES = {
+            'soil_thickness': 'upland_hill-slope_soil_thickness.tif',
+            'regolith_thickness': 'upland_hill-slope_regolith_thickness.tif',
+            'sedimentary_thickness': 'upland_valley-bottom_and_lowland_sedimentary_deposit_thickness.tif',
+            'average_thickness': 'average_soil_and_sedimentary-deposit_thickness.tif',
+            'hillslope_valley_average': 'hill-slope_and_valley-bottom_average_soil_and_sedimentary-deposit_thickness.tif',
+        }
+        legacy_name = _LEGACY_NAMES.get(attr_key)
+        if legacy_name:
+            legacy = pelletier_dir / legacy_name
+            if legacy.exists():
+                return legacy
+
+        self.logger.debug(f"Pelletier file not found: {attr_key}")
+        return None
+
+    def _find_soilgrids_file(
+        self, soilgrids_dir: Path, component: str, depth: str
+    ) -> Optional[Path]:
+        """Find a SoilGrids TIF file, checking acquisition and legacy naming."""
+        # Acquisition naming: domain_{name}_soilgrids_{component}_{depth}_mean.tif
+        matches = list(soilgrids_dir.glob(f"*soilgrids_{component}_{depth}_mean.tif"))
+        if matches:
+            return matches[0]
+
+        # Legacy nested: {component}/{component}_{depth}_mean.tif
+        legacy = soilgrids_dir / component / f"{component}_{depth}_mean.tif"
+        if legacy.exists():
+            return legacy
+
+        # Legacy flat
+        flat = soilgrids_dir / f"{component}_{depth}_mean.tif"
+        if flat.exists():
+            return flat
+
+        self.logger.debug(f"Soil component file not found: {component} {depth}")
+        return None
 
     def _derive_hydraulic_properties(self, texture_results: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -361,26 +412,28 @@ class SoilProcessor(BaseAttributeProcessor):
         results = {}
 
         # Define path to Pelletier data (configurable via PELLETIER_DIR)
-        pelletier_dir = Path(self._get_config_value(lambda: None, default=str(self.data_dir / 'geospatial' / 'pelletier' / 'raw'), dict_key='PELLETIER_DIR')
-        )
+        pelletier_dir = Path(self._get_config_value(
+            lambda: None,
+            default=str(self.project_dir / 'data' / 'attributes' / 'soilclass' / 'pelletier'),
+            dict_key='PELLETIER_DIR',
+        ))
 
-        # Define files to process
-        pelletier_files = {
-            "upland_hill-slope_regolith_thickness.tif": "regolith_thickness",
-            "upland_hill-slope_soil_thickness.tif": "soil_thickness",
-            "upland_valley-bottom_and_lowland_sedimentary_deposit_thickness.tif": "sedimentary_thickness",
-            "average_soil_and_sedimentary-deposit_thickness.tif": "average_thickness"
+        # Define attributes to process with possible filename patterns
+        pelletier_attributes = {
+            'regolith_thickness': 'regolith_thickness',
+            'soil_thickness': 'soil_thickness',
+            'sedimentary_thickness': 'sedimentary_thickness',
+            'average_thickness': 'average_thickness',
+            'hillslope_valley_average': 'hillslope_valley_average',
         }
 
         stats = ['mean', 'min', 'max', 'std']
 
-        for file_name, attribute in pelletier_files.items():
-            # Define file path
-            tif_path = pelletier_dir / file_name
+        for attr_key, attribute in pelletier_attributes.items():
+            # Search: acquisition naming then legacy naming
+            tif_path = self._find_pelletier_file(pelletier_dir, attr_key)
 
-            # Skip if file doesn't exist
-            if not tif_path.exists():
-                self.logger.warning(f"Pelletier file not found: {tif_path}")
+            if tif_path is None:
                 continue
 
             self.logger.info(f"Processing Pelletier {attribute}")

--- a/src/symfluence/models/hype/calibration/hype_regionalization.py
+++ b/src/symfluence/models/hype/calibration/hype_regionalization.py
@@ -33,7 +33,7 @@ from symfluence.optimization.regionalization.strategies import (
 
 HYPE_LU_PARAM_CONFIG: Dict[str, Dict[str, Any]] = {
     'ttmp':  {'attribute': 'vegetation_height', 'calibrate_b': True},
-    'cmlt':  {'attribute': 'vegetation_height', 'calibrate_b': True},
+    'cmlt':  {'attribute': 'glacier_fraction',  'calibrate_b': True},
     'cevp':  {'attribute': 'lai',               'calibrate_b': True},
     'srrcs': {'attribute': 'root_depth',        'calibrate_b': True},
 }
@@ -51,23 +51,23 @@ HYPE_GLOBAL_PARAMS: List[str] = [
 ]
 
 _IGBP_ATTRIBUTES: Dict[int, Dict[str, float]] = {
-    1:  {'lai': 5.0, 'vegetation_height': 20.0, 'root_depth': 2.0},
-    2:  {'lai': 6.0, 'vegetation_height': 25.0, 'root_depth': 2.5},
-    3:  {'lai': 3.5, 'vegetation_height': 18.0, 'root_depth': 1.8},
-    4:  {'lai': 4.5, 'vegetation_height': 20.0, 'root_depth': 2.0},
-    5:  {'lai': 4.0, 'vegetation_height': 18.0, 'root_depth': 2.0},
-    6:  {'lai': 2.0, 'vegetation_height': 3.0,  'root_depth': 1.0},
-    7:  {'lai': 1.5, 'vegetation_height': 1.5,  'root_depth': 0.8},
-    8:  {'lai': 3.0, 'vegetation_height': 10.0, 'root_depth': 1.5},
-    9:  {'lai': 2.0, 'vegetation_height': 5.0,  'root_depth': 1.0},
-    10: {'lai': 2.5, 'vegetation_height': 0.5,  'root_depth': 0.8},
-    11: {'lai': 3.0, 'vegetation_height': 2.0,  'root_depth': 0.5},
-    12: {'lai': 3.5, 'vegetation_height': 1.0,  'root_depth': 0.8},
-    13: {'lai': 1.0, 'vegetation_height': 10.0, 'root_depth': 0.3},
-    14: {'lai': 3.0, 'vegetation_height': 5.0,  'root_depth': 1.0},
-    15: {'lai': 0.1, 'vegetation_height': 0.1,  'root_depth': 0.1},
-    16: {'lai': 0.5, 'vegetation_height': 0.2,  'root_depth': 0.3},
-    17: {'lai': 0.0, 'vegetation_height': 0.0,  'root_depth': 0.0},
+    1:  {'lai': 5.0, 'vegetation_height': 20.0, 'root_depth': 2.0, 'glacier_fraction': 0.0},
+    2:  {'lai': 6.0, 'vegetation_height': 25.0, 'root_depth': 2.5, 'glacier_fraction': 0.0},
+    3:  {'lai': 3.5, 'vegetation_height': 18.0, 'root_depth': 1.8, 'glacier_fraction': 0.0},
+    4:  {'lai': 4.5, 'vegetation_height': 20.0, 'root_depth': 2.0, 'glacier_fraction': 0.0},
+    5:  {'lai': 4.0, 'vegetation_height': 18.0, 'root_depth': 2.0, 'glacier_fraction': 0.0},
+    6:  {'lai': 2.0, 'vegetation_height': 3.0,  'root_depth': 1.0, 'glacier_fraction': 0.0},
+    7:  {'lai': 1.5, 'vegetation_height': 1.5,  'root_depth': 0.8, 'glacier_fraction': 0.0},
+    8:  {'lai': 3.0, 'vegetation_height': 10.0, 'root_depth': 1.5, 'glacier_fraction': 0.0},
+    9:  {'lai': 2.0, 'vegetation_height': 5.0,  'root_depth': 1.0, 'glacier_fraction': 0.0},
+    10: {'lai': 2.5, 'vegetation_height': 0.5,  'root_depth': 0.8, 'glacier_fraction': 0.0},
+    11: {'lai': 3.0, 'vegetation_height': 2.0,  'root_depth': 0.5, 'glacier_fraction': 0.0},
+    12: {'lai': 3.5, 'vegetation_height': 1.0,  'root_depth': 0.8, 'glacier_fraction': 0.0},
+    13: {'lai': 1.0, 'vegetation_height': 10.0, 'root_depth': 0.3, 'glacier_fraction': 0.0},
+    14: {'lai': 3.0, 'vegetation_height': 5.0,  'root_depth': 1.0, 'glacier_fraction': 0.0},
+    15: {'lai': 0.1, 'vegetation_height': 0.1,  'root_depth': 0.1, 'glacier_fraction': 1.0},
+    16: {'lai': 0.5, 'vegetation_height': 0.2,  'root_depth': 0.3, 'glacier_fraction': 0.0},
+    17: {'lai': 0.0, 'vegetation_height': 0.0,  'root_depth': 0.0, 'glacier_fraction': 0.0},
 }
 
 

--- a/src/symfluence/models/hype/calibration/hype_regionalization.py
+++ b/src/symfluence/models/hype/calibration/hype_regionalization.py
@@ -81,12 +81,9 @@ def load_lu_attributes(
     rows = []
     for lu_id in lu_ids:
         attrs = _IGBP_ATTRIBUTES.get(int(lu_id), _IGBP_ATTRIBUTES[16])
-        rows.append({
-            'lu_id': int(lu_id),
-            'lai': attrs['lai'],
-            'vegetation_height': attrs['vegetation_height'],
-            'root_depth': attrs['root_depth'],
-        })
+        row = {'lu_id': int(lu_id)}
+        row.update(attrs)
+        rows.append(row)
     df = pd.DataFrame(rows)
     logger.info(f"Loaded LU attributes: {len(df)} classes, IDs={list(lu_ids)}")
     return df, lu_ids

--- a/src/symfluence/models/hype/geodata_manager.py
+++ b/src/symfluence/models/hype/geodata_manager.py
@@ -227,6 +227,27 @@ class HYPEGeoDataManager:
 
         base_df['elev_mean'] = base_df['subid'].apply(get_elevation)
 
+        # Load glacier fraction from domain_type intersection shapefile
+        glacier_shp = None
+        if intersect_base_path:
+            glacier_shp = Path(intersect_base_path).parent / 'with_domain_type' / 'catchment_with_domain_type.shp'
+        if glacier_shp is None or not glacier_shp.exists():
+            glacier_shp = Path(str(subbasins_shapefile)).parents[1] / 'catchment_intersection' / 'with_domain_type' / 'catchment_with_domain_type.shp'
+        if glacier_shp.exists():
+            try:
+                gl_gdf = gpd.read_file(glacier_shp)
+                gl_cols = [c for c in gl_gdf.columns if c.startswith('domType_') and c != 'domType_1']
+                if gl_cols:
+                    gl_frac = gl_gdf[gl_cols].sum(axis=1).values
+                    if len(gl_frac) == len(cat):
+                        gl_map = dict(zip(cat[basin_id_col].values, gl_frac))
+                        base_df['glacier_fraction'] = base_df['subid'].map(gl_map).fillna(0.0)
+                        self.logger.debug("Loaded glacier_fraction for %d sub-basins (mean=%.3f)", len(base_df), base_df['glacier_fraction'].mean())
+            except Exception as e:  # noqa: BLE001
+                self.logger.debug("Could not load glacier fraction: %s", e)
+        if 'glacier_fraction' not in base_df.columns:
+            base_df['glacier_fraction'] = 0.0
+
         # Normalize SLC fractions
         slc_cols = [col for col in base_df.columns if col.startswith('SLC_')]
         if slc_cols:

--- a/src/symfluence/resources/config_templates/config_template_comprehensive.yaml
+++ b/src/symfluence/resources/config_templates/config_template_comprehensive.yaml
@@ -3027,6 +3027,12 @@ RIVER_NETWORK_SHP_SLOPE: "Slope"
 #   Usage:      3
 SOILGRIDS_LAYER: "wrb_0-5cm_mode"
 
+# ATTRIBUTE_PROFILE - 'core', 'camels_spat', or 'full' (all available attribute datasets)
+#   Type:        Literal['core', 'camels_spat', 'full']
+#   Default:     core
+#   Source:      DomainConfig (domain.py)
+ATTRIBUTE_PROFILE: "core"
+
 # SOILGRIDS_WCS_MAP
 #   Type:        str
 #   Default:     /map/wcs/soilgrids.map

--- a/tests/unit/data/acquisition/test_attribute_profiles.py
+++ b/tests/unit/data/acquisition/test_attribute_profiles.py
@@ -142,6 +142,7 @@ def _make_service(profile='core', overrides=None):
     mock_config.domain.name = 'test_domain'
     mock_config.system.data_dir = '/tmp/test'
     mock_config.domain.bounding_box_coords = '51.76/-116.55/50.95/-115.5'
+    mock_config.data.max_acquisition_workers = 1
 
     logger = logging.getLogger('test_profiles')
     logger.setLevel(logging.DEBUG)

--- a/tests/unit/data/acquisition/test_attribute_profiles.py
+++ b/tests/unit/data/acquisition/test_attribute_profiles.py
@@ -1,0 +1,231 @@
+"""Tests for ATTRIBUTE_PROFILE config flag and profile-driven acquisition."""
+
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from symfluence.core.config.models.domain import DomainConfig
+from symfluence.data.acquisition.attribute_profiles import (
+    PROFILES,
+    ProfileDataset,
+)
+
+# ---------------------------------------------------------------------------
+# Profile definitions
+# ---------------------------------------------------------------------------
+
+class TestProfileDefinitions:
+    """Validate the profile registry."""
+
+    def test_core_profile_exists(self):
+        assert 'core' in PROFILES
+
+    def test_camels_spat_profile_exists(self):
+        assert 'camels_spat' in PROFILES
+
+    def test_core_is_empty(self):
+        assert PROFILES['core'] == []
+
+    def test_camels_spat_has_eight_datasets(self):
+        assert len(PROFILES['camels_spat']) == 8
+
+    def test_camels_spat_handler_names(self):
+        names = {ds.handler_name for ds in PROFILES['camels_spat']}
+        expected = {
+            'SOILGRIDS_PROPERTIES', 'PELLETIER', 'GLHYMPS',
+            'HYDROLAKES', 'MODIS_LAI', 'GLAD_TREE_HEIGHT',
+            'WORLDCLIM', 'GLCLU_2019',
+        }
+        assert names == expected
+
+    def test_full_profile_exists(self):
+        assert 'full' in PROFILES
+
+    def test_full_includes_camels_spat(self):
+        cs_names = {ds.handler_name for ds in PROFILES['camels_spat']}
+        full_names = {ds.handler_name for ds in PROFILES['full']}
+        assert cs_names.issubset(full_names)
+
+    def test_full_has_extra_datasets(self):
+        full_names = {ds.handler_name for ds in PROFILES['full']}
+        extras = {
+            'GLACIER', 'GLWD', 'BEDROCK_DEPTH', 'ARIDITY_INDEX',
+            'MODIS_NDVI', 'ROOT_ZONE_STORAGE', 'JRC_WATER',
+            'WOKAM', 'MERIT_HYDRO',
+        }
+        assert extras.issubset(full_names)
+
+    def test_full_has_seventeen_datasets(self):
+        assert len(PROFILES['full']) == 17
+
+    def test_all_non_fatal(self):
+        for name, datasets in PROFILES.items():
+            for ds in datasets:
+                assert ds.fatal is False, f"{name}/{ds.handler_name} should be non-fatal"
+
+    def test_all_have_override_keys(self):
+        for name, datasets in PROFILES.items():
+            for ds in datasets:
+                assert ds.config_override_key is not None
+                assert ds.config_override_key.startswith('DOWNLOAD_')
+
+    def test_profile_dataset_is_frozen(self):
+        ds = ProfileDataset(
+            handler_name='TEST',
+            description='test',
+            output_subdir='test',
+        )
+        with pytest.raises(AttributeError):
+            ds.handler_name = 'OTHER'
+
+
+# ---------------------------------------------------------------------------
+# DomainConfig validation
+# ---------------------------------------------------------------------------
+
+class TestAttributeProfileConfig:
+    """Validate ATTRIBUTE_PROFILE field on DomainConfig."""
+
+    _MINIMAL = {
+        'DOMAIN_NAME': 'test',
+        'EXPERIMENT_ID': 'run1',
+        'EXPERIMENT_TIME_START': '2000-01-01',
+        'EXPERIMENT_TIME_END': '2001-01-01',
+        'DOMAIN_DEFINITION_METHOD': 'lumped',
+        'SUB_GRID_DISCRETIZATION': 'elevation',
+    }
+
+    def test_default_is_core(self):
+        cfg = DomainConfig.model_validate(self._MINIMAL)
+        assert cfg.attribute_profile == 'core'
+
+    def test_accepts_core(self):
+        data = {**self._MINIMAL, 'ATTRIBUTE_PROFILE': 'core'}
+        cfg = DomainConfig.model_validate(data)
+        assert cfg.attribute_profile == 'core'
+
+    def test_accepts_camels_spat(self):
+        data = {**self._MINIMAL, 'ATTRIBUTE_PROFILE': 'camels_spat'}
+        cfg = DomainConfig.model_validate(data)
+        assert cfg.attribute_profile == 'camels_spat'
+
+    def test_accepts_full(self):
+        data = {**self._MINIMAL, 'ATTRIBUTE_PROFILE': 'full'}
+        cfg = DomainConfig.model_validate(data)
+        assert cfg.attribute_profile == 'full'
+
+    def test_case_insensitive(self):
+        data = {**self._MINIMAL, 'ATTRIBUTE_PROFILE': 'CAMELS_SPAT'}
+        cfg = DomainConfig.model_validate(data)
+        assert cfg.attribute_profile == 'camels_spat'
+
+    def test_rejects_invalid_profile(self):
+        data = {**self._MINIMAL, 'ATTRIBUTE_PROFILE': 'nonexistent'}
+        with pytest.raises(Exception):
+            DomainConfig.model_validate(data)
+
+
+# ---------------------------------------------------------------------------
+# _acquire_profile_datasets() logic
+# ---------------------------------------------------------------------------
+
+def _make_service(profile='core', overrides=None):
+    """Create a minimal AcquisitionService for profile testing."""
+    from symfluence.data.acquisition.acquisition_service import (
+        AcquisitionService,
+    )
+
+    mock_config = MagicMock()
+    mock_config.domain.attribute_profile = profile
+    mock_config.domain.name = 'test_domain'
+    mock_config.system.data_dir = '/tmp/test'
+    mock_config.domain.bounding_box_coords = '51.76/-116.55/50.95/-115.5'
+
+    logger = logging.getLogger('test_profiles')
+    logger.setLevel(logging.DEBUG)
+
+    with patch.object(
+        AcquisitionService, '__init__', lambda self, *a, **kw: None,
+    ):
+        svc = AcquisitionService.__new__(AcquisitionService)
+
+    svc._config = mock_config
+    svc.config = mock_config
+    svc.logger = logger
+    svc.project_dir = Path('/tmp/test/domain_test_domain')
+    svc.domain_name = 'test_domain'
+    svc.reporting_manager = None
+    svc._config_dict_override = overrides or {}
+    return svc
+
+
+class TestAcquireProfileDatasets:
+    """Unit tests for _acquire_profile_datasets()."""
+
+    def test_core_profile_returns_immediately(self):
+        svc = _make_service(profile='core')
+        svc._acquire_profile_datasets()
+
+    @patch(
+        'symfluence.data.acquisition.acquisition_service.AcquisitionRegistry'
+    )
+    @patch(
+        'symfluence.data.acquisition.acquisition_service.resolve_data_subdir'
+    )
+    def test_camels_spat_creates_tasks(
+        self, mock_resolve, mock_registry
+    ):
+        svc = _make_service(profile='camels_spat')
+
+        mock_resolve.return_value = Path('/tmp/test/attributes')
+        mock_handler = MagicMock()
+        mock_handler.download.return_value = Path('/tmp/test/out')
+        mock_registry.get_handler.return_value = mock_handler
+
+        svc._acquire_profile_datasets()
+
+        assert mock_registry.get_handler.call_count == 8
+
+    @patch(
+        'symfluence.data.acquisition.acquisition_service.AcquisitionRegistry'
+    )
+    @patch(
+        'symfluence.data.acquisition.acquisition_service.resolve_data_subdir'
+    )
+    def test_override_skips_dataset(self, mock_resolve, mock_registry):
+        svc = _make_service(
+            profile='camels_spat',
+            overrides={'DOWNLOAD_GLHYMPS': False},
+        )
+
+        mock_resolve.return_value = Path('/tmp/test/attributes')
+        mock_handler = MagicMock()
+        mock_handler.download.return_value = Path('/tmp/test/out')
+        mock_registry.get_handler.return_value = mock_handler
+
+        svc._acquire_profile_datasets()
+
+        handler_names = [
+            call.args[0]
+            for call in mock_registry.get_handler.call_args_list
+        ]
+        assert 'GLHYMPS' not in handler_names
+        assert mock_registry.get_handler.call_count == 7
+
+    @patch(
+        'symfluence.data.acquisition.acquisition_service.AcquisitionRegistry'
+    )
+    @patch(
+        'symfluence.data.acquisition.acquisition_service.resolve_data_subdir'
+    )
+    def test_nonfatal_failure_warns(self, mock_resolve, mock_registry):
+        svc = _make_service(profile='camels_spat')
+
+        mock_resolve.return_value = Path('/tmp/test/attributes')
+        mock_handler = MagicMock()
+        mock_handler.download.side_effect = RuntimeError('network error')
+        mock_registry.get_handler.return_value = mock_handler
+
+        svc._acquire_profile_datasets()

--- a/tools/quality/broad_exception_allowlist.txt
+++ b/tools/quality/broad_exception_allowlist.txt
@@ -147,7 +147,8 @@ src/symfluence/data/acquisition/handlers/gldas_tws.py:GLDASAcquirer.download:exc
 src/symfluence/data/acquisition/handlers/gleam_et.py:GLEAMETAcquirer._download_via_sftp:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/acquisition/handlers/gleam_et.py:GLEAMETAcquirer._download_via_sftp:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/acquisition/handlers/gleam_et.py:GLEAMETAcquirer._download_via_sftp:except Exception:  # noqa: BLE001 — preprocessing resilience
-src/symfluence/data/acquisition/handlers/glhymps.py:GLHYMPSAcquirer._get_global_shapefile:except Exception as e:  # noqa: BLE001 — preprocessing resilience
+src/symfluence/data/acquisition/handlers/glhymps.py:GLHYMPSAcquirer._get_global_shapefile:except Exception as e:  # noqa: BLE001
+src/symfluence/data/acquisition/handlers/glhymps.py:GLHYMPSAcquirer._get_global_shapefile:except Exception as e:  # noqa: BLE001
 src/symfluence/data/acquisition/handlers/globsnow.py:GlobSnowAcquirer._download_daily_file:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/acquisition/handlers/globsnow.py:GlobSnowAcquirer._download_daily_file:except Exception:  # noqa: BLE001 — NSIDC fallback resilience
 src/symfluence/data/acquisition/handlers/globsnow.py:GlobSnowAcquirer._reproject_ease_to_wgs84:except Exception as e:  # noqa: BLE001 — preprocessing resilience
@@ -194,6 +195,7 @@ src/symfluence/data/acquisition/handlers/mswep.py:MSWEPAcquirer._download_ftp:ex
 src/symfluence/data/acquisition/handlers/mswep.py:MSWEPAcquirer._download_http:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/acquisition/handlers/nex_gddp.py:NEXGDDPCHandler.download:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/acquisition/handlers/openet.py:OpenETAcquirer._request_timeseries:except Exception as e:  # noqa: BLE001 — preprocessing resilience
+src/symfluence/data/acquisition/handlers/pelletier.py:PelletierAcquirer._create_earthdata_session:except Exception as e:  # noqa: BLE001
 src/symfluence/data/acquisition/handlers/pelletier.py:PelletierAcquirer.download:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/acquisition/handlers/polaris.py:POLARISAcquirer.download:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/acquisition/handlers/rdrs.py:RDRSAcquirer._download_http:except Exception as e:  # noqa: BLE001 — preprocessing resilience
@@ -220,6 +222,7 @@ src/symfluence/data/acquisition/handlers/viirs_snow.py:VIIRSSnowAcquirer._submit
 src/symfluence/data/acquisition/handlers/viirs_snow.py:VIIRSSnowAcquirer.download:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/acquisition/handlers/wokam.py:WOKAMAcquirer._get_global_shapefile:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/acquisition/handlers/wokam.py:WOKAMAcquirer.download:except Exception as e:  # noqa: BLE001 — preprocessing resilience
+src/symfluence/data/acquisition/handlers/worldclim.py:WorldClimAcquirer.download:except Exception as e:  # noqa: BLE001
 src/symfluence/data/acquisition/maf_pipeline.py:datatoolRunner.execute_datatool_command:except Exception as e:  # noqa: BLE001 — wrap-and-raise to domain error
 src/symfluence/data/acquisition/utils.py:resolve_credentials:except Exception as e:  # noqa: BLE001 — .netrc fallback is non-critical
 src/symfluence/data/acquisition/zonal_stats_processor.py:DataPreProcessor.calculate_land_stats:except Exception as e:  # noqa: BLE001 — wrap-and-raise to domain error

--- a/tools/quality/broad_exception_allowlist.txt
+++ b/tools/quality/broad_exception_allowlist.txt
@@ -764,6 +764,7 @@ src/symfluence/models/hype/config_manager.py:HYPEConfigManager.write_par_file:ex
 src/symfluence/models/hype/extractor.py:HYPEResultExtractor._extract_from_text:except Exception as e:  # noqa: BLE001 — wrap-and-raise to domain error
 src/symfluence/models/hype/forcing_processor.py:HYPEForcingProcessor._merge_forcing_files:except Exception as xe:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/hype/geodata_manager.py:HYPEGeoDataManager._calculate_geometry_area:except Exception as e:  # noqa: BLE001 — model execution resilience
+src/symfluence/models/hype/geodata_manager.py:HYPEGeoDataManager.create_geofiles:except Exception as e:  # noqa: BLE001
 src/symfluence/models/hype/geodata_manager.py:HYPEGeoDataManager.sort_geodata:except Exception as e:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/hype/geodata_manager.py:HYPEGeoDataManager.sort_geodata:except Exception as e:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/hype/plotter.py:HYPEPlotter.plot_streamflow:except Exception as e:  # noqa: BLE001 — model execution resilience

--- a/tools/quality/broad_exception_allowlist.txt
+++ b/tools/quality/broad_exception_allowlist.txt
@@ -236,6 +236,8 @@ src/symfluence/data/model_ready/attributes_builder.py:AttributesNetCDFBuilder._r
 src/symfluence/data/model_ready/forcings_builder.py:ForcingsStoreBuilder._enrich_metadata:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/model_ready/observations_builder.py:ObservationsNetCDFBuilder._read_timeseries_csv:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/model_ready/store_builder.py:ModelReadyStoreBuilder._compute_climate_statistics:except Exception as e:  # noqa: BLE001
+src/symfluence/data/model_ready/store_builder.py:ModelReadyStoreBuilder._compute_climate_statistics:except Exception:  # noqa: BLE001
+src/symfluence/data/model_ready/store_builder.py:ModelReadyStoreBuilder._compute_climate_statistics:except Exception:  # noqa: BLE001
 src/symfluence/data/observation/base.py:BaseObservationHandler._open_dataset:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/observation/base.py:BaseObservationHandler.safe_acquire:except Exception as e:  # noqa: BLE001 — wrap-and-raise to domain error
 src/symfluence/data/observation/base.py:BaseObservationHandler.safe_process:except Exception as e:  # noqa: BLE001 — wrap-and-raise to domain error
@@ -657,8 +659,6 @@ src/symfluence/models/fuse/calibration/model_execution.py:_log_fuse_diagnostics:
 src/symfluence/models/fuse/calibration/model_execution.py:_validate_fuse_output:except Exception as e:  # noqa: BLE001 — calibration resilience
 src/symfluence/models/fuse/calibration/model_execution.py:handle_fuse_output:except Exception as e:  # noqa: BLE001 — calibration resilience
 src/symfluence/models/fuse/calibration/model_execution.py:log_execution_directory:except Exception as e:  # noqa: BLE001 — calibration resilience
-src/symfluence/models/fuse/calibration/multi_gauge_metrics.py:MultiGaugeMetrics._extract_simulated_at_segment:except Exception as e:  # noqa: BLE001 — calibration resilience
-src/symfluence/models/fuse/calibration/multi_gauge_metrics.py:MultiGaugeMetrics._load_observed_streamflow:except Exception as e:  # noqa: BLE001 — calibration resilience
 src/symfluence/models/fuse/calibration/optimizer.py:FUSEModelOptimizer._add_elevation_params_to_constraints:except Exception as e:  # noqa: BLE001 — calibration resilience
 src/symfluence/models/fuse/calibration/optimizer.py:FUSEModelOptimizer._apply_best_parameters_for_final:except Exception as e:  # noqa: BLE001 — calibration resilience
 src/symfluence/models/fuse/calibration/optimizer.py:FUSEModelOptimizer._create_para_def_nc:except Exception as e:  # noqa: BLE001 — calibration resilience
@@ -1068,6 +1068,9 @@ src/symfluence/models/summa/calibration/parameter_manager.py:SUMMAParameterManag
 src/symfluence/models/summa/calibration/parameter_manager.py:SUMMAParameterManager._update_soil_depths:except Exception as e:  # noqa: BLE001 — calibration resilience
 src/symfluence/models/summa/calibration/worker.py:SUMMAWorker._apply_parameters_direct:except Exception as e:  # noqa: BLE001 — calibration resilience
 src/symfluence/models/summa/calibration/worker.py:SUMMAWorker._calculate_metrics_direct:except Exception as e:  # noqa: BLE001 — calibration resilience
+src/symfluence/models/summa/calibration/worker.py:SUMMAWorker._calculate_multi_gauge_metrics:except Exception as e:  # noqa: BLE001 — calibration resilience
+src/symfluence/models/summa/calibration/worker.py:SUMMAWorker._calculate_multi_gauge_metrics:except Exception as exc:  # noqa: BLE001
+src/symfluence/models/summa/calibration/worker.py:SUMMAWorker._ensure_gauge_mapping:except Exception as e:  # noqa: BLE001
 src/symfluence/models/summa/calibration/worker.py:SUMMAWorker._run_summa_direct:except Exception as e:  # noqa: BLE001 — calibration resilience
 src/symfluence/models/summa/calibration/worker.py:SUMMAWorker.apply_parameters:except Exception as e:  # noqa: BLE001 — calibration resilience
 src/symfluence/models/summa/calibration/worker.py:SUMMAWorker.calculate_metrics:except Exception as e:  # noqa: BLE001 — calibration resilience
@@ -1200,6 +1203,8 @@ src/symfluence/models/wrfhydro/preprocessor.py:WRFHydroPreProcessor.run_preproce
 src/symfluence/optimization/mixins/parallel_execution.py:ParallelExecutionMixin.execute_batch:except Exception as e2:  # noqa: BLE001 — must-not-raise contract
 src/symfluence/optimization/mixins/parallel_execution.py:ParallelExecutionMixin.execute_batch:except Exception as e:  # noqa: BLE001 — must-not-raise contract
 src/symfluence/optimization/mixins/parallel_execution.py:ParallelExecutionMixin.execute_batch:except Exception as e:  # noqa: BLE001 — must-not-raise contract
+src/symfluence/optimization/multi_gauge/metrics.py:MultiGaugeMetrics._extract_simulated_at_segment:except Exception as e:  # noqa: BLE001 — calibration resilience
+src/symfluence/optimization/multi_gauge/metrics.py:MultiGaugeMetrics._load_observed_streamflow:except Exception as e:  # noqa: BLE001 — calibration resilience
 src/symfluence/optimization/optimization_manager.py:OptimizationManager._calibrate_with_registry:except Exception as e:  # noqa: BLE001 — must-not-raise contract
 src/symfluence/optimization/optimizers/algorithms/sce_ua.py:SCEUAAlgorithm.optimize:except Exception as e:  # noqa: BLE001 - best-effort tracking path setup
 src/symfluence/optimization/optimizers/base_model_optimizer.py:BaseModelOptimizer._build_algorithm_callbacks.save_checkpoint:except Exception as e:  # noqa: BLE001 — must-not-raise contract

--- a/tools/quality/broad_exception_allowlist.txt
+++ b/tools/quality/broad_exception_allowlist.txt
@@ -233,6 +233,7 @@ src/symfluence/data/data_manager.py:DataManager._ensure_gauge_segment_mapping:ex
 src/symfluence/data/data_manager.py:DataManager._ensure_multi_gauge_dataset_present:except Exception as exc:  # noqa: BLE001 — let downstream errors surface specifics
 src/symfluence/data/data_manager.py:DataManager.process_observed_data:except Exception as e:  # noqa: BLE001 — must-not-raise contract
 src/symfluence/data/model_ready/attributes_builder.py:AttributesNetCDFBuilder._build_climate_group:except Exception as e:  # noqa: BLE001 — preprocessing resilience
+src/symfluence/data/model_ready/attributes_builder.py:AttributesNetCDFBuilder._build_csv_group:except Exception as e:  # noqa: BLE001
 src/symfluence/data/model_ready/attributes_builder.py:AttributesNetCDFBuilder._build_hru_identity_group:except Exception:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/model_ready/attributes_builder.py:AttributesNetCDFBuilder._build_hydrogeology_group:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/model_ready/attributes_builder.py:AttributesNetCDFBuilder._read_shapefile:except Exception as e:  # noqa: BLE001 — preprocessing resilience
@@ -316,11 +317,13 @@ src/symfluence/data/observation/handlers/viirs_snow.py:VIIRSSnowHandler.acquire:
 src/symfluence/data/observation/handlers/viirs_snow.py:VIIRSSnowHandler.get_processed_data:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/observation/handlers/viirs_snow.py:VIIRSSnowHandler.process:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/preprocessing/attribute_processor.py:attributeProcessor.process_attributes:except Exception as e:  # noqa: BLE001 — wrap-and-raise to domain error
+src/symfluence/data/preprocessing/attribute_processor.py:attributeProcessor.process_profile_attributes:except Exception as e:  # noqa: BLE001
 src/symfluence/data/preprocessing/attribute_processors/elevation.py:ElevationProcessor.generate_slope_and_aspect:except Exception as e:  # noqa: BLE001 — wrap-and-raise to domain error
 src/symfluence/data/preprocessing/attribute_processors/elevation.py:ElevationProcessor.process:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/preprocessing/attribute_processors/hydrology.py:HydrologyProcessor.calculate_baseflow_attributes:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/preprocessing/attribute_processors/hydrology.py:HydrologyProcessor.calculate_streamflow_signatures:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/preprocessing/attribute_processors/hydrology.py:HydrologyProcessor.calculate_water_balance:except Exception as e:  # noqa: BLE001 — preprocessing resilience
+src/symfluence/data/preprocessing/attribute_processors/landcover.py:LandCoverProcessor._process_lai_from_netcdf:except Exception as e:  # noqa: BLE001
 src/symfluence/data/preprocessing/attribute_processors/soil.py:SoilProcessor._check_and_set_nodata_value:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/preprocessing/attribute_processors/soil.py:SoilProcessor._read_scale_and_offset:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/preprocessing/dataset_alignment_manager.py:DatasetAlignmentManager._align_single_dataset:except Exception as e:  # noqa: BLE001 — preprocessing resilience


### PR DESCRIPTION
## Summary
- Wire attribute processors into the workflow pipeline so `ATTRIBUTE_PROFILE` controls processing as well as acquisition (depends on PR #108)
- Fix path defaults in all 4 attribute processors to match acquisition handler output locations
- Fix catchment shapefile discovery to handle `{method}/{experiment_id}/` subdirectories
- Add `process_profile_attributes()` to `attributeProcessor` — profile-driven orchestrator
- Make `ForcingResampler` non-fatal so attribute-only runs complete without forcing data
- Extend `AttributesNetCDFBuilder` with generic `_build_csv_group()` for new attribute categories

**End-to-end result on Bow at Banff with `ATTRIBUTE_PROFILE: camels_spat`:**
- 8 NetCDF groups with 484 total attributes
- climate: 358 vars (WorldClim 7 vars × 12 months × stats)
- soil_extended: 85 vars (SoilGrids texture 5 depths + Pelletier depths)
- landcover_extended: 32 vars (GLCLU fractions + LAI + forest height)
- Plus core groups: terrain, soil, landcover, hru_identity, topology

## Test plan
- [x] 5680 unit tests pass (0 regressions)
- [x] End-to-end: `acquire_attributes` → `define_domain` → `discretize_domain` → `model_agnostic_preprocessing` → `build_model_ready_store` verified on Bow at Banff
- [x] Backward compatibility: `ATTRIBUTE_PROFILE: core` produces identical output
- [x] Non-fatal failure: missing datasets (GLHYMPS) warn and continue

> Repo and code assistance from [Claude](https://claude.ai) (Anthropic).