### PR TITLE
feat(ngen): add mizuRoute routing for SAC-SMA and TOPMODEL

### DIFF
--- a/src/symfluence/models/mizuroute/control_writer.py
+++ b/src/symfluence/models/mizuroute/control_writer.py
@@ -79,6 +79,17 @@ MODEL_CONFIGS = {
         hru_var='gruId',
         comment_name='GR4J'
     ),
+    'ngen': ModelRunoffConfig(
+        output_dir_key='EXPERIMENT_OUTPUT_NGEN',
+        output_dir_name='NGEN',
+        default_var='runoff',
+        default_units='m/s',
+        default_dt='3600',
+        output_file_pattern='{experiment_id}_runoff.nc',
+        hru_dim='hru',
+        hru_var='hruId',
+        comment_name='NGEN'
+    ),
 }
 
 
@@ -171,6 +182,7 @@ class ControlFileWriter(ConfigurableMixin):
             'EXPERIMENT_OUTPUT_SUMMA': lambda: self.config.model.summa.experiment_output,
             'EXPERIMENT_OUTPUT_FUSE': lambda: self.config.model.fuse.experiment_output,
             'EXPERIMENT_OUTPUT_GR': lambda: self.config.model.gr.experiment_output,
+            'EXPERIMENT_OUTPUT_NGEN': lambda: self.config.model.ngen.experiment_output if self.config.model.ngen else None,
         }
         getter = key_to_config.get(model_config.output_dir_key)
         if getter:

--- a/src/symfluence/models/mizuroute/preprocessor.py
+++ b/src/symfluence/models/mizuroute/preprocessor.py
@@ -370,6 +370,8 @@ class MizuRoutePreProcessor(BaseModelPreProcessor, GeospatialUtilsMixin, MizuRou
             self.create_fuse_control_file()
         elif from_model == 'GR' or gr_routing == 'mizuRoute':
             self.create_gr_control_file()
+        elif from_model == 'NGEN':
+            self.create_ngen_control_file()
         else:
             self.create_control_file()
 
@@ -464,6 +466,22 @@ class MizuRoutePreProcessor(BaseModelPreProcessor, GeospatialUtilsMixin, MizuRou
         writer = self._get_control_writer()
         mizu_config = self._get_mizu_config()
         writer.write_control_file(model_type='gr', mizu_config=mizu_config)
+
+    def create_ngen_control_file(self):
+        """Create mizuRoute control file for NGEN runoff input.
+
+        NGEN modules like SAC-SMA and TOPMODEL produce raw runoff without
+        built-in routing (unlike CFE which has GIUH). The NGEN postprocessor
+        converts nexus CSV outputs to a mizuRoute-compatible NetCDF with
+        runoff in m/s. This control file points mizuRoute at that NetCDF.
+
+        doesBasinRoute is set to 1 (IRF hillslope routing) since NGEN's
+        SAC-SMA/TOPMODEL output is unrouted.
+        """
+        writer = self._get_control_writer()
+        mizu_config = self._get_mizu_config()
+        mizu_config['within_basin'] = 1
+        writer.write_control_file(model_type='ngen', mizu_config=mizu_config)
 
     def _get_control_writer(self) -> ControlFileWriter:
         """Get a configured ControlFileWriter instance."""

--- a/src/symfluence/models/mizuroute/runner.py
+++ b/src/symfluence/models/mizuroute/runner.py
@@ -125,6 +125,10 @@ class MizuRouteRunner(BaseModelRunner):  # type: ignore[misc]
             else:
                 experiment_output_dir = Path(experiment_output_hype)
             runoff_filename = f"{self.experiment_id}_timestep.nc"
+        elif 'NGEN' in active_models:
+            self.logger.info("NGEN runoff NetCDF for mizuRoute — checking time precision")
+            experiment_output_dir = self.project_dir / f"simulations/{self.experiment_id}" / 'NGEN'
+            runoff_filename = f"{self.experiment_id}_runoff.nc"
         else:
             self.logger.info(f"Fixing SUMMA time precision for mizuRoute compatibility (Active models: {active_models})")
             experiment_output_summa = self._get_config_value(
@@ -490,6 +494,8 @@ class MizuRouteRunner(BaseModelRunner):  # type: ignore[misc]
                     control_file = 'mizuRoute_control_GR.txt'
                 elif mizu_from == 'FUSE':
                     control_file = 'mizuRoute_control_FUSE.txt'
+                elif mizu_from == 'NGEN':
+                    control_file = 'mizuroute.control'
                 else:
                     control_file = 'mizuroute.control'
                 self.logger.debug(f"Using default mizuRoute control file: {control_file}")

--- a/src/symfluence/models/mizuroute/topology_generator.py
+++ b/src/symfluence/models/mizuroute/topology_generator.py
@@ -76,9 +76,14 @@ class MizuRouteTopologyGenerator:
 
         # Check if this is lumped domain with distributed routing
         # If so, use the delineated river network (from distributed delineation)
+        routing_delineation = self.pp._get_config_value(
+            lambda: self.pp.config.domain.routing,
+            default='lumped',
+            dict_key='ROUTING_DELINEATION',
+        )
         is_lumped_to_distributed = (
             self.pp.domain_definition_method == 'lumped' and
-            self.pp._get_config_value(lambda: self.pp.config.model.mizuroute.routing_delineation, default='river_network') == 'river_network'
+            routing_delineation == 'river_network'
         )
 
         # For lumped-to-distributed, use delineated river network and catchments

--- a/src/symfluence/models/model_manager.py
+++ b/src/symfluence/models/model_manager.py
@@ -40,8 +40,12 @@ class ModelManager(BaseManager):
         execution_list = []
 
         # Models that need an EXTERNAL routing step (standalone MIZUROUTE/dRoute).
-        # FUSE and GR handle routing internally in their runners (like MESH, HYPE, NGEN).
+        # FUSE and GR handle routing internally in their runners (like MESH, HYPE).
+        # NGEN: CFE has built-in GIUH routing, but SAC-SMA and TOPMODEL do not —
+        # so NGEN needs external routing when using those modules.
         routable_models = {'SUMMA'}
+        if 'NGEN' in configured_models and self._ngen_needs_external_routing():
+            routable_models.add('NGEN')
 
         # Determine which routing model to use
         routing_model = self._get_config_value(
@@ -125,6 +129,38 @@ class ModelManager(BaseManager):
                         execution_list.insert(pf_idx + 1, rt)
 
         return execution_list
+
+    def _ngen_needs_external_routing(self) -> bool:
+        """Check if the active NGEN runoff module lacks built-in routing.
+
+        CFE has a built-in GIUH (Geomorphologic Instantaneous Unit Hydrograph),
+        so it doesn't need external routing. SAC-SMA and TOPMODEL produce raw
+        runoff that requires an external routing step (mizuRoute or t-route).
+        """
+        modules_str = self._get_config_value(
+            lambda: self.config.model.ngen.modules_selected,
+            default='SLOTH,PET,CFE',
+        )
+        alias_map = {'SAC-SMA': 'SACSMA', 'SNOW-17': 'SNOW17', 'NOAH-OWP': 'NOAH'}
+        selected = set()
+        for m in str(modules_str).split(','):
+            name = m.strip().upper()
+            if name:
+                selected.add(alias_map.get(name, name))
+
+        has_cfe = 'CFE' in selected
+        has_sacsma = 'SACSMA' in selected
+        has_topmodel = 'TOPMODEL' in selected
+
+        if has_sacsma or has_topmodel:
+            self.logger.info(
+                f"NGEN using {'SAC-SMA' if has_sacsma else 'TOPMODEL'} — "
+                "no built-in routing; external routing eligible"
+            )
+            return True
+        if has_cfe:
+            self.logger.debug("NGEN using CFE with built-in GIUH — external routing not required")
+        return False
 
     def _ensure_mizuroute_in_workflow(self, execution_list: List[str], source_model: str):
         """

--- a/src/symfluence/models/ngen/postprocessor.py
+++ b/src/symfluence/models/ngen/postprocessor.py
@@ -8,8 +8,9 @@ Processes simulation outputs from the NOAA NextGen Framework (ngen).
 Migrated to use StandardModelPostprocessor with multi-file support (Phase 1.5).
 """
 
+import json
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -153,10 +154,20 @@ class NgenPostprocessor(StandardModelPostprocessor):
             aggregated_flow = combined_streamflow.groupby('datetime')['streamflow_cms'].sum()
 
         # Save using standard method
-        return self.save_streamflow_to_results(
+        result = self.save_streamflow_to_results(
             aggregated_flow,
             model_column_name=f"NGEN_{experiment_id}_discharge_cms"
         )
+
+        # If mizuRoute is the routing model, convert nexus CSVs to NetCDF
+        routing_model = self._get_config_value(
+            lambda: self.config.model.routing_model, default=None
+        )
+        if routing_model and str(routing_model).upper() in ('MIZUROUTE', 'MIZU_ROUTE', 'MIZU'):
+            self.logger.info("mizuRoute routing configured — converting NGEN output to NetCDF")
+            self.convert_output_to_mizuroute_netcdf(experiment_id=experiment_id)
+
+        return result
 
     def _read_ngen_nexus_file(self, nexus_file: Path) -> Optional[pd.DataFrame]:
         """
@@ -173,7 +184,7 @@ class NgenPostprocessor(StandardModelPostprocessor):
         """
         try:
             # First try reading with header
-            df = pd.read_csv(nexus_file)
+            df = pd.read_csv(nexus_file, skipinitialspace=True)
 
             # Check for standard NGEN headerless format (index, time, flow)
             is_headerless = False
@@ -187,11 +198,11 @@ class NgenPostprocessor(StandardModelPostprocessor):
                     pass
 
             if is_headerless:
-                # Reload with header=None
                 df = pd.read_csv(
                     nexus_file,
                     header=None,
-                    names=['index', 'time', 'flow']
+                    names=['index', 'time', 'flow'],
+                    skipinitialspace=True,
                 )
                 flow_col = 'flow'
             else:
@@ -217,10 +228,9 @@ class NgenPostprocessor(StandardModelPostprocessor):
                 self.logger.warning(f"No time column found in {nexus_file}")
                 return None
 
-            # Create standardized output dataframe
             return pd.DataFrame({
                 'datetime': time,
-                'streamflow_cms': df[flow_col]
+                'streamflow_cms': pd.to_numeric(df[flow_col], errors='coerce')
             })
 
         except Exception as e:  # noqa: BLE001 — model execution resilience
@@ -264,3 +274,162 @@ class NgenPostprocessor(StandardModelPostprocessor):
         kge = 1 - np.sqrt((r - 1)**2 + (alpha - 1)**2 + (beta - 1)**2)
 
         return kge
+
+    # -----------------------------------------------------------------
+    # mizuRoute integration: convert NGEN CSV output → NetCDF
+    # -----------------------------------------------------------------
+
+    def convert_output_to_mizuroute_netcdf(
+        self,
+        experiment_id: Optional[str] = None,
+    ) -> Optional[Path]:
+        """Convert NGEN nexus CSV outputs to a mizuRoute-compatible NetCDF.
+
+        mizuRoute expects a NetCDF file with dimensions (time, hru) containing
+        a runoff variable in depth/time units (m/s). NGEN outputs per-nexus
+        CSV files with flow in m³/s. This method reads all nexus CSVs,
+        converts flow to runoff depth using catchment areas, and writes the
+        result as a single NetCDF.
+
+        Args:
+            experiment_id: Override experiment ID (default: from config)
+
+        Returns:
+            Path to the generated NetCDF file, or None on failure.
+        """
+        import xarray as xr
+
+        if experiment_id is None:
+            experiment_id = self._get_config_value(
+                lambda: self.config.domain.experiment_id, default='run_1'
+            )
+
+        output_dir = self.project_dir / 'simulations' / experiment_id / self.model_name
+        nexus_files = sorted(output_dir.glob(self.output_file_glob))
+
+        if not nexus_files:
+            self.logger.error(f"No nexus output files in {output_dir}")
+            return None
+
+        # Load catchment areas from the GeoJSON written by the preprocessor
+        domain_name = self._get_config_value(
+            lambda: self.config.domain.name, default='domain'
+        )
+        areas_km2 = self._load_catchment_areas(domain_name)
+
+        # Read each nexus file into a per-HRU timeseries
+        hru_data: Dict[str, pd.Series] = {}
+        for nexus_file in nexus_files:
+            df = self._read_ngen_nexus_file(nexus_file)
+            if df is None:
+                continue
+
+            nexus_id = nexus_file.stem.replace('_output', '')
+            cat_id = nexus_id.replace('nex-', 'cat-')
+            hru_data[cat_id] = df.set_index('datetime')['streamflow_cms']
+
+        if not hru_data:
+            self.logger.error("No valid nexus data could be read")
+            return None
+
+        # Build a DataFrame: columns=catchment IDs, index=time, values=flow (m³/s)
+        flow_df = pd.DataFrame(hru_data)
+        flow_df.index = pd.to_datetime(flow_df.index)
+        flow_df = flow_df.sort_index()
+
+        # Convert m³/s → m/s (runoff depth) using catchment area
+        runoff_df = flow_df.copy()
+        for cat_id in runoff_df.columns:
+            area_km2 = areas_km2.get(cat_id, None)
+            if area_km2 is None or area_km2 <= 0:
+                self.logger.warning(
+                    f"No area for {cat_id}, using 1.0 km² — "
+                    "runoff depth will be approximate"
+                )
+                area_km2 = 1.0
+            area_m2 = area_km2 * 1e6
+            runoff_df[cat_id] = flow_df[cat_id] / area_m2
+
+        # Assign integer HRU IDs (1-based)
+        hru_ids = list(range(1, len(runoff_df.columns) + 1))
+
+        # Build xarray Dataset
+        time_values = runoff_df.index.values
+        runoff_array = runoff_df.values
+
+        ds = xr.Dataset(
+            {
+                'runoff': (['time', 'hru'], runoff_array, {
+                    'units': 'm/s',
+                    'long_name': 'NGEN catchment runoff',
+                }),
+                'hruId': (['hru'], np.array(hru_ids, dtype=np.int32), {
+                    'long_name': 'HRU identifier',
+                }),
+            },
+            coords={
+                'time': time_values,
+            },
+            attrs={
+                'source': 'NGEN via SYMFLUENCE',
+                'experiment_id': experiment_id,
+                'history': 'Converted from NGEN nexus CSV outputs for mizuRoute routing',
+            },
+        )
+
+        nc_path = output_dir / f"{experiment_id}_runoff.nc"
+        ds.to_netcdf(nc_path, format='NETCDF4')
+        self.logger.info(
+            f"NGEN → mizuRoute NetCDF written: {nc_path} "
+            f"({len(hru_ids)} HRUs, {len(time_values)} timesteps)"
+        )
+        return nc_path
+
+    def _load_catchment_areas(self, domain_name: str) -> Dict[str, float]:
+        """Load catchment areas (km²) from the NGEN catchments GeoJSON."""
+        settings_dir = self.project_dir / "settings" / "NGEN"
+
+        geojson_path = settings_dir / f"{domain_name}_catchments.geojson"
+        if geojson_path.exists():
+            try:
+                with open(geojson_path, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+
+                areas: Dict[str, float] = {}
+                for feature in data.get('features', []):
+                    props = feature.get('properties', {})
+                    cat_id = props.get('id', props.get('cat_id', ''))
+                    for area_key in ['areasqkm', 'area_km2', 'area_sqkm', 'AREA']:
+                        if area_key in props and props[area_key] is not None:
+                            area_val = float(props[area_key])
+                            if area_val > 1e6:
+                                area_val /= 1e6
+                            areas[cat_id] = area_val
+                            break
+                return areas
+            except Exception as e:  # noqa: BLE001
+                self.logger.warning(f"Could not read catchment areas from {geojson_path}: {e}")
+
+        gpkg_path = settings_dir / f"{domain_name}_catchments.gpkg"
+        if gpkg_path.exists():
+            try:
+                import geopandas as gpd
+                gdf = gpd.read_file(gpkg_path)
+                areas = {}
+                id_col = next((c for c in ['id', 'cat_id', 'HRU_ID'] if c in gdf.columns), None)
+                area_col = next(
+                    (c for c in ['areasqkm', 'area_km2', 'area_sqkm', 'AREA', 'HRU_area']
+                     if c in gdf.columns), None
+                )
+                if id_col and area_col:
+                    for _, row in gdf.iterrows():
+                        area_val = float(row[area_col])
+                        if area_val > 1e6:
+                            area_val /= 1e6
+                        areas[str(row[id_col])] = area_val
+                return areas
+            except Exception as e:  # noqa: BLE001
+                self.logger.warning(f"Could not read catchment areas from {gpkg_path}: {e}")
+
+        self.logger.warning("No catchment area file found — using default 1.0 km² for all HRUs")
+        return {}

--- a/src/symfluence/models/ngen/runner.py
+++ b/src/symfluence/models/ngen/runner.py
@@ -489,6 +489,14 @@ class NgenRunner(BaseModelRunner):  # type: ignore[misc]
         """
         import json
 
+        # If mizuRoute handles routing externally, skip t-route entirely
+        routing_model = self._get_config_value(
+            lambda: self.config.model.routing_model, default=None
+        )
+        if routing_model and str(routing_model).upper() in ('MIZUROUTE', 'MIZU_ROUTE', 'MIZU'):
+            self.logger.info("Skipping t-route — mizuRoute will handle routing externally.")
+            return True
+
         try:
             # Check if ngen_routing is available
             from ngen_routing.ngen_main import ngen_main
@@ -517,10 +525,25 @@ class NgenRunner(BaseModelRunner):  # type: ignore[misc]
             except Exception as e:  # noqa: BLE001 — model execution resilience
                 self.logger.debug(f"Could not parse nexus file for lumped detection: {e}")
 
-        # For lumped domains, we can skip routing and use nexus output directly
+        # For lumped domains, t-route channel routing is not needed.
+        # However, if the active runoff module lacks built-in routing (SAC-SMA,
+        # TOPMODEL), the nexus output is raw unrouted runoff — an external
+        # routing model (mizuRoute) must handle attenuation separately.
         if is_lumped:
-            self.logger.info("Skipping t-route for lumped domain - nex-*.csv output is already at the outlet.")
-            return True  # Return True since flow is already at outlet
+            routing_model = self._get_config_value(
+                lambda: self.config.model.routing_model, default=None
+            )
+            routing_upper = str(routing_model).upper() if routing_model else ''
+            if routing_upper in ('MIZUROUTE', 'MIZU_ROUTE', 'MIZU'):
+                self.logger.info(
+                    "Lumped domain — skipping t-route; mizuRoute will handle routing."
+                )
+            else:
+                self.logger.info(
+                    "Skipping t-route for lumped domain — "
+                    "nex-*.csv output is already at the outlet."
+                )
+            return True
 
         # Create troute output directory
         troute_output_dir = output_dir / "troute_output"

--- a/tools/quality/broad_exception_allowlist.txt
+++ b/tools/quality/broad_exception_allowlist.txt
@@ -938,6 +938,8 @@ src/symfluence/models/ngen/calibration/worker.py:NgenWorker.apply_parameters:exc
 src/symfluence/models/ngen/calibration/worker.py:NgenWorker.calculate_metrics:except Exception as e:  # noqa: BLE001 — calibration resilience
 src/symfluence/models/ngen/calibration/worker.py:NgenWorker.run_model:except Exception as e:  # noqa: BLE001 — calibration resilience
 src/symfluence/models/ngen/plotter.py:NGENPlotter.plot_results:except Exception as e:  # noqa: BLE001 — model execution resilience
+src/symfluence/models/ngen/postprocessor.py:NgenPostprocessor._load_catchment_areas:except Exception as e:  # noqa: BLE001
+src/symfluence/models/ngen/postprocessor.py:NgenPostprocessor._load_catchment_areas:except Exception as e:  # noqa: BLE001
 src/symfluence/models/ngen/postprocessor.py:NgenPostprocessor._read_ngen_nexus_file:except Exception as e:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/ngen/postprocessor.py:NgenPostprocessor.extract_streamflow:except Exception as e:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/ngen/preprocessor.py:NgenPreProcessor._create_troute_topology:except Exception as e:  # noqa: BLE001 — model execution resilience


### PR DESCRIPTION
## Summary

- Adds mizuRoute as an external routing option for NGEN when using SAC-SMA or TOPMODEL (which lack CFE's built-in GIUH routing)
- Converts NGEN nexus CSV output to mizuRoute-compatible NetCDF (m³/s flow → m/s runoff depth)
- Fixes topology generator reading `routing_delineation` from wrong config namespace
- Fixes NGEN CSV parser choking on leading-space values

## Context

Anthony Preucil reported that SAC-SMA storm events were "instantly running off" — sharp unattenuated peaks with no baseflow. Root cause: SAC-SMA in NGEN has no built-in unit hydrograph (unlike CFE which has GIUH), and the framework assumed all NGEN modules handle routing internally.

## Changes (7 files, +281/-12)

| File | Change |
|------|--------|
| `model_manager.py` | Conditionally add NGEN to `routable_models` when SAC-SMA/TOPMODEL active |
| `ngen/runner.py` | Skip t-route when mizuRoute handles routing; improved lumped domain logging |
| `ngen/postprocessor.py` | CSV→NetCDF conversion for mizuRoute; `skipinitialspace` + `pd.to_numeric` fixes |
| `mizuroute/control_writer.py` | NGEN model config (`doesBasinRoute=1` for IRF hillslope routing) |
| `mizuroute/preprocessor.py` | `create_ngen_control_file()` + dispatch |
| `mizuroute/runner.py` | NGEN in time precision fix + control file selection |
| `mizuroute/topology_generator.py` | Read `ROUTING_DELINEATION` from `domain.routing` instead of non-existent `mizuroute.routing_delineation` |

## Test plan

- [x] NGEN SAC-SMA lumped (1 catchment) + mizuRoute — forward run
- [x] NGEN SAC-SMA semi-distributed (29 catchments) + mizuRoute — forward run
- [x] SUMMA semi-distributed + mizuRoute + DDS 5x calibration (no regression)
- [x] FUSE distributed + mizuRoute + DDS 5x calibration, KGE=0.88 (no regression)
- [x] GR4J distributed + mizuRoute + DDS 5x calibration (no regression)
- [x] 5683 unit tests pass, 0 regressions

> Repo and code assistance from [Claude](https://claude.ai) (Anthropic).