### PR TITLE
feat(summa): parallel GRU calibration + Iceland SUMMA config

### DIFF
--- a/examples/iceland_national_model/config_iceland_summa_glacier.yaml
+++ b/examples/iceland_national_model/config_iceland_summa_glacier.yaml
@@ -1,0 +1,271 @@
+# Iceland National Water Model — SUMMA + mizuRoute (Glacier Mode)
+#
+# Semi-distributed setup across all of Iceland using TauDEM delineation
+# with elevation-band HRUs, CARRA forcing, and LamaH-ICE observations.
+# Glacier mode enabled for Vatnajökull, Langjökull, Hofsjökull, etc.
+#
+# Key advantage over HYPE: SUMMA supports per-GRU parameter variation,
+# breaking through the class-level parameter ceiling (~0.13 median KGE).
+
+# ── System ──────────────────────────────────────────────────────────
+SYMFLUENCE_DATA_DIR: default
+SYMFLUENCE_CODE_DIR: default
+NUM_PROCESSES: 1
+FORCE_RUN_ALL_STEPS: false
+LOG_LEVEL: INFO
+LOG_TO_FILE: true
+LOG_FORMAT: detailed
+
+# ── Domain identification ───────────────────────────────────────────
+DOMAIN_NAME: Iceland_National
+EXPERIMENT_ID: iceland_summa_glacier_v1
+
+# ── Temporal extent ─────────────────────────────────────────────────
+# 5-year spinup (1998-2002) to fill soil, snow, and glacier stores,
+# 5 years calibration, 3 years evaluation
+EXPERIMENT_TIME_START: 1998-01-01 00:00
+EXPERIMENT_TIME_END:   2010-12-31 00:00
+SPINUP_PERIOD:         1998-01-01, 2002-12-31
+CALIBRATION_PERIOD:    2003-01-01 00:00, 2007-12-31 00:00
+EVALUATION_PERIOD:     2008-01-01 00:00, 2010-12-31 00:00
+
+# ── Spatial domain ──────────────────────────────────────────────────
+BOUNDING_BOX_COORDS: 66.6/-24.6/63.2/-13.2
+POUR_POINT_COORDS: 64.5/-18.5
+
+DOMAIN_DEFINITION_METHOD: delineate
+ROUTING_DELINEATION: distributed
+GEOFABRIC_TYPE: na
+DELINEATION_METHOD: stream_threshold
+STREAM_THRESHOLD: 5000
+LUMPED_WATERSHED_METHOD: TauDEM
+
+DELINEATE_COASTAL_WATERSHEDS: true
+DELINEATE_BY_POURPOINT: false
+MOVE_OUTLETS_MAX_DISTANCE: 200
+CLEANUP_INTERMEDIATE_FILES: false
+
+# ── Sub-grid discretization ────────────────────────────────────────
+# Elevation bands for snow/glacier dynamics — 300m bands (same as HYPE)
+DOMAIN_DISCRETIZATION: GRUs
+SUB_GRID_DISCRETIZATION: elevation
+ELEVATION_BAND_SIZE: 300
+MIN_HRU_SIZE: 4
+MIN_GRU_SIZE: 0
+
+# ── DEM & land surface data ────────────────────────────────────────
+DATA_ACCESS: cloud
+DEM_SOURCE: copdem90
+SOILGRIDS_LAYER: wrb_0-5cm_mode
+ATTRIBUTE_PROFILE: full
+
+# ── Forcing ─────────────────────────────────────────────────────────
+# CARRA (2.5km Arctic reanalysis) — much better for Iceland than ERA5
+FORCING_DATASET: CARRA
+FORCING_VARIABLES: default
+FORCING_MEASUREMENT_HEIGHT: 2
+FORCING_TIME_STEP_SIZE: 3600
+APPLY_LAPSE_RATE: true
+LAPSE_RATE: 0.0065
+PET_METHOD: oudin
+SUPPLEMENT_FORCING: false
+
+# ── Observations — LamaH-ICE ───────────────────────────────────────
+EVALUATION_DATA:
+  - streamflow
+STREAMFLOW_DATA_PROVIDER: LAMAH_ICE
+LAMAH_ICE_DOMAIN_ID: 105
+LAMAH_ICE_PATH: default
+
+# ── Multi-gauge calibration ────────────────────────────────────────
+# Same curated gauge set as HYPE baseline for direct comparison
+MULTI_GAUGE_CALIBRATION: true
+MULTI_GAUGE_OBS_DIR: /Users/darri.eythorsson/compHydro/SYMFLUENCE_data/lamah_ice/D_gauges/2_timeseries/daily
+MULTI_GAUGE_AGGREGATION: median
+MULTI_GAUGE_MIN_GAUGES: 5
+MULTI_GAUGE_KGE_FLOOR: -0.41
+MULTI_GAUGE_MAX_DISTANCE: 0.1
+MULTI_GAUGE_MIN_OVERLAP_DAYS: 365
+MULTI_GAUGE_EXCLUDE_IDS:
+  # Reservoir / hydropower
+  - 6    # Blöndulón Reservoir
+  - 43   # Hálslón Reservoir
+  - 51   # Hágöngulón Reservoir
+  - 62   # Lagarfossvirkjun
+  - 78   # Smyrlabjargaárvirkjun
+  - 104  # Þjórsárlón Reservoir
+  # Period-duplicates
+  - 99   # Norðlingaalda 1970-1980
+  - 990  # Norðlingaalda 1985-1996
+  - 101  # Dynkur 1988-1996
+  # No obs in calibration period
+  - 5    # Hylvað
+  - 10   # Dalsá
+  - 19   # Þjórsárdal
+  - 49   # Sauðafell
+  - 50   # Klifshagavellir
+  - 52   # Þveralda
+  - 53   # Við Brúarfoss
+  - 57   # Gegnt Klúku
+  - 61   # Kálfá
+  - 87   # Hrauneyjafoss
+  - 88   # Hald
+  - 89   # Faxi
+  - 100  # Sandafell
+  - 103  # Tröllkonuhlaup
+  - 107  # Þórisós
+  - 4    # Austurbugur
+  - 28   # Litla-Gljúfur
+  - 41   # Djúpárbakki
+  # Unmappable
+  - 96   # Álftafitjakvísl
+  - 82   # Hófleðurshóll
+  - 85   # Tjaldkvísl
+  - 25   # ofan Landbrotsár
+  - 94   # Víðidalsá, Kolugil
+  - 44   # Kálfseyrarvað
+  # Variance/correlation failures
+  - 64   # Helluvað
+  - 95   # Árbæjarfoss
+  - 65   # Fossbrún
+  - 90   # Efstalækjarbrú
+  - 7    # Langamýri
+  - 47   # Hóll
+  - 20   # Hjálp
+  - 14   # Tungufoss
+  - 37   # Kljáfoss
+  - 890  # Faxi (duplicate)
+  - 77   # Aldeyjarfoss
+  - 56   # Ofan Folavatns
+  - 58   # Keldnaholt
+  # Zero SLC / remapped failures from HYPE
+  - 1    # Laugafljót
+  - 24   # gamla brú
+  - 26   # Reyðarvatnsós
+  - 29   # Einstigsfoss
+  - 71   # ofan Sultarkrika
+  - 9    # Syðri-Bægisá
+  - 69   # Brúaröræfum
+  - 79   # Ásgarður
+  - 83   # ofan Ullarfossbrúar
+
+# ── Model: SUMMA ────────────────────────────────────────────────────
+HYDROLOGICAL_MODEL: SUMMA
+SUMMA_EXE: summa_sundials.exe
+SETTINGS_SUMMA_CONNECT_HRUS: true
+
+# Glacier mode disabled — installed SUMMA v4.0.0-exp-sundials doesn't
+# support initGridFile/attribGridFile. Snow physics still active.
+SETTINGS_SUMMA_GLACIER_MODE: false
+
+# Parallel GRU execution — split 696 GRUs across 8 cores
+# Each core handles ~87 GRUs, cutting runtime from ~10h to ~1.25h per iteration
+SETTINGS_SUMMA_USE_PARALLEL_SUMMA: true
+SETTINGS_SUMMA_CPUS_PER_TASK: 8
+
+# Timeout per iteration (parallel): slowest GRU split can take 4-5 hours
+SUMMA_TIMEOUT: 21600
+
+# Calibration parameters — per-GRU variation via transfer function
+# Snow: tempCritRain, frozenPrecipMultip
+# Soil: k_soil, vGn_n, theta_sat, Fcapil, k_macropore
+# Routing: routingGammaScale, routingGammaShape
+PARAMS_TO_CALIBRATE: tempCritRain,k_soil,vGn_n,theta_sat,frozenPrecipMultip,Fcapil,k_macropore
+BASIN_PARAMS_TO_CALIBRATE: routingGammaScale,routingGammaShape
+
+# Transfer function regionalization — per-GRU parameters from attributes
+PARAMETER_REGIONALIZATION: transfer_function
+
+# SUMMA decisions — cold-region & glacier-appropriate physics
+SUMMA_DECISION_OPTIONS:
+  snowIncept:
+    - lightSnow
+  compaction:
+    - anderson
+  snowLayers:
+    - CLM_2010
+  alb_method:
+    - conDecay
+  thCondSnow:
+    - smnv2000
+  vegeParTbl:
+    - MODIFIED_IGBP_MODIS_NOAH
+  soilStress:
+    - NoahType
+  stomResist:
+    - BallBerry
+  LAI_method:
+    - monTable
+  veg_traits:
+    - Raupach_BLM1994
+  canopyEmis:
+    - difTrans
+  windPrfile:
+    - logBelowCanopy
+  canopySrad:
+    - BeersLaw
+  soilCatTbl:
+    - ROSETTA
+  f_Richards:
+    - mixdform
+  groundwatr:
+    - bigBuckt
+  hc_profile:
+    - constant
+  bcLowrSoiH:
+    - drainage
+  thCondSoil:
+    - funcSoilWet
+  spatial_gw:
+    - localColumn
+  subRouting:
+    - timeDlay
+  num_method:
+    - itertive
+  fDerivMeth:
+    - analytic
+  bcUpprTdyn:
+    - nrg_flux
+  bcLowrTdyn:
+    - zeroFlux
+  bcUpprSoiH:
+    - liq_flux
+  astability:
+    - louisinv
+
+# ── Routing: mizuRoute ──────────────────────────────────────────────
+ROUTING_MODEL: mizuRoute
+INSTALL_PATH_MIZUROUTE: default
+EXE_NAME_MIZUROUTE: mizuRoute.exe
+MIZUROUTE_TIMEOUT: 7200
+MIZUROUTE_NUM_THREADS: 8
+SETTINGS_MIZU_ROUTING_DT: 3600
+SETTINGS_MIZU_ROUTING_UNITS: m/s
+SETTINGS_MIZU_ROUTING_VAR: averageRoutedRunoff
+SETTINGS_MIZU_OUTPUT_FREQ: single
+SETTINGS_MIZU_OUTPUT_VARS: 1
+SETTINGS_MIZU_NEEDS_REMAP: false
+
+# ── Optimization ────────────────────────────────────────────────────
+OPTIMIZATION_METHODS:
+  - iteration
+OPTIMIZATION_TARGET: streamflow
+CALIBRATION_TIMESTEP: daily
+ITERATIVE_OPTIMIZATION_ALGORITHM: DDS
+NUMBER_OF_ITERATIONS: 1000
+DDS_R: 0.2
+OPTIMIZATION_METRIC: KGE
+
+# ── Shapefile field mappings ────────────────────────────────────────
+CATCHMENT_SHP_LAT: center_lat
+CATCHMENT_SHP_LON: center_lon
+CATCHMENT_SHP_AREA: HRU_area
+CATCHMENT_SHP_HRUID: HRU_ID
+CATCHMENT_SHP_GRUID: GRU_ID
+RIVER_BASIN_SHP_RM_GRUID: GRU_ID
+RIVER_BASIN_SHP_HRU_TO_SEG: gru_to_seg
+RIVER_BASIN_SHP_AREA: GRU_area
+RIVER_NETWORK_SHP_LENGTH: Length
+RIVER_NETWORK_SHP_SEGID: LINKNO
+RIVER_NETWORK_SHP_DOWNSEGID: DSLINKNO
+RIVER_NETWORK_SHP_SLOPE: Slope

--- a/src/symfluence/models/mizuroute/build_instructions.py
+++ b/src/symfluence/models/mizuroute/build_instructions.py
@@ -93,7 +93,7 @@ perl -i -pe "s|^FC_EXE\s*=.*$|FC_EXE = ${FC:-gfortran}|" Makefile
 perl -i -pe "s|^EXE\s*=.*$|EXE = mizuRoute.exe|" Makefile
 perl -i -pe "s|^F_MASTER\s*=.*$|F_MASTER = $F_MASTER_PATH/|" Makefile
 perl -i -pe "s|^\s*NCDF_PATH\s*=.*$|NCDF_PATH = ${NETCDF_FORTRAN}|" Makefile
-perl -i -pe "s|^isOpenMP\s*=.*$|isOpenMP = no|" Makefile
+perl -i -pe "s|^isOpenMP\s*=.*$|isOpenMP = ${MIZUROUTE_OPENMP:-no}|" Makefile
 
 # Fix LIBNETCDF for separate C/Fortran libs (e.g., macOS Homebrew, HPC with separate installs)
 # Note: LIBNETCDF in mizuRoute is a multi-line definition with backslash continuation,

--- a/src/symfluence/models/mizuroute/runner.py
+++ b/src/symfluence/models/mizuroute/runner.py
@@ -521,15 +521,22 @@ class MizuRouteRunner(BaseModelRunner):  # type: ignore[misc]
             if backup == 'yes':
                 self.backup_settings(settings_path, backup_subdir="run_settings")
 
-            # Run mizuRoute
+            # Run mizuRoute (with OpenMP thread count if configured)
             mizu_log_path.mkdir(parents=True, exist_ok=True)
             mizu_command = [str(self.mizu_exe), str(settings_path / control_file)]
-            self.logger.debug(f'Running mizuRoute with command: {" ".join(mizu_command)}')
+
+            mizu_num_threads = self._get_config_value(
+                lambda: self.config.model.mizuroute.num_threads,
+                default=1, dict_key='MIZUROUTE_NUM_THREADS',
+            )
+            mizu_env = {**__import__('os').environ, 'OMP_NUM_THREADS': str(mizu_num_threads)}
+            self.logger.debug(f'Running mizuRoute with command: {" ".join(mizu_command)} (OMP_NUM_THREADS={mizu_num_threads})')
 
             self.execute_subprocess(
                 mizu_command,
                 mizu_log_path / mizu_log_name,
-                success_message="mizuRoute run completed successfully"
+                success_message="mizuRoute run completed successfully",
+                env=mizu_env,
             )
 
             return mizu_out_path

--- a/src/symfluence/models/summa/calibration/worker.py
+++ b/src/symfluence/models/summa/calibration/worker.py
@@ -215,7 +215,7 @@ class SUMMAWorker(BaseWorker):
             summa_timeout = int(config.get('SUMMA_TIMEOUT', 7200))
             success = _run_summa_worker(
                 summa_exe, file_manager, summa_dir, internal_logger, debug_info, settings_dir,
-                timeout=summa_timeout
+                timeout=summa_timeout, config=config
             )
 
             if not success:

--- a/src/symfluence/optimization/mixins/parallel/config_updater.py
+++ b/src/symfluence/optimization/mixins/parallel/config_updater.py
@@ -277,6 +277,8 @@ class ConfigurationUpdater(ConfigMixin):
         if model_upper == 'SUMMA':
             fname_qsim = f'proc_{proc_id:02d}_{experiment_id}_timestep.nc'
             vname_qsim = 'averageRoutedRunoff'
+            sim_start_time = '00:00'
+            sim_end_time = '00:00'
         elif model_upper == 'FUSE':
             fname_qsim = f'proc_{proc_id:02d}_{experiment_id}_timestep.nc'
             vname_qsim = self._get_config_value(lambda: self.config.model.mizuroute.routing_var, default='q_routed', dict_key='SETTINGS_MIZU_ROUTING_VAR')
@@ -365,14 +367,13 @@ class ConfigurationUpdater(ConfigMixin):
                     f"! Time interval of input runoff in seconds\n"
                 )
             elif '<dname_hruid>' in line:
-                # FUSE converter outputs 'gru' dimension, SUMMA uses 'hru'
-                dim_name = 'gru' if mizu_config['model_name'].upper() == 'FUSE' else 'hru'
+                # averageRoutedRunoff is on the 'gru' dimension for distributed SUMMA
+                dim_name = 'gru' if mizu_config['model_name'].upper() in ('FUSE', 'SUMMA') else 'hru'
                 updated_lines.append(
                     f"<dname_hruid>           {dim_name}     ! Dimension name for HM_HRU ID\n"
                 )
             elif '<vname_hruid>' in line:
-                # FUSE converter outputs 'gruId' variable, SUMMA uses 'hruId'
-                var_name = 'gruId' if mizu_config['model_name'].upper() == 'FUSE' else 'hruId'
+                var_name = 'gruId' if mizu_config['model_name'].upper() in ('FUSE', 'SUMMA') else 'hruId'
                 updated_lines.append(
                     f"<vname_hruid>           {var_name}   ! Variable name for HM_HRU ID\n"
                 )

--- a/src/symfluence/optimization/workers/summa/__init__.py
+++ b/src/symfluence/optimization/workers/summa/__init__.py
@@ -47,6 +47,11 @@ from .netcdf_utilities import (
     fix_summa_time_precision,
     fix_summa_time_precision_inplace,
 )
+from .parallel_gru_execution import (
+    compute_gru_splits,
+    merge_split_outputs,
+    run_summa_gru_parallel,
+)
 from .parameter_application import (
     _apply_parameters_worker,
     _generate_trial_params_worker,
@@ -80,6 +85,10 @@ __all__ = [
     '_run_summa_worker',
     '_run_mizuroute_worker',
     '_needs_mizuroute_routing_worker',
+    # Parallel GRU execution
+    'run_summa_gru_parallel',
+    'compute_gru_splits',
+    'merge_split_outputs',
     # Worker orchestration
     '_evaluate_parameters_worker',
     # DDS optimization

--- a/src/symfluence/optimization/workers/summa/model_execution.py
+++ b/src/symfluence/optimization/workers/summa/model_execution.py
@@ -44,7 +44,6 @@ def _cleanup_stale_output_files(output_dir: Path, logger) -> None:
     files_removed = 0
     for pattern in cleanup_patterns:
         for file_path in output_dir.glob(pattern):
-            # Skip if it's a directory
             if file_path.is_dir():
                 continue
             try:
@@ -53,8 +52,18 @@ def _cleanup_stale_output_files(output_dir: Path, logger) -> None:
             except (FileNotFoundError, subprocess.CalledProcessError, OSError) as e:
                 logger.warning(f"Could not remove stale file {file_path}: {e}")
 
+    # Clean up stale GRU-parallel split directories
+    for split_dir in output_dir.glob('gru_split_*'):
+        if split_dir.is_dir():
+            try:
+                import shutil
+                shutil.rmtree(split_dir, ignore_errors=True)
+                files_removed += 1
+            except OSError as e:
+                logger.warning(f"Could not remove stale split dir {split_dir}: {e}")
+
     if files_removed > 0:
-        logger.debug(f"Cleaned up {files_removed} stale output files from {output_dir}")
+        logger.debug(f"Cleaned up {files_removed} stale output files/dirs from {output_dir}")
 
 
 def _deduplicate_output_control(output_control_path: Path, logger):
@@ -99,7 +108,7 @@ def _deduplicate_output_control(output_control_path: Path, logger):
         logger.warning(f"Failed to deduplicate output control: {e}")
 
 
-def _run_summa_worker(summa_exe: Path, file_manager: Path, summa_dir: Path, logger, debug_info: Dict, summa_settings_dir: Path = None, timeout: int = 7200) -> bool:
+def _run_summa_worker(summa_exe: Path, file_manager: Path, summa_dir: Path, logger, debug_info: Dict, summa_settings_dir: Path = None, timeout: int = 7200, config: Dict = None) -> bool:
     """SUMMA execution with iteration-aware logging.
 
     Log files include iteration number to prevent overwriting during calibration.
@@ -220,6 +229,29 @@ def _run_summa_worker(summa_exe: Path, file_manager: Path, summa_dir: Path, logg
         except (FileNotFoundError, subprocess.CalledProcessError, OSError) as e:
             logger.warning(f"Failed to update file manager paths: {e}")
             # Continue anyway, hoping it works or fails later
+
+        # Check for intra-iteration parallel GRU execution
+        use_parallel = config.get('SETTINGS_SUMMA_USE_PARALLEL_SUMMA', False) if config else False
+        logger.info(f"Parallel SUMMA check: config={config is not None}, use_parallel={use_parallel}, settings_dir={summa_settings_dir}")
+        if use_parallel and summa_settings_dir is not None:
+            from .parallel_gru_execution import run_summa_gru_parallel
+
+            num_parallel = int(config.get('SETTINGS_SUMMA_CPUS_PER_TASK', 8))
+            logger.info(f"Launching parallel SUMMA with {num_parallel} processes")
+            result = run_summa_gru_parallel(
+                summa_exe=Path(summa_exe_str),
+                file_manager=Path(file_manager_str),
+                summa_dir=summa_dir,
+                settings_dir=Path(summa_settings_dir) if not isinstance(summa_settings_dir, Path) else summa_settings_dir,
+                num_parallel=num_parallel,
+                logger=logger,
+                debug_info=debug_info,
+                timeout=timeout,
+                env=env,
+            )
+            if result:
+                return True
+            logger.warning("Parallel GRU execution did not succeed, falling back to sequential")
 
         # Build command as list to avoid shell=True security concerns
         cmd = [summa_exe_str, "-m", file_manager_str]
@@ -372,7 +404,12 @@ def _run_mizuroute_worker(task_data: Dict, mizuroute_dir: Path, logger, debug_in
         cmd = [str(mizu_exe), str(control_file)]
         cmd_str = " ".join(cmd)
 
-        logger.info(f"Executing mizuRoute command: {cmd_str}")
+        # Set OpenMP thread count for mizuRoute (if compiled with OpenMP)
+        mizu_env = os.environ.copy()
+        mizu_num_threads = str(config.get('MIZUROUTE_NUM_THREADS', 1))
+        mizu_env['OMP_NUM_THREADS'] = mizu_num_threads
+
+        logger.info(f"Executing mizuRoute command: {cmd_str} (OMP_NUM_THREADS={mizu_num_threads})")
         debug_info['commands_run'].append(f"mizuRoute: {cmd_str}")
         debug_info['mizuroute_log'] = str(log_file)
 
@@ -383,6 +420,7 @@ def _run_mizuroute_worker(task_data: Dict, mizuroute_dir: Path, logger, debug_in
             f.write("mizuRoute Execution Log\n")
             f.write(f"Command: {cmd_str}\n")
             f.write(f"Working Directory: {control_file.parent}\n")
+            f.write(f"OMP_NUM_THREADS: {mizu_num_threads}\n")
             f.write("=" * 50 + "\n")
             f.flush()
 
@@ -392,6 +430,7 @@ def _run_mizuroute_worker(task_data: Dict, mizuroute_dir: Path, logger, debug_in
                 component='mizuroute',
                 iteration=debug_info.get('iteration'),
                 cwd=control_file.parent,
+                env=mizu_env,
                 track_files=True,
                 output_dir=mizuroute_dir
             ) as proc:

--- a/src/symfluence/optimization/workers/summa/parallel_gru_execution.py
+++ b/src/symfluence/optimization/workers/summa/parallel_gru_execution.py
@@ -1,0 +1,357 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""
+Intra-iteration parallel GRU execution for SUMMA calibration.
+
+Splits a SUMMA domain into N chunks using the ``-g startGRU numGRU`` flag,
+runs them as concurrent subprocesses, then merges outputs.  This is
+orthogonal to inter-iteration parallelism (ProcessPool/MPI) — each
+calibration process can independently split its own SUMMA run.
+
+Activated when ``SETTINGS_SUMMA_USE_PARALLEL_SUMMA: true`` in config.
+The default pathway (sequential, single-process SUMMA) is unchanged.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import logging
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+
+def get_gru_count_from_attributes(settings_dir: Path) -> int:
+    """Read total GRU count from SUMMA attributes.nc."""
+    import xarray as xr
+
+    attr_path = settings_dir / 'attributes.nc'
+    if not attr_path.exists():
+        raise FileNotFoundError(f"attributes.nc not found in {settings_dir}")
+
+    with xr.open_dataset(attr_path) as ds:
+        if 'gru' not in ds.sizes:
+            raise KeyError("'gru' dimension not found in attributes.nc")
+        return int(ds.sizes['gru'])
+
+
+def compute_gru_splits(
+    total_grus: int,
+    num_processes: int,
+) -> List[Tuple[int, int]]:
+    """Compute (startGRU, numGRU) pairs for parallel execution.
+
+    Divides GRUs as evenly as possible.  GRU indices are 1-based
+    (SUMMA convention).
+    """
+    num_processes = max(1, min(num_processes, total_grus))
+    base_size = total_grus // num_processes
+    remainder = total_grus % num_processes
+
+    splits: List[Tuple[int, int]] = []
+    current = 1
+    for i in range(num_processes):
+        chunk = base_size + (1 if i < remainder else 0)
+        splits.append((current, chunk))
+        current += chunk
+    return splits
+
+
+def create_split_file_manager(
+    source_file_manager: Path,
+    split_output_dir: Path,
+    split_id: int,
+    logger: logging.Logger,
+) -> Path:
+    """Create a file-manager copy whose ``outputPath`` points at *split_output_dir*.
+
+    ``settingsPath`` is left unchanged — all splits share the same
+    trialParams.nc, attributes.nc, forcing, etc.
+    """
+    split_output_dir.mkdir(parents=True, exist_ok=True)
+    split_fm = split_output_dir / 'fileManager.txt'
+
+    output_path_str = str(split_output_dir).rstrip(os.sep) + os.sep
+
+    with open(source_file_manager, 'r', encoding='utf-8') as f:
+        lines = f.readlines()
+
+    updated: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith('!'):
+            updated.append(line)
+        elif 'outputPath' in line:
+            updated.append(f"outputPath '{output_path_str}'\n")
+        elif 'outFilePrefix' in line:
+            orig = line.split("'")[1] if "'" in line else 'output'
+            updated.append(f"outFilePrefix 'split_{split_id:02d}_{orig}'\n")
+        else:
+            updated.append(line)
+
+    with open(split_fm, 'w', encoding='utf-8') as f:
+        f.writelines(updated)
+
+    logger.debug("Created split %d file manager: %s", split_id, split_fm)
+    return split_fm
+
+
+# Module-level function so it can be used with ThreadPoolExecutor
+def _run_single_gru_split(split_args: Dict[str, Any]) -> Dict[str, Any]:
+    """Execute a single GRU split as a subprocess."""
+    start = time.time()
+    split_id = split_args['split_id']
+
+    try:
+        cmd = [
+            split_args['summa_exe'],
+            '-g', str(split_args['start_gru']), str(split_args['num_gru']),
+            '-m', split_args['file_manager'],
+        ]
+
+        env = os.environ.copy()
+        env.update({
+            'OMP_NUM_THREADS': '1',
+            'MKL_NUM_THREADS': '1',
+            'OPENBLAS_NUM_THREADS': '1',
+        })
+        if split_args.get('env'):
+            env.update(split_args['env'])
+
+        with open(split_args['log_file'], 'w', encoding='utf-8') as log_f:
+            log_f.write(
+                f"Split {split_id}: GRUs {split_args['start_gru']}-"
+                f"{split_args['start_gru'] + split_args['num_gru'] - 1}\n"
+            )
+            log_f.write(f"Command: {' '.join(cmd)}\n")
+            log_f.write('=' * 50 + '\n')
+            log_f.flush()
+
+            result = subprocess.run(
+                cmd,
+                stdout=log_f,
+                stderr=subprocess.STDOUT,
+                timeout=split_args['timeout'],
+                env=env,
+            )
+
+        return {
+            'split_id': split_id,
+            'success': result.returncode == 0,
+            'error': f'Exit code {result.returncode}' if result.returncode != 0 else None,
+            'duration': time.time() - start,
+        }
+
+    except subprocess.TimeoutExpired:
+        return {
+            'split_id': split_id,
+            'success': False,
+            'error': 'Timeout',
+            'duration': time.time() - start,
+        }
+    except Exception as e:  # noqa: BLE001
+        return {
+            'split_id': split_id,
+            'success': False,
+            'error': str(e),
+            'duration': time.time() - start,
+        }
+
+
+def merge_split_outputs(
+    split_dirs: List[Path],
+    target_dir: Path,
+    experiment_prefix: str,
+    logger: logging.Logger,
+) -> bool:
+    """Merge per-split SUMMA NetCDF outputs along the ``hru`` dimension."""
+    import xarray as xr
+
+    for suffix in ('timestep', 'day'):
+        split_files: list[Path] = []
+        for split_dir in split_dirs:
+            found = sorted(split_dir.glob(f'*_{suffix}.nc'))
+            if found:
+                split_files.append(found[0])
+
+        if not split_files:
+            continue
+
+        try:
+            datasets = [xr.open_dataset(f) for f in split_files]
+
+            # SUMMA outputs some vars on (time, hru) and others on (time, gru).
+            # Concat each dimension independently then merge.
+            hru_vars = [v for v in datasets[0].data_vars if 'hru' in datasets[0][v].dims]
+            gru_vars = [v for v in datasets[0].data_vars
+                        if 'gru' in datasets[0][v].dims and v not in hru_vars]
+
+            parts = []
+            if hru_vars:
+                parts.append(xr.concat(
+                    [ds[hru_vars] for ds in datasets],
+                    dim='hru', coords='minimal', compat='override',
+                ))
+            if gru_vars:
+                parts.append(xr.concat(
+                    [ds[gru_vars] for ds in datasets],
+                    dim='gru', coords='minimal', compat='override',
+                ))
+
+            merged = xr.merge(parts, compat='override') if parts else datasets[0]
+
+            encoding = {}
+            for var in merged.data_vars:
+                if merged[var].dtype.kind == 'i':
+                    encoding[var] = {'_FillValue': None}
+
+            output_file = target_dir / f'{experiment_prefix}_{suffix}.nc'
+            merged.to_netcdf(output_file, format='NETCDF4', encoding=encoding)
+
+            total_hrus = sum(ds.sizes.get('hru', 0) for ds in datasets)
+            for ds in datasets:
+                ds.close()
+            merged.close()
+
+            logger.info("Merged %d splits -> %s (%d HRUs)", len(split_files), output_file.name, total_hrus)
+        except Exception as e:  # noqa: BLE001
+            logger.error("Merge failed for %s files: %s", suffix, e)
+            return False
+
+    return True
+
+
+def _read_out_file_prefix(file_manager: Path) -> str:
+    """Extract outFilePrefix from a SUMMA file manager."""
+    with open(file_manager, 'r', encoding='utf-8') as f:
+        for line in f:
+            if 'outFilePrefix' in line and not line.strip().startswith('!'):
+                return line.split("'")[1] if "'" in line else 'output'
+    return 'output'
+
+
+def cleanup_split_dirs(summa_dir: Path) -> None:
+    """Remove gru_split_* subdirectories from a previous iteration."""
+    for d in summa_dir.glob('gru_split_*'):
+        if d.is_dir():
+            shutil.rmtree(d, ignore_errors=True)
+
+
+def run_summa_gru_parallel(
+    summa_exe: Path,
+    file_manager: Path,
+    summa_dir: Path,
+    settings_dir: Path,
+    num_parallel: int,
+    logger: logging.Logger,
+    debug_info: Dict[str, Any],
+    timeout: int = 7200,
+    env: Optional[Dict[str, str]] = None,
+) -> bool:
+    """Run SUMMA with GRU-parallel execution.
+
+    1. Read GRU count from attributes.nc
+    2. Compute GRU splits
+    3. Create per-split output directories and file managers
+    4. Launch all splits concurrently via ThreadPoolExecutor
+    5. Wait for all with a total timeout
+    6. Merge outputs into standard files
+    7. Clean up split directories on success
+    """
+    # 0. Clean stale splits from previous iterations
+    cleanup_split_dirs(summa_dir)
+
+    # 1. GRU count
+    try:
+        total_grus = get_gru_count_from_attributes(settings_dir)
+    except (FileNotFoundError, KeyError) as exc:
+        logger.warning("Cannot read GRU count (%s) — falling back to sequential", exc)
+        return False  # caller will re-try sequentially
+
+    # 2. Splits
+    num_parallel = max(1, min(num_parallel, total_grus))
+    splits = compute_gru_splits(total_grus, num_parallel)
+    logger.info(
+        "Parallel SUMMA: %d GRUs across %d processes (%d-%d GRUs each)",
+        total_grus, len(splits), splits[-1][1], splits[0][1],
+    )
+
+    # 3. Prepare
+    experiment_prefix = _read_out_file_prefix(file_manager)
+    split_dirs: list[Path] = []
+    split_args_list: list[dict] = []
+
+    log_dir = summa_dir / 'logs'
+    log_dir.mkdir(parents=True, exist_ok=True)
+    iteration = debug_info.get('iteration', 0)
+
+    for split_id, (start_gru, num_gru) in enumerate(splits):
+        split_dir = summa_dir / f'gru_split_{split_id:02d}'
+        split_dirs.append(split_dir)
+
+        split_fm = create_split_file_manager(
+            file_manager, split_dir, split_id, logger,
+        )
+
+        split_args_list.append({
+            'summa_exe': str(summa_exe),
+            'file_manager': str(split_fm),
+            'start_gru': start_gru,
+            'num_gru': num_gru,
+            'output_dir': str(split_dir),
+            'log_file': str(log_dir / f'summa_split_{split_id:02d}_iter{iteration:05d}.log'),
+            'timeout': timeout,
+            'env': env,
+            'split_id': split_id,
+        })
+
+    # 4. Execute
+    start_time = time.time()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(splits)) as executor:
+        futures = {
+            executor.submit(_run_single_gru_split, args): args['split_id']
+            for args in split_args_list
+        }
+
+        done, not_done = concurrent.futures.wait(
+            futures, timeout=timeout,
+            return_when=concurrent.futures.ALL_COMPLETED,
+        )
+
+        if not_done:
+            logger.error("%d GRU splits timed out", len(not_done))
+            for future in not_done:
+                future.cancel()
+            debug_info.setdefault('errors', []).append(
+                f'GRU parallel timeout: {len(not_done)} splits incomplete'
+            )
+            return False
+
+        for future in done:
+            result = future.result()
+            if not result['success']:
+                logger.error(
+                    "Split %d failed: %s", result['split_id'], result.get('error'),
+                )
+                debug_info.setdefault('errors', []).append(
+                    f"GRU split {result['split_id']} failed: {result.get('error')}"
+                )
+                return False
+
+    wall_time = time.time() - start_time
+    logger.info("All %d GRU splits completed in %.1fs", len(splits), wall_time)
+
+    # 5. Merge
+    if not merge_split_outputs(split_dirs, summa_dir, experiment_prefix, logger):
+        debug_info.setdefault('errors', []).append('GRU split output merge failed')
+        return False
+
+    # 6. Cleanup on success
+    cleanup_split_dirs(summa_dir)
+
+    return True

--- a/src/symfluence/optimization/workers/summa/worker_orchestration.py
+++ b/src/symfluence/optimization/workers/summa/worker_orchestration.py
@@ -162,7 +162,7 @@ def _evaluate_parameters_worker(task_data: Dict) -> Dict:
         summa_timeout = int(config.get('SUMMA_TIMEOUT', 7200))
         logger.info("Running SUMMA")
         summa_start = time.time()
-        if not _run_summa_worker(summa_exe, file_manager, summa_dir, logger, debug_info, summa_settings_dir, timeout=summa_timeout):
+        if not _run_summa_worker(summa_exe, file_manager, summa_dir, logger, debug_info, summa_settings_dir, timeout=summa_timeout, config=config):
             error_msg = 'SUMMA simulation failed'
             logger.error(error_msg)
             eval_runtime = time.time() - eval_start_time

--- a/tools/quality/broad_exception_allowlist.txt
+++ b/tools/quality/broad_exception_allowlist.txt
@@ -1221,6 +1221,8 @@ src/symfluence/optimization/optimizers/algorithms/sce_ua.py:SCEUAAlgorithm.optim
 src/symfluence/optimization/optimizers/algorithms/sce_ua.py:SCEUAAlgorithm.optimize:except Exception as e:  # noqa: BLE001
 src/symfluence/optimization/optimizers/algorithms/sce_ua.py:SCEUAAlgorithm.optimize:except Exception as e:  # noqa: BLE001 - best-effort path setup
 src/symfluence/optimization/optimizers/base_model_optimizer.py:BaseModelOptimizer._build_algorithm_callbacks.save_checkpoint:except Exception as e:  # noqa: BLE001 — must-not-raise contract
+src/symfluence/optimization/workers/summa/parallel_gru_execution.py:_run_single_gru_split:except Exception as e:  # noqa: BLE001
+src/symfluence/optimization/workers/summa/parallel_gru_execution.py:merge_split_outputs:except Exception as e:  # noqa: BLE001
 src/symfluence/project/project_manager.py:ProjectManager.create_pour_point:except Exception as e:  # noqa: BLE001 — configuration resilience
 src/symfluence/project/workflow_orchestrator.py:WorkflowOrchestrator.run_individual_steps:except Exception as e:  # noqa: BLE001 — must-not-raise contract
 src/symfluence/project/workflow_orchestrator.py:WorkflowOrchestrator.run_workflow:except Exception as e:  # noqa: BLE001 — must-not-raise contract


### PR DESCRIPTION
## Summary

- **Parallel SUMMA calibration**: Split GRU domain across N concurrent subprocesses using SUMMA's `-g` flag within each calibration iteration. Configurable via `SETTINGS_SUMMA_USE_PARALLEL_SUMMA: true` and `SETTINGS_SUMMA_CPUS_PER_TASK: 8`. Default behavior unchanged (sequential).
- **mizuRoute fixes**: Correct time alignment (`00:00` instead of `01:00` for SUMMA), fix `dname_hruid` to use `gru` dimension for distributed SUMMA with elevation bands, add configurable OpenMP build and `MIZUROUTE_NUM_THREADS` runtime config.
- **Iceland SUMMA config**: National-scale SUMMA+mizuRoute config with CARRA forcing, 696 GRUs, elevation bands, transfer function regionalization, and curated multi-gauge calibration against 55 LamaH-ICE gauges.

## Test plan

- [x] All 133 SUMMA unit tests pass
- [x] All 5683 unit tests pass (full suite)
- [x] `compute_gru_splits` verified with edge cases (1 GRU, uneven division, more procs than GRUs)
- [x] Parallel SUMMA tested on Iceland domain (696 GRUs, 8 processes)
- [x] Merged output verified (2057 HRUs, 696 GRUs, correct time dimension)
- [x] End-to-end pipeline: parallel SUMMA → merge → mizuRoute → multi-gauge KGE score
- [ ] Full calibration run (1000 iterations) — in progress

> Repo and code assistance from [Claude](https://claude.ai) (Anthropic).