### PR TITLE
fix(summa): resolve mizuRoute output path in final evaluation

### DIFF
--- a/src/symfluence/models/summa/calibration/worker.py
+++ b/src/symfluence/models/summa/calibration/worker.py
@@ -349,6 +349,17 @@ class SUMMAWorker(BaseWorker):
             if not mizuroute_dir and self.needs_routing(config):
                 sim_dir = kwargs.get('sim_dir', output_dir)
                 mizuroute_dir = sim_dir / 'mizuRoute'
+                # Fall back to the standard simulations path when the
+                # optimization-dir path has no output (e.g. final evaluation
+                # redirects SUMMA output but mizuRoute still writes to simulations/)
+                if not list(mizuroute_dir.glob('*.nc')):
+                    experiment_id = config.get('EXPERIMENT_ID', '')
+                    data_dir = config.get('SYMFLUENCE_DATA_DIR', '')
+                    domain_name = config.get('DOMAIN_NAME', '')
+                    if experiment_id and data_dir and domain_name:
+                        fallback = Path(data_dir) / f"domain_{domain_name}" / 'simulations' / experiment_id / 'mizuRoute'
+                        if list(fallback.glob('*.nc')):
+                            mizuroute_dir = fallback
 
             metrics = _calculate_metrics_with_target(
                 output_dir, mizuroute_dir, config, self.logger


### PR DESCRIPTION
## Summary

- Fix DDS final evaluation failing to find mizuRoute output for distributed SUMMA domains
- The final evaluation redirects SUMMA output to the optimization directory, but mizuRoute still writes to the standard simulations path — the metrics calculator now falls back to `simulations/{experiment}/mizuRoute/` when the optimization-dir path has no `.nc` files

## Context

Discovered during a 1000-iteration Bow at Banff calibration run (KGE 0.9506) where calibration completed successfully but the final evaluation reported "Routing failed — cannot calculate streamflow metrics" even though mizuRoute had finished normally.

## Test plan

- [x] Unit tests pass (`pytest tests/unit/ -k summa` — 133 passed)
- [x] Verified mizuRoute output exists at simulations path and is correctly located by fallback logic

> Repo and code assistance from [Claude](https://claude.ai) (Anthropic).