### PR TITLE
fix: cache MPI unavailability to avoid repeated fallback cascade

### DIFF
--- a/src/symfluence/optimization/mixins/parallel_execution.py
+++ b/src/symfluence/optimization/mixins/parallel_execution.py
@@ -678,6 +678,24 @@ class ParallelExecutionMixin(ConfigMixin):
             max_workers = self.max_workers
 
         if self.use_parallel and len(tasks) > 1:
+            # --- Fast-path: skip MPI if a previous cascade already proved it unavailable ---
+            if getattr(self, '_mpi_unavailable', False):
+                try:
+                    strategy = ProcessPoolExecutionStrategy(self.logger)
+                    return strategy.execute(tasks, worker_func, max_workers)
+                except Exception as e2:  # noqa: BLE001 — must-not-raise contract
+                    self.logger.error(f"ProcessPool fallback also failed: {e2}")
+                    import traceback
+                    self.logger.error(f"Traceback: {traceback.format_exc()}")
+                    return [
+                        {
+                            'individual_id': task.get('individual_id', i),
+                            'score': None,
+                            'error': str(e2)
+                        }
+                        for i, task in enumerate(tasks)
+                    ]
+
             # --- Try persistent MPI first (no repeated Python imports) ---
             try:
                 strategy = self._get_or_create_persistent_mpi_strategy(
@@ -697,6 +715,13 @@ class ParallelExecutionMixin(ConfigMixin):
                 return strategy.execute(tasks, worker_func, max_workers)
             except Exception as e:  # noqa: BLE001 — must-not-raise contract
                 self.logger.warning(f"MPI batch execution failed: {e}")
+
+            # Both MPI strategies failed — cache the decision so subsequent
+            # iterations skip straight to ProcessPool without repeating the cascade.
+            self._mpi_unavailable = True
+            self.logger.info(
+                "MPI unavailable — using ProcessPool for all remaining iterations"
+            )
 
             # --- Fallback: ProcessPool ---
             try:

--- a/tools/quality/broad_exception_allowlist.txt
+++ b/tools/quality/broad_exception_allowlist.txt
@@ -1214,6 +1214,7 @@ src/symfluence/models/wrfhydro/postprocessor.py:WRFHydroPostProcessor._extract_f
 src/symfluence/models/wrfhydro/postprocessor.py:WRFHydroPostProcessor._extract_from_ldasout:except Exception:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/wrfhydro/preprocessor.py:WRFHydroPreProcessor.run_preprocessing:except Exception as e:  # noqa: BLE001 — model execution resilience
 src/symfluence/optimization/mixins/parallel_execution.py:ParallelExecutionMixin.execute_batch:except Exception as e2:  # noqa: BLE001 — must-not-raise contract
+src/symfluence/optimization/mixins/parallel_execution.py:ParallelExecutionMixin.execute_batch:except Exception as e2:  # noqa: BLE001 — must-not-raise contract
 src/symfluence/optimization/mixins/parallel_execution.py:ParallelExecutionMixin.execute_batch:except Exception as e:  # noqa: BLE001 — must-not-raise contract
 src/symfluence/optimization/mixins/parallel_execution.py:ParallelExecutionMixin.execute_batch:except Exception as e:  # noqa: BLE001 — must-not-raise contract
 src/symfluence/optimization/multi_gauge/metrics.py:MultiGaugeMetrics._extract_simulated_at_segment:except Exception as e:  # noqa: BLE001 — calibration resilience


### PR DESCRIPTION
## Summary
- When `mpi4py` is not installed, `execute_batch()` was re-attempting the full MPI fallback cascade (persistent MPI → spawn-per-batch MPI → ProcessPool) on **every calibration iteration**, producing enormous log output
- Adds a `_mpi_unavailable` instance flag: after the first failure cascade, subsequent iterations skip straight to ProcessPool
- Turns N fallback cascades into exactly 1

## Context
Reported by Tristan on the staging platform running the Async-DDS notebook — the repeated MPI failures made monitoring calibration progress nearly impossible.

## Test plan
- [x] All 5690 unit tests pass
- [x] ruff lint clean
- [x] mypy clean

> Repo and code assistance from [Claude](https://claude.ai) (Anthropic).