### PR TITLE
feat: tRoute adapter parity + shared routing infrastructure

### DIFF
--- a/src/symfluence/geospatial/delineation.py
+++ b/src/symfluence/geospatial/delineation.py
@@ -537,16 +537,61 @@ class DomainDelineator(PathResolverMixin):
         """
         try:
             self.logger.info("Delineating lumped domain into subcatchments")
-            # Use GeofabricDelineator to delineate the lumped domain
+
+            # Back up original lumped shapefiles before delineation overwrites them
+            river_net_dir = self.project_dir / "shapefiles" / "river_network"
+            river_bas_dir = self.project_dir / "shapefiles" / "river_basins"
+            lumped_net = river_net_dir / f"{self.domain_name}_riverNetwork_lumped.shp"
+            lumped_bas = river_bas_dir / f"{self.domain_name}_riverBasins_lumped.shp"
+
+            import shutil
+            lumped_net_bak = lumped_net.with_suffix('.shp.bak') if lumped_net.exists() else None
+            lumped_bas_bak = lumped_bas.with_suffix('.shp.bak') if lumped_bas.exists() else None
+            if lumped_net_bak:
+                for ext in ['.shp', '.shx', '.dbf', '.prj', '.cpg']:
+                    src = lumped_net.with_suffix(ext)
+                    if src.exists():
+                        shutil.copy2(src, src.with_suffix(ext + '.bak'))
+            if lumped_bas_bak:
+                for ext in ['.shp', '.shx', '.dbf', '.prj', '.cpg']:
+                    src = lumped_bas.with_suffix(ext)
+                    if src.exists():
+                        shutil.copy2(src, src.with_suffix(ext + '.bak'))
+
+            # delineate_geofabric() writes to _lumped suffix (domain_definition_method)
             delineated_network, delineated_basins = self.delineator.delineate_geofabric()
 
             if delineated_network and delineated_basins:
-                self.logger.info(f"Created delineated river network: {delineated_network}")
-                self.logger.info(f"Created delineated river basins: {delineated_basins}")
+                # Rename delineated output from _lumped to _delineate suffix
+                # so topology generators can find them without conflicting with the originals
+                final_net = river_net_dir / f"{self.domain_name}_riverNetwork_delineate.shp"
+                final_bas = river_bas_dir / f"{self.domain_name}_riverBasins_delineate.shp"
+
+                for src_base, dst_base in [(delineated_network, final_net), (delineated_basins, final_bas)]:
+                    for ext in ['.shp', '.shx', '.dbf', '.prj', '.cpg']:
+                        src = src_base.with_suffix(ext)
+                        if src.exists():
+                            shutil.copy2(src, dst_base.with_suffix(ext))
+
+                # Restore original lumped shapefiles
+                if lumped_net_bak:
+                    for ext in ['.shp', '.shx', '.dbf', '.prj', '.cpg']:
+                        bak = lumped_net.with_suffix(ext + '.bak')
+                        if bak.exists():
+                            shutil.move(str(bak), str(lumped_net.with_suffix(ext)))
+                if lumped_bas_bak:
+                    for ext in ['.shp', '.shx', '.dbf', '.prj', '.cpg']:
+                        bak = lumped_bas.with_suffix(ext + '.bak')
+                        if bak.exists():
+                            shutil.move(str(bak), str(lumped_bas.with_suffix(ext)))
+
+                self.logger.info(f"Delineated river network: {final_net}")
+                self.logger.info(f"Delineated river basins: {final_bas}")
+                return final_net, final_bas
             else:
                 self.logger.warning("Geofabric delineation did not produce expected outputs")
+                return None, None
 
-            return delineated_network, delineated_basins
         except Exception as e:  # noqa: BLE001 — geospatial resilience
             self.logger.error(f"Error delineating lumped domain: {str(e)}")
             import traceback

--- a/src/symfluence/models/execution/spatial_orchestrator.py
+++ b/src/symfluence/models/execution/spatial_orchestrator.py
@@ -454,9 +454,9 @@ class SpatialOrchestrator(ABC):
             # Normalize time units format (mizuRoute expects specific format)
             mizu_ds['time'].attrs['units'] = mizu_ds['time'].attrs['units'].replace('T', ' ')
 
-        # Add gru dimension and gruId variable
+        # Add gru dimension using source coordinates to avoid xarray alignment NaN
         n_gru = data.sizes['gru']
-        mizu_ds['gru'] = xr.DataArray(range(n_gru), dims=('gru',))
+        mizu_ds['gru'] = data.gru
 
         # Convert IDs to int if possible
         try:

--- a/src/symfluence/models/troute/calibration/optimizer.py
+++ b/src/symfluence/models/troute/calibration/optimizer.py
@@ -112,11 +112,11 @@ class TRouteModelOptimizer(BaseModelOptimizer):
             ds = xr.open_dataset(output_file)
             results = {}
 
-            # T-Route streamflow variable is usually 'streamflow' or 'velocity'
-            # Check variables
-            flow_var = 'streamflow'
-            if flow_var not in ds and 'velocity' in ds:
-                flow_var = 'velocity' # Fallback if flow not found (unlikely for routing)
+            flow_var = None
+            for candidate in ('flow', 'flowveldepth', 'streamflow', 'velocity'):
+                if candidate in ds:
+                    flow_var = candidate
+                    break
 
             if flow_var in ds:
                 # Return dataframe

--- a/src/symfluence/models/troute/mixins.py
+++ b/src/symfluence/models/troute/mixins.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""
+TRoute configuration mixin.
+
+Provides typed property accessors for TRouteConfig fields via _get_config_value.
+"""
+
+
+class TRouteConfigMixin:
+    """Typed config accessors for t-route settings."""
+
+    @property
+    def troute_install_path(self) -> str:
+        return self._get_config_value(
+            lambda: self.config.model.troute.install_path, default='default'
+        )
+
+    @property
+    def troute_settings_path(self) -> str:
+        return self._get_config_value(
+            lambda: self.config.model.troute.settings_path, default='default'
+        )
+
+    @property
+    def troute_topology_file(self) -> str:
+        return self._get_config_value(
+            lambda: self.config.model.troute.topology_file, default='troute_topology.nc'
+        )
+
+    @property
+    def troute_config_file(self) -> str:
+        return self._get_config_value(
+            lambda: self.config.model.troute.config_file, default='troute_config.yml'
+        )
+
+    @property
+    def troute_dt_seconds(self) -> int:
+        return self._get_config_value(
+            lambda: self.config.model.troute.dt_seconds, default=3600
+        )
+
+    @property
+    def troute_routing_method(self) -> str:
+        return self._get_config_value(
+            lambda: self.config.model.troute.routing_method, default='muskingum_cunge'
+        )
+
+    @property
+    def troute_from_model(self) -> str:
+        return self._get_config_value(
+            lambda: self.config.model.troute.from_model, default='SUMMA'
+        )
+
+    @property
+    def troute_mannings_n(self) -> float:
+        return self._get_config_value(
+            lambda: self.config.model.troute.mannings_n, default=0.035
+        )
+
+    @property
+    def troute_experiment_output(self) -> str:
+        return self._get_config_value(
+            lambda: self.config.model.troute.experiment_output, default='default'
+        )
+
+    @property
+    def troute_experiment_log(self) -> str:
+        return self._get_config_value(
+            lambda: self.config.model.troute.experiment_log, default='default'
+        )
+
+    @property
+    def troute_hg_width_coeff(self) -> float:
+        return self._get_config_value(
+            lambda: self.config.model.troute.hg_width_coeff, default=2.71
+        )
+
+    @property
+    def troute_hg_width_exp(self) -> float:
+        return self._get_config_value(
+            lambda: self.config.model.troute.hg_width_exp, default=0.557
+        )
+
+    @property
+    def troute_make_outlet(self) -> str:
+        return self._get_config_value(
+            lambda: self.config.model.troute.make_outlet,
+            default='n/a',
+            dict_key='TROUTE_MAKE_OUTLET',
+        )
+
+    @property
+    def troute_needs_remap(self) -> bool:
+        return self._get_config_value(
+            lambda: self.config.model.troute.needs_remap,
+            default=False,
+            dict_key='TROUTE_NEEDS_REMAP',
+        )

--- a/src/symfluence/models/troute/postprocessor.py
+++ b/src/symfluence/models/troute/postprocessor.py
@@ -24,7 +24,7 @@ class TRoutePostProcessor(StandardModelPostprocessor):
 
     model_name = "TROUTE"
     output_file_pattern = "*.nc"  # TRoute outputs multiple timestamped NC files
-    streamflow_variable = "flowveldepth"  # TRoute flow variable
+    streamflow_variable = "flow"  # Built-in MC routing output variable
     streamflow_unit = "cms"  # TRoute outputs in m³/s
     netcdf_selections = {}  # Will be determined dynamically
 

--- a/src/symfluence/models/troute/preprocessor.py
+++ b/src/symfluence/models/troute/preprocessor.py
@@ -5,6 +5,7 @@
 TRoute Model Preprocessor.
 
 Handles spatial preprocessing and configuration generation for the t-route routing model.
+Supports all domain types: distributed, grid-based, point-scale, and lumped-to-distributed.
 """
 
 import logging
@@ -14,30 +15,31 @@ from pathlib import Path
 from shutil import copyfile
 from typing import Any, Dict, List, Optional
 
-import geopandas as gpd
-import netCDF4 as nc4
-import numpy as np
 import yaml
 
 from symfluence.geospatial.geometry_utils import GeospatialUtilsMixin
 from symfluence.models.base import BaseModelPreProcessor
 from symfluence.models.registry import ModelRegistry
+from symfluence.models.troute.mixins import TRouteConfigMixin
 
 
 @ModelRegistry.register_preprocessor('TROUTE')
-class TRoutePreProcessor(BaseModelPreProcessor, GeospatialUtilsMixin):  # type: ignore[misc]
+class TRoutePreProcessor(BaseModelPreProcessor, GeospatialUtilsMixin, TRouteConfigMixin):  # type: ignore[misc]
     """
     A standalone preprocessor for t-route within the SYMFLUENCE framework.
 
-    This class creates all necessary input and configuration files for a
-    t-route run without any dependency on other routing model utilities.
+    Supports all SYMFLUENCE domain types (distributed, grid, point, lumped-to-distributed)
+    via the shared BaseTopologyGenerator infrastructure with cycle detection/fix.
     """
 
-
     MODEL_NAME = "troute"
+
     def __init__(self, config: Dict[str, Any], logger: logging.Logger):
-        # Initialize base class (handles standard paths and directories)
         super().__init__(config, logger)
+        self.summa_uses_gru_runoff = False
+        self.needs_remap_lumped_distributed = False
+        self.subcatchment_weights = None
+        self.subcatchment_gru_ids = None
 
     def run_preprocessing(self):
         """Main entry point for running all t-route preprocessing steps."""
@@ -70,139 +72,71 @@ class TRoutePreProcessor(BaseModelPreProcessor, GeospatialUtilsMixin):  # type: 
     def create_troute_topology_file(self):
         """
         Creates the NetCDF network topology file using t-route's expected NWM variable names.
+
+        Uses the shared BaseTopologyGenerator infrastructure for cycle detection/fix,
+        headwater basin handling, and multi-domain-type support.
         """
-        self.logger.info("Creating t-route specific network topology file...")
+        from symfluence.models.troute.topology_generator import TRouteTopologyGenerator
 
-        # Define paths using SYMFLUENCE conventions
-        river_network_path = self.project_dir / 'shapefiles/river_network'
-        river_network_name = f"{self.domain_name}_riverNetwork_{self.domain_definition_method}.shp"
-        river_basin_path = self.project_dir / 'shapefiles/river_basins'
-        river_basin_name = f"{self.domain_name}_riverBasins_{self.domain_definition_method}.shp"
-        topology_name = self._get_config_value(
-            lambda: self.config.model.troute.topology_file, default='troute_topology.nc'
-        )
-        topology_filepath = self.setup_dir / topology_name
+        self.logger.info("Creating t-route network topology file...")
+        generator = TRouteTopologyGenerator(self)
+        topology_data = generator.write_topology_with_shapefiles()
 
-        # Load shapefiles
-        shp_river = gpd.read_file(river_network_path / river_network_name)
-        shp_basin = gpd.read_file(river_basin_path / river_basin_name)
-
-        with nc4.Dataset(topology_filepath, 'w', format='NETCDF4') as ncid:
-            # Set global attributes
-            ncid.setncattr('Author', "Created by SYMFLUENCE workflow for t-route")
-            ncid.setncattr('History', f'Created {datetime.now().strftime("%Y/%m/%d %H:%M:%S")}')
-            ncid.setncattr('Conventions', "CF-1.6")
-
-            # Create dimensions based on t-route standards
-            ncid.createDimension('link', len(shp_river))
-            ncid.createDimension('nhru', len(shp_basin))
-            ncid.createDimension('gages', None) # Unlimited dimension for gages
-
-            # Map SYMFLUENCE shapefile columns to t-route's required variable names
-            seg_id_col = self._get_config_value(lambda: self.config.paths.river_network_segid, default='LINKNO')
-            downseg_id_col = self._get_config_value(lambda: self.config.paths.river_network_downsegid, default='DSLINKNO')
-            length_col = self._get_config_value(lambda: self.config.paths.river_network_length, default='Length')
-            slope_col = self._get_config_value(lambda: self.config.paths.river_network_slope, default='Slope')
-            hru_to_seg_col = self._get_config_value(lambda: self.config.paths.river_basin_hru_to_seg, default='gru_to_seg')
-            area_col = self._get_config_value(lambda: self.config.paths.river_basin_area, default='GRU_area')
-
-            self._create_and_fill_nc_var(ncid, 'comid', 'i4', 'link', shp_river[seg_id_col], 'Unique segment ID')
-            self._create_and_fill_nc_var(ncid, 'to_node', 'i4', 'link', shp_river[downseg_id_col], 'Downstream segment ID')
-            self._create_and_fill_nc_var(ncid, 'length', 'f8', 'link', shp_river[length_col], 'Segment length', 'meters')
-            self._create_and_fill_nc_var(ncid, 'slope', 'f8', 'link', shp_river[slope_col], 'Segment slope', 'm/m')
-            self._create_and_fill_nc_var(ncid, 'link_id_hru', 'i4', 'nhru', shp_basin[hru_to_seg_col], 'Segment ID for HRU discharge')
-            self._create_and_fill_nc_var(ncid, 'hru_area_m2', 'f8', 'nhru', shp_basin[area_col], 'HRU area', 'm^2')
-
-            # Add required placeholder variables with sensible defaults
-            centroids = self.calculate_feature_centroids(shp_river)
-
-            shp_river['lat'] = centroids.y
-            shp_river['lon'] = centroids.x
-            self._create_and_fill_nc_var(ncid, 'lat', 'f8', 'link', shp_river['lat'], 'Latitude of segment midpoint', 'degrees_north')
-            self._create_and_fill_nc_var(ncid, 'lon', 'f8', 'link', shp_river['lon'], 'Longitude of segment midpoint', 'degrees_east')
-            self._create_and_fill_nc_var(ncid, 'alt', 'f8', 'link', [0.0] * len(shp_river), 'Mean elevation of segment', 'meters')
-            self._create_and_fill_nc_var(ncid, 'from_node', 'i4', 'link', [0] * len(shp_river), 'Upstream node ID')
-            mannings_n = float(self._get_config_value(
-                lambda: self.config.model.troute.mannings_n, default=0.035
-            ))
-            self._create_and_fill_nc_var(ncid, 'n', 'f8', 'link', [mannings_n] * len(shp_river), 'Mannings roughness coefficient')
-
-            # Add drainage area from river network shapefile (DSContArea is in m²)
-            if 'DSContArea' in shp_river.columns:
-                da_km2 = shp_river['DSContArea'].values.astype(np.float64) / 1e6
-                self._create_and_fill_nc_var(ncid, 'drainage_area_km2', 'f8', 'link', da_km2, 'Downstream contributing area', 'km^2')
-                self.logger.info(f"Drainage area: {da_km2.min():.1f}-{da_km2.max():.1f} km²")
-
-                # Compute channel width from hydraulic geometry: W = a * A^b
-                hg_a = float(self._get_config_value(
-                    lambda: self.config.model.troute.hg_width_coeff, default=2.71
-                ))
-                hg_b = float(self._get_config_value(
-                    lambda: self.config.model.troute.hg_width_exp, default=0.557
-                ))
-                da_clamped = np.maximum(da_km2, 0.01)
-                channel_width = np.maximum(hg_a * da_clamped ** hg_b, 1.0)
-                self._create_and_fill_nc_var(ncid, 'channel_width', 'f8', 'link', channel_width, 'Channel width from hydraulic geometry', 'meters')
-                self.logger.info(f"Channel width (W={hg_a}*A^{hg_b}): {channel_width.min():.1f}-{channel_width.max():.1f} m")
-            else:
-                self.logger.warning("DSContArea not found in river shapefile — channel width will use fallback")
-
-            # Add stream order if available
-            if 'strmOrder' in shp_river.columns:
-                self._create_and_fill_nc_var(ncid, 'stream_order', 'i4', 'link', shp_river['strmOrder'], 'Strahler stream order')
-
-        self.logger.info(f"t-route topology file created at {topology_filepath}")
+        # Store state flags for config file generation
+        self.summa_uses_gru_runoff = topology_data.summa_uses_gru_runoff
+        self.needs_remap_lumped_distributed = topology_data.needs_remap_lumped_distributed
+        if topology_data.subcatchment_weights is not None:
+            self.subcatchment_weights = topology_data.subcatchment_weights
+            self.subcatchment_gru_ids = topology_data.subcatchment_gru_ids
 
     def create_troute_yaml_config(self):
         """Creates the t-route YAML configuration file from SYMFLUENCE config settings."""
+        from symfluence.models.utilities.runoff_loader import get_model_config
+
         self.logger.info("Creating t-route YAML configuration file...")
 
-        # Determine paths and parameters from config
-        source_model = self._get_config_value(
-            lambda: self.config.model.troute.from_model, default='SUMMA'
-        ).upper()
-        input_dir = self.project_dir / f"simulations/{self.experiment_id}" / source_model
+        source_model = self.troute_from_model.upper()
+        model_cfg = get_model_config(source_model)
+
+        input_dir = self.project_dir / f"simulations/{self.experiment_id}" / model_cfg.output_dir_name
         output_dir = self.project_dir / f"simulations/{self.experiment_id}" / 'troute'
-        topology_name = self._get_config_value(
-            lambda: self.config.model.troute.topology_file, default='troute_topology.nc'
-        )
+        topology_name = self.troute_topology_file
 
         # Calculate nts (Number of Timesteps)
         start_dt = datetime.fromisoformat(self.time_start)
         end_dt = datetime.fromisoformat(self.time_end)
-        time_step_seconds = int(self._get_config_value(
-            lambda: self.config.model.troute.dt_seconds, default=3600
-        ))
+        time_step_seconds = self.troute_dt_seconds
         total_seconds = (end_dt - start_dt).total_seconds() + time_step_seconds
         nts = int(total_seconds / time_step_seconds)
 
-        # Build configuration dictionary matching t-route's schema
+        # Determine file pattern from source model config
+        file_pattern = model_cfg.output_file_pattern.format(
+            experiment_id=self.experiment_id,
+            domain_name=self.domain_name,
+        )
+
         config_dict = {
             'log_parameters': {'showtiming': True, 'log_level': 'DEBUG'},
-            'network_topology_parameters': {'supernetwork_parameters': {'geo_file_path': str(self.setup_dir / topology_name)}},
+            'network_topology_parameters': {
+                'supernetwork_parameters': {
+                    'geo_file_path': str(self.setup_dir / topology_name),
+                }
+            },
             'compute_parameters': {
                 'restart_parameters': {'start_datetime': self.time_start},
                 'forcing_parameters': {
                     'nts': nts,
                     'qlat_input_folder': str(input_dir),
-                    'qlat_file_pattern_filter': f"{self.experiment_id}_timestep.nc"
-                }
+                    'qlat_file_pattern_filter': file_pattern,
+                },
             },
-            'output_parameters': {'stream_output': {'stream_output_directory': str(output_dir)}}
+            'output_parameters': {
+                'stream_output': {'stream_output_directory': str(output_dir)},
+            },
         }
 
-        # Write dictionary to YAML file
-        yaml_filename = self._get_config_value(
-            lambda: self.config.model.troute.config_file, default='troute_config.yml'
-        )
+        yaml_filename = self.troute_config_file
         yaml_filepath = self.setup_dir / yaml_filename
         with open(yaml_filepath, 'w', encoding='utf-8') as f:
             yaml.dump(config_dict, f, default_flow_style=False, sort_keys=False, indent=2)
         self.logger.info(f"t-route YAML config written to {yaml_filepath}")
-
-    def _create_and_fill_nc_var(self, ncid, var_name, var_type, dim, data, long_name, units='-'):
-        """Helper to create and fill a NetCDF variable."""
-        var = ncid.createVariable(var_name, var_type, (dim,))
-        var[:] = data.values if hasattr(data, 'values') else data
-        var.long_name = long_name
-        var.units = units

--- a/src/symfluence/models/troute/runner.py
+++ b/src/symfluence/models/troute/runner.py
@@ -283,14 +283,19 @@ class TRouteRunner(BaseModelRunner):  # type: ignore[misc]
         if q_lat_vals.ndim == 1:
             q_lat_vals = q_lat_vals.reshape(-1, 1)
 
-        # Build HRU → segment inflow mapping
         q_seg = np.zeros((n_time, n_seg), dtype=np.float64)
-        for h in range(min(n_hru, len(hru_to_seg))):
-            seg_for_hru = int(hru_to_seg[h])
-            seg_idx = seg_id_to_idx.get(seg_for_hru, -1)
-            if seg_idx >= 0 and h < len(hru_areas):
-                # Convert depth rate (m/s) to volume rate (m³/s)
-                q_seg[:, seg_idx] += q_lat_vals[:, h] * hru_areas[h]
+
+        if n_hru == 1 and n_seg > 1:
+            # Lumped-to-distributed: spread single HRU runoff across all
+            # segments proportionally to subcatchment areas
+            for s in range(n_seg):
+                q_seg[:, s] = q_lat_vals[:, 0] * hru_areas[s]
+        else:
+            for h in range(min(n_hru, len(hru_to_seg))):
+                seg_for_hru = int(hru_to_seg[h])
+                seg_idx = seg_id_to_idx.get(seg_for_hru, -1)
+                if seg_idx >= 0 and h < len(hru_areas):
+                    q_seg[:, seg_idx] += q_lat_vals[:, h] * hru_areas[h]
 
         # --- Channel geometry ---
         if 'channel_width' in topo:

--- a/src/symfluence/models/troute/runner.py
+++ b/src/symfluence/models/troute/runner.py
@@ -76,14 +76,22 @@ class TRouteRunner(BaseModelRunner):  # type: ignore[misc]
         troute_out_path = self.get_experiment_output_dir()
         troute_out_path.mkdir(parents=True, exist_ok=True)
 
-        # 3. Choose execution mode
+        # 3. Choose execution mode (nwm_routing with fallback to built-in MC)
+        used_builtin = False
         if _check_troute_available():
             self.logger.info("Using compiled troute (nwm_routing) for routing.")
-            self._run_nwm_routing(settings_path, troute_out_path)
+            try:
+                self._run_nwm_routing(settings_path, troute_out_path)
+            except Exception as e:  # noqa: BLE001
+                self.logger.warning(
+                    f"nwm_routing failed ({e}), falling back to built-in Muskingum-Cunge."
+                )
+                used_builtin = True
         else:
-            self.logger.info(
-                "Compiled troute not available. Using built-in Muskingum-Cunge routing."
-            )
+            used_builtin = True
+
+        if used_builtin:
+            self.logger.info("Using built-in Muskingum-Cunge routing.")
             self._run_builtin_muskingum_cunge(
                 runoff_filepath, topology_file, troute_out_path
             )
@@ -97,12 +105,21 @@ class TRouteRunner(BaseModelRunner):  # type: ignore[misc]
 
     def _prepare_runoff_file(self) -> Path:
         """
-        Loads the hydrological model output and renames the runoff variable
-        to 'q_lateral' as required by t-route.
+        Locate and prepare the runoff file for t-route.
+
+        Creates a non-destructive copy with the variable renamed to 'q_lateral'
+        in the tRoute output directory, preserving the source model's original
+        output file.
 
         Returns:
-            Path to the (possibly renamed) runoff file.
+            Path to the prepared runoff file (copy with renamed variable).
         """
+        from symfluence.models.utilities.runoff_loader import (
+            detect_runoff_variable,
+            fix_time_precision,
+            resolve_runoff_file,
+        )
+
         self.logger.info("Preparing runoff file for t-route...")
 
         source_model = self._get_config_value(
@@ -112,41 +129,45 @@ class TRouteRunner(BaseModelRunner):  # type: ignore[misc]
         experiment_id = self._get_config_value(
             lambda: self.config.domain.experiment_id
         )
-        runoff_filepath = (
-            self.project_dir
-            / f"simulations/{experiment_id}/{source_model}/{experiment_id}_timestep.nc"
+
+        runoff_filepath = resolve_runoff_file(
+            source_model=source_model,
+            project_dir=self.project_dir,
+            experiment_id=experiment_id,
+            domain_name=self.domain_name,
+            config=self.config,
         )
+        if runoff_filepath is None:
+            raise ModelExecutionError("Could not locate runoff file for t-route")
 
         self.verify_required_files(runoff_filepath, context="t-route runoff preparation")
 
-        original_var_config = self._get_config_value(
-            lambda: self.config.model.mizuroute.routing_var if self.config.model and self.config.model.mizuroute else None,
-            default='averageRoutedRunoff'
-        )
-        if original_var_config in ('default', None, ''):
-            original_var = 'averageRoutedRunoff'
-        else:
-            original_var = original_var_config
+        # Fix time precision before routing
+        fix_time_precision(runoff_filepath, rounding_freq='h')
 
-        self.logger.debug(f"Checking for variable '{original_var}' in {runoff_filepath}")
-
+        # Detect the runoff variable for this source model
         with xr.open_dataset(runoff_filepath) as ds:
-            if original_var in ds.data_vars:
-                self.logger.info(f"Found '{original_var}', renaming to 'q_lateral'.")
-                ds_mem = ds.rename({original_var: 'q_lateral'}).load()
-            elif 'q_lateral' in ds.data_vars:
+            original_var = detect_runoff_variable(ds, source_model)
+            if original_var is None:
+                raise ValueError(f"No runoff variable found in {runoff_filepath}")
+
+            if original_var == 'q_lateral':
                 self.logger.info("Runoff variable already named 'q_lateral'.")
                 return runoff_filepath
-            else:
-                self.logger.error(
-                    f"Expected runoff variable '{original_var}' not found."
-                )
-                raise ValueError(f"Runoff variable not found in {runoff_filepath}")
 
-        ds_mem.to_netcdf(runoff_filepath, mode='w', format='NETCDF4')
+            # Create non-destructive copy with renamed variable
+            self.logger.info(f"Found '{original_var}', creating prepared copy with 'q_lateral'.")
+            ds_mem = ds.rename({original_var: 'q_lateral'}).load()
+
+        # Write to tRoute output directory (not the source model's directory)
+        troute_out_path = self.get_experiment_output_dir()
+        troute_out_path.mkdir(parents=True, exist_ok=True)
+        prepared_path = troute_out_path / 'prepared_runoff.nc'
+        ds_mem.to_netcdf(prepared_path, format='NETCDF4')
         ds_mem.close()
-        self.logger.info("Runoff variable successfully renamed.")
-        return runoff_filepath
+
+        self.logger.info(f"Prepared runoff file written to {prepared_path}")
+        return prepared_path
 
     # ------------------------------------------------------------------
     # Mode 1: nwm_routing subprocess

--- a/src/symfluence/models/troute/topology_generator.py
+++ b/src/symfluence/models/troute/topology_generator.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""
+TRoute topology generator.
+
+Subclass of BaseTopologyGenerator that writes NWM-format NetCDF topology
+with t-route's expected variable schema (comid, to_node, link_id_hru, etc.).
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import netCDF4 as nc4
+import numpy as np
+
+from symfluence.models.utilities.base_topology_generator import BaseTopologyGenerator, TopologyData
+
+if TYPE_CHECKING:
+    from symfluence.models.troute.preprocessor import TRoutePreProcessor
+
+
+class TRouteTopologyGenerator(BaseTopologyGenerator):
+    """
+    Generates NWM-format network topology NetCDF files for t-route.
+
+    Produces files with dimensions link/nhru and variables: comid, to_node,
+    length, slope, link_id_hru, hru_area_m2, lat, lon, alt, n, channel_width.
+    """
+
+    def __init__(self, preprocessor: 'TRoutePreProcessor'):
+        super().__init__(preprocessor)
+
+    def get_topology_output_path(self) -> Path:
+        topology_name = self.pp._get_config_value(
+            lambda: self.pp.config.model.troute.topology_file, default='troute_topology.nc'
+        )
+        return self.pp.setup_dir / topology_name
+
+    def write_topology_file(self, topology_data: TopologyData, output_path: Path) -> None:
+        """Write topology in t-route's NWM NetCDF format."""
+        with nc4.Dataset(output_path, 'w', format='NETCDF4') as ncid:
+            ncid.setncattr('Author', "Created by SYMFLUENCE workflow for t-route")
+            ncid.setncattr('History', f'Created {datetime.now().strftime("%Y/%m/%d %H:%M:%S")}')
+            ncid.setncattr('Conventions', "CF-1.6")
+
+            ncid.createDimension('link', topology_data.num_seg)
+            ncid.createDimension('nhru', topology_data.num_hru)
+            ncid.createDimension('gages', None)
+
+            self._write_var(ncid, 'comid', 'i4', 'link', topology_data.seg_ids, 'Unique segment ID')
+            self._write_var(ncid, 'to_node', 'i4', 'link', topology_data.down_seg_ids, 'Downstream segment ID')
+            self._write_var(ncid, 'length', 'f8', 'link', topology_data.lengths, 'Segment length', 'meters')
+            self._write_var(ncid, 'slope', 'f8', 'link', topology_data.slopes, 'Segment slope', 'm/m')
+            self._write_var(ncid, 'link_id_hru', 'i4', 'nhru', topology_data.hru_to_seg_ids, 'Segment ID for HRU discharge')
+            self._write_var(ncid, 'hru_area_m2', 'f8', 'nhru', topology_data.hru_areas, 'HRU area', 'm^2')
+
+            # Manning's n (uniform)
+            mannings_n = self.pp._get_config_value(
+                lambda: self.pp.config.model.troute.mannings_n, default=0.035
+            )
+            self._write_var(ncid, 'n', 'f8', 'link', np.full(topology_data.num_seg, float(mannings_n)), 'Mannings roughness coefficient')
+
+            # Elevations if available
+            if topology_data.elevations is not None:
+                self._write_var(ncid, 'alt', 'f8', 'link', topology_data.elevations, 'Mean elevation of segment', 'meters')
+            else:
+                self._write_var(ncid, 'alt', 'f8', 'link', np.zeros(topology_data.num_seg), 'Mean elevation of segment', 'meters')
+
+            # Lat/lon from centroids if we have the river shapefile
+            self._write_var(ncid, 'lat', 'f8', 'link', np.zeros(topology_data.num_seg), 'Latitude of segment midpoint', 'degrees_north')
+            self._write_var(ncid, 'lon', 'f8', 'link', np.zeros(topology_data.num_seg), 'Longitude of segment midpoint', 'degrees_east')
+            self._write_var(ncid, 'from_node', 'i4', 'link', np.zeros(topology_data.num_seg, dtype=int), 'Upstream node ID')
+
+            # Channel width from hydraulic geometry (W = a * A^b)
+            self._write_channel_width(ncid, topology_data)
+
+        self.pp.logger.info(f"t-route topology file created at {output_path}")
+
+    def write_topology_with_shapefiles(self) -> TopologyData:
+        """
+        Build topology from shapefiles and write to NWM-format NetCDF.
+
+        Also adds lat/lon centroids and drainage area from the river shapefile.
+        Returns the TopologyData for use by the preprocessor.
+        """
+        topology_data = self.build_topology()
+        output_path = self.get_topology_output_path()
+
+        # Try to enrich with shapefile geometry
+        try:
+            self._enrich_with_shapefile_data(topology_data, output_path)
+        except Exception:  # noqa: BLE001
+            self.write_topology_file(topology_data, output_path)
+
+        return topology_data
+
+    def _enrich_with_shapefile_data(self, topology_data: TopologyData, output_path: Path) -> None:
+        """Write topology with additional data from shapefiles (centroids, drainage area)."""
+        import geopandas as gpd
+
+        # Load shapefiles to get centroids
+        domain_type = self.detect_domain_type()
+        if domain_type == 'point':
+            self.write_topology_file(topology_data, output_path)
+            return
+
+        try:
+            if domain_type == 'grid':
+                grid_path = (
+                    self.pp.project_dir / 'shapefiles' / 'river_basins'
+                    / f"{self.pp.domain_name}_riverBasins_distribute.shp"
+                )
+                shp_river = gpd.read_file(grid_path)
+            else:
+                routing_suffix = 'delineate' if domain_type == 'lumped_to_distributed' else self._get_method_suffix()
+                river_network_path = self.pp.project_dir / 'shapefiles/river_network'
+                river_network_name = f"{self.pp.domain_name}_riverNetwork_{routing_suffix}.shp"
+                shp_river = gpd.read_file(river_network_path / river_network_name)
+        except Exception:  # noqa: BLE001
+            self.write_topology_file(topology_data, output_path)
+            return
+
+        centroids = self.pp.calculate_feature_centroids(shp_river)
+
+        with nc4.Dataset(output_path, 'w', format='NETCDF4') as ncid:
+            ncid.setncattr('Author', "Created by SYMFLUENCE workflow for t-route")
+            ncid.setncattr('History', f'Created {datetime.now().strftime("%Y/%m/%d %H:%M:%S")}')
+            ncid.setncattr('Conventions', "CF-1.6")
+
+            ncid.createDimension('link', topology_data.num_seg)
+            ncid.createDimension('nhru', topology_data.num_hru)
+            ncid.createDimension('gages', None)
+
+            self._write_var(ncid, 'comid', 'i4', 'link', topology_data.seg_ids, 'Unique segment ID')
+            self._write_var(ncid, 'to_node', 'i4', 'link', topology_data.down_seg_ids, 'Downstream segment ID')
+            self._write_var(ncid, 'length', 'f8', 'link', topology_data.lengths, 'Segment length', 'meters')
+            self._write_var(ncid, 'slope', 'f8', 'link', topology_data.slopes, 'Segment slope', 'm/m')
+            self._write_var(ncid, 'link_id_hru', 'i4', 'nhru', topology_data.hru_to_seg_ids, 'Segment ID for HRU discharge')
+            self._write_var(ncid, 'hru_area_m2', 'f8', 'nhru', topology_data.hru_areas, 'HRU area', 'm^2')
+
+            mannings_n = self.pp._get_config_value(
+                lambda: self.pp.config.model.troute.mannings_n, default=0.035
+            )
+            self._write_var(ncid, 'n', 'f8', 'link', np.full(topology_data.num_seg, float(mannings_n)), 'Mannings roughness coefficient')
+
+            # Centroids from shapefile
+            lats = centroids.y.values[:topology_data.num_seg] if len(centroids) >= topology_data.num_seg else np.zeros(topology_data.num_seg)
+            lons = centroids.x.values[:topology_data.num_seg] if len(centroids) >= topology_data.num_seg else np.zeros(topology_data.num_seg)
+            self._write_var(ncid, 'lat', 'f8', 'link', lats, 'Latitude of segment midpoint', 'degrees_north')
+            self._write_var(ncid, 'lon', 'f8', 'link', lons, 'Longitude of segment midpoint', 'degrees_east')
+
+            # Elevation
+            if topology_data.elevations is not None:
+                self._write_var(ncid, 'alt', 'f8', 'link', topology_data.elevations, 'Mean elevation of segment', 'meters')
+            elif 'elev_mean' in shp_river.columns:
+                self._write_var(ncid, 'alt', 'f8', 'link', shp_river['elev_mean'].values[:topology_data.num_seg].astype(float), 'Mean elevation', 'meters')
+            else:
+                self._write_var(ncid, 'alt', 'f8', 'link', np.zeros(topology_data.num_seg), 'Mean elevation of segment', 'meters')
+
+            self._write_var(ncid, 'from_node', 'i4', 'link', np.zeros(topology_data.num_seg, dtype=int), 'Upstream node ID')
+
+            # Drainage area and channel width
+            if 'DSContArea' in shp_river.columns:
+                da_km2 = shp_river['DSContArea'].values[:topology_data.num_seg].astype(np.float64) / 1e6
+                self._write_var(ncid, 'drainage_area_km2', 'f8', 'link', da_km2, 'Downstream contributing area', 'km^2')
+            self._write_channel_width(ncid, topology_data, shp_river=shp_river)
+
+            if 'strmOrder' in shp_river.columns:
+                self._write_var(ncid, 'stream_order', 'i4', 'link', shp_river['strmOrder'].values[:topology_data.num_seg].astype(int), 'Strahler stream order')
+
+        self.pp.logger.info(f"t-route topology file created at {output_path}")
+
+    def _write_channel_width(self, ncid, topology_data: TopologyData, shp_river=None) -> None:
+        """Compute channel width from hydraulic geometry: W = a * A^b."""
+        hg_a = float(self.pp._get_config_value(
+            lambda: self.pp.config.model.troute.hg_width_coeff, default=2.71
+        ))
+        hg_b = float(self.pp._get_config_value(
+            lambda: self.pp.config.model.troute.hg_width_exp, default=0.557
+        ))
+
+        da_km2 = None
+        if shp_river is not None and 'DSContArea' in shp_river.columns:
+            da_km2 = shp_river['DSContArea'].values[:topology_data.num_seg].astype(np.float64) / 1e6
+
+        if da_km2 is not None:
+            da_clamped = np.maximum(da_km2, 0.01)
+            channel_width = np.maximum(hg_a * da_clamped ** hg_b, 1.0)
+        else:
+            # Fallback: estimate from HRU areas
+            hru_areas_km2 = topology_data.hru_areas[:topology_data.num_seg] / 1e6 if len(topology_data.hru_areas) >= topology_data.num_seg else np.ones(topology_data.num_seg)
+            da_clamped = np.maximum(hru_areas_km2, 0.01)
+            channel_width = np.maximum(hg_a * da_clamped ** hg_b, 1.0)
+
+        self._write_var(ncid, 'channel_width', 'f8', 'link', channel_width, 'Channel width from hydraulic geometry', 'meters')
+
+    @staticmethod
+    def _write_var(ncid, name, dtype, dim, data, long_name, units='-'):
+        """Helper to create and fill a NetCDF variable."""
+        var = ncid.createVariable(name, dtype, (dim,))
+        var[:] = data.values if hasattr(data, 'values') else data
+        var.long_name = long_name
+        var.units = units

--- a/src/symfluence/models/utilities/__init__.py
+++ b/src/symfluence/models/utilities/__init__.py
@@ -15,9 +15,18 @@ from symfluence.data.preprocessing.dataset_alignment_manager import DatasetAlign
 from symfluence.data.preprocessing.time_window_manager import TimeWindowManager
 
 from .base_forcing_processor import BaseForcingProcessor
+from .base_remap_generator import BaseRemapGenerator, RemapData
+from .base_topology_generator import BaseTopologyGenerator, TopologyData
 from .data_quality_handler import DataQualityHandler
 from .forcing_data_processor import ForcingDataProcessor
 from .routing_decider import RoutingDecider
+from .runoff_loader import (
+    MODEL_CONFIGS,
+    ModelRunoffConfig,
+    detect_runoff_variable,
+    fix_time_precision,
+    resolve_runoff_file,
+)
 
 __all__ = [
     'TimeWindowManager',
@@ -26,5 +35,14 @@ __all__ = [
     'DatasetAlignmentManager',
     'align_forcing_datasets',
     'BaseForcingProcessor',
+    'BaseRemapGenerator',
+    'BaseTopologyGenerator',
+    'MODEL_CONFIGS',
+    'ModelRunoffConfig',
+    'RemapData',
     'RoutingDecider',
+    'TopologyData',
+    'detect_runoff_variable',
+    'fix_time_precision',
+    'resolve_runoff_file',
 ]

--- a/src/symfluence/models/utilities/base_remap_generator.py
+++ b/src/symfluence/models/utilities/base_remap_generator.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""
+Base remap generator for routing models.
+
+Provides shared algorithms for spatial remapping between source model
+spatial units and routing network HRUs. Supports area-weighted, equal-weight,
+and EASYMORE spatial intersection approaches.
+
+Each routing model subclasses this to write remap data in its own format.
+"""
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+class RemapPreprocessorProtocol(Protocol):
+    """Protocol defining what the remap generator needs from a preprocessor."""
+
+    logger: Any
+
+    @property
+    def project_dir(self) -> Path: ...
+    @property
+    def domain_name(self) -> str: ...
+    @property
+    def setup_dir(self) -> Path: ...
+
+    def _get_config_value(self, getter: Any, default: Any = None, dict_key: str = '') -> Any: ...
+
+
+@dataclass
+class RemapData:
+    """Intermediate representation of spatial remapping."""
+
+    rn_hru_ids: np.ndarray
+    n_overlaps: np.ndarray
+    hm_hru_ids: np.ndarray
+    weights: np.ndarray
+    num_hru: int = 0
+    num_data: int = 0
+
+    def __post_init__(self):
+        if self.num_hru == 0:
+            self.num_hru = len(self.rn_hru_ids)
+        if self.num_data == 0:
+            self.num_data = len(self.hm_hru_ids)
+
+
+class BaseRemapGenerator(ABC):
+    """
+    Base class for routing model remap generators.
+
+    Provides shared algorithms for computing spatial remapping weights.
+    Subclasses implement write_remap_file() to produce model-specific output.
+    """
+
+    def __init__(self, preprocessor: RemapPreprocessorProtocol):
+        self.pp = preprocessor
+
+    # =========================================================================
+    # Abstract methods
+    # =========================================================================
+
+    @abstractmethod
+    def write_remap_file(self, remap_data: RemapData, output_path: Path) -> None:
+        """Write remap data in the model-specific format."""
+
+    # =========================================================================
+    # Remapping strategies
+    # =========================================================================
+
+    def create_area_weighted_remap(
+        self,
+        hru_ids: np.ndarray,
+        weights: np.ndarray,
+        source_gru_id: int = 1,
+    ) -> RemapData:
+        """
+        Create area-weighted remapping from delineated catchment weights.
+
+        Each routing HRU receives runoff from a single source GRU,
+        distributed according to areal weights (fractional subcatchment areas).
+        """
+        n_hrus = len(hru_ids)
+        return RemapData(
+            rn_hru_ids=hru_ids.astype(int),
+            n_overlaps=np.ones(n_hrus, dtype=int),
+            hm_hru_ids=np.full(n_hrus, source_gru_id, dtype=int),
+            weights=weights.astype(float),
+        )
+
+    def create_equal_weight_remap(
+        self,
+        hru_ids: np.ndarray,
+        source_gru_id: int = 1,
+    ) -> RemapData:
+        """
+        Create equal-weight remapping for all routing HRUs.
+
+        Distributes runoff uniformly from a single source GRU to all
+        routing HRUs. Weight = 1/n_hrus for each.
+        """
+        n_hrus = len(hru_ids)
+        equal_weight = 1.0 / n_hrus
+        return RemapData(
+            rn_hru_ids=hru_ids.astype(int),
+            n_overlaps=np.ones(n_hrus, dtype=int),
+            hm_hru_ids=np.full(n_hrus, source_gru_id, dtype=int),
+            weights=np.full(n_hrus, equal_weight),
+        )
+
+    def create_spatial_intersection_remap(
+        self,
+        hm_shape_path: Path,
+        rm_shape_path: Path,
+        hm_hru_col: str = 'GRU_ID',
+        rm_hru_col: str = 'GRU_ID',
+    ) -> RemapData:
+        """
+        Create remapping via EASYMORE spatial intersection.
+
+        Performs area-weighted spatial intersection between source model (HM)
+        catchments and routing model (RM) basins.
+        """
+        import geopandas as gpd
+        import pandas as pd
+
+        hm_shape = gpd.read_file(hm_shape_path)
+        rm_shape = gpd.read_file(rm_shape_path)
+
+        # Reproject to equal-area for accurate intersection
+        hm_shape = hm_shape.to_crs('EPSG:6933')
+        rm_shape = rm_shape.to_crs('EPSG:6933')
+
+        esmr_obj = _create_easymore_instance()
+        intersected = esmr_obj.intersection_shp(rm_shape, hm_shape)
+
+        # Process intersection results
+        int_rm_id = f"S_1_{rm_hru_col}"
+        int_hm_id = f"S_2_{hm_hru_col}"
+        int_weight = 'AP1N'
+
+        intersected = intersected.sort_values(by=[int_rm_id, int_hm_id])
+
+        rn_hru_ids = intersected.groupby(int_rm_id).agg({int_rm_id: pd.unique}).values.astype(int).flatten()
+        n_overlaps = intersected.groupby(int_rm_id).agg({int_hm_id: 'count'}).values.astype(int).flatten()
+
+        nested_hm_ids = intersected.groupby(int_rm_id).agg({int_hm_id: list}).values.tolist()
+        hm_hru_ids = np.array([item for sublist in nested_hm_ids for item in sublist[0]], dtype=int)
+
+        nested_weights = intersected.groupby(int_rm_id).agg({int_weight: list}).values.tolist()
+        weights = np.array([item for sublist in nested_weights for item in sublist[0]], dtype=float)
+
+        return RemapData(
+            rn_hru_ids=rn_hru_ids,
+            n_overlaps=n_overlaps,
+            hm_hru_ids=hm_hru_ids,
+            weights=weights,
+        )
+
+
+def _create_easymore_instance():
+    """Create an EASYMORE instance handling different module structures."""
+    import easymore
+
+    if hasattr(easymore, "Easymore"):
+        return easymore.Easymore()
+    if hasattr(easymore, "easymore"):
+        return easymore.easymore()
+    raise AttributeError("easymore module does not expose an Easymore class")

--- a/src/symfluence/models/utilities/base_topology_generator.py
+++ b/src/symfluence/models/utilities/base_topology_generator.py
@@ -1,0 +1,728 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""
+Base topology generator for routing models.
+
+Provides shared algorithms for network topology generation: cycle detection/fix,
+headwater basin detection, synthetic network creation, pour point snapping,
+downstream reference validation, outlet enforcement, and topological sort.
+
+Each routing model subclasses this to produce its own topology format.
+"""
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, List, Optional, Protocol, Set, Tuple
+
+import numpy as np
+
+if TYPE_CHECKING:
+    import geopandas as gpd
+
+logger = logging.getLogger(__name__)
+
+
+class TopologyPreprocessorProtocol(Protocol):
+    """Protocol defining what the base topology generator needs from a preprocessor."""
+
+    logger: Any
+
+    @property
+    def project_dir(self) -> Path: ...
+    @property
+    def domain_name(self) -> str: ...
+    @property
+    def domain_definition_method(self) -> str: ...
+    @property
+    def river_segid_col(self) -> str: ...
+    @property
+    def river_downsegid_col(self) -> str: ...
+    @property
+    def river_length_col(self) -> str: ...
+    @property
+    def river_slope_col(self) -> str: ...
+    @property
+    def basin_gruid_col(self) -> str: ...
+    @property
+    def basin_hru_to_seg_col(self) -> str: ...
+    @property
+    def basin_area_col(self) -> str: ...
+
+    def _get_config_value(self, getter: Any, default: Any = None, dict_key: str = '') -> Any: ...
+    def calculate_feature_centroids(self, gdf: Any) -> Any: ...
+
+
+@dataclass
+class TopologyData:
+    """Intermediate representation of network topology."""
+
+    seg_ids: np.ndarray
+    down_seg_ids: np.ndarray
+    slopes: np.ndarray
+    lengths: np.ndarray
+    hru_ids: np.ndarray
+    hru_to_seg_ids: np.ndarray
+    hru_areas: np.ndarray
+    elevations: Optional[np.ndarray] = None
+    num_seg: int = 0
+    num_hru: int = 0
+    domain_type: str = 'distributed'
+    summa_uses_gru_runoff: bool = False
+    needs_remap_lumped_distributed: bool = False
+    subcatchment_weights: Optional[np.ndarray] = None
+    subcatchment_gru_ids: Optional[np.ndarray] = None
+    extra: dict = field(default_factory=dict)
+
+    def __post_init__(self):
+        if self.num_seg == 0:
+            self.num_seg = len(self.seg_ids)
+        if self.num_hru == 0:
+            self.num_hru = len(self.hru_ids)
+
+
+class BaseTopologyGenerator(ABC):
+    """
+    Base class for routing model topology generators.
+
+    Provides shared algorithms for network topology construction. Subclasses
+    implement write_topology_file() to produce model-specific output formats.
+    """
+
+    def __init__(self, preprocessor: TopologyPreprocessorProtocol):
+        self.pp = preprocessor
+
+    # =========================================================================
+    # Abstract methods — subclasses must implement
+    # =========================================================================
+
+    @abstractmethod
+    def write_topology_file(self, topology_data: TopologyData, output_path: Path) -> None:
+        """Write topology data in the model-specific format."""
+
+    @abstractmethod
+    def get_topology_output_path(self) -> Path:
+        """Return the output path for the topology file."""
+
+    # =========================================================================
+    # Domain type detection
+    # =========================================================================
+
+    def detect_domain_type(self) -> str:
+        """Detect the domain type from configuration."""
+        method = self.pp.domain_definition_method
+        if method == 'distribute':
+            return 'grid'
+        if method == 'point':
+            return 'point'
+
+        routing_delineation = self.pp._get_config_value(
+            lambda: self.pp.config.domain.routing,  # type: ignore[attr-defined]
+            default='lumped',
+            dict_key='ROUTING_DELINEATION',
+        )
+        if method == 'lumped' and routing_delineation == 'river_network':
+            return 'lumped_to_distributed'
+        return 'distributed'
+
+    # =========================================================================
+    # Network topology construction
+    # =========================================================================
+
+    def build_topology(self) -> TopologyData:
+        """
+        Build topology data from shapefiles based on the detected domain type.
+
+        Returns TopologyData with all network information populated.
+        """
+        domain_type = self.detect_domain_type()
+
+        if domain_type == 'grid':
+            return self._build_grid_topology()
+        if domain_type == 'point':
+            return self._build_point_topology()
+        if domain_type == 'lumped_to_distributed':
+            return self._build_lumped_to_distributed_topology()
+        return self._build_distributed_topology()
+
+    def _build_distributed_topology(self) -> TopologyData:
+        """Build topology from river network and basin shapefiles."""
+        shp_river, shp_basin = self._load_river_and_basin_shapefiles()
+
+        # Check for SUMMA attributes with multi-HRU per GRU
+        attributes_path = self.pp.project_dir / 'settings' / 'SUMMA' / 'attributes.nc'
+        summa_uses_gru_runoff = False
+
+        if attributes_path.exists():
+            import netCDF4 as nc4
+            with nc4.Dataset(attributes_path, 'r') as attrs:
+                n_hrus = len(attrs.dimensions['hru'])
+                n_grus = len(attrs.dimensions['gru'])
+
+                if n_hrus > n_grus:
+                    summa_uses_gru_runoff = True
+                    self.pp.logger.info(f"Distributed SUMMA with {n_hrus} HRUs across {n_grus} GRUs")
+
+                    gru_ids = attrs.variables['gruId'][:].astype(int)
+                    hru2gru = attrs.variables['hru2gruId'][:].astype(int)
+                    hru_areas_all = attrs.variables['HRUarea'][:].astype(float)
+
+                    gru_areas = np.zeros(n_grus)
+                    for i, gru_id in enumerate(gru_ids):
+                        gru_mask = hru2gru == gru_id
+                        gru_areas[i] = hru_areas_all[gru_mask].sum()
+
+                    hru_ids = gru_ids
+                    hru_to_seg_ids = gru_ids
+                    hru_areas = gru_areas
+                    num_hru = n_grus
+                else:
+                    hru_ids, hru_to_seg_ids, hru_areas, num_hru = self._extract_basin_topology(
+                        shp_river, shp_basin
+                    )
+        else:
+            hru_ids, hru_to_seg_ids, hru_areas, num_hru = self._extract_basin_topology(
+                shp_river, shp_basin
+            )
+
+        num_seg = len(shp_river)
+        self._enforce_minimum_values(shp_river)
+        self._enforce_outlets(shp_river)
+        self._validate_downstream_refs(shp_river)
+        hru_to_seg_ids = self._validate_hru_to_seg_refs(
+            hru_ids, hru_to_seg_ids, shp_river
+        )
+
+        seg_ids = shp_river[self.pp.river_segid_col].values.astype(int)
+        down_seg_ids = shp_river[self.pp.river_downsegid_col].values.astype(int)
+        slopes = shp_river[self.pp.river_slope_col].values.astype(float)
+        lengths = shp_river[self.pp.river_length_col].values.astype(float)
+
+        return TopologyData(
+            seg_ids=seg_ids,
+            down_seg_ids=down_seg_ids,
+            slopes=slopes,
+            lengths=lengths,
+            hru_ids=hru_ids,
+            hru_to_seg_ids=hru_to_seg_ids,
+            hru_areas=hru_areas,
+            num_seg=num_seg,
+            num_hru=num_hru,
+            domain_type='distributed',
+            summa_uses_gru_runoff=summa_uses_gru_runoff,
+        )
+
+    def _build_lumped_to_distributed_topology(self) -> TopologyData:
+        """Build topology for lumped domain with distributed routing."""
+        import geopandas as gpd
+
+        shp_river, shp_basin = self._load_river_and_basin_shapefiles(
+            routing_suffix='delineate'
+        )
+
+        catchment_path = (
+            self.pp.project_dir / 'shapefiles' / 'catchment'
+            / f"{self.pp.domain_name}_catchment_delineated.shp"
+        )
+        if not catchment_path.exists():
+            raise FileNotFoundError(f"Delineated catchment shapefile not found: {catchment_path}")
+
+        shp_catchments = gpd.read_file(catchment_path)
+        self.pp.logger.info(f"Loaded {len(shp_catchments)} delineated subcatchments")
+
+        hru_ids = shp_catchments['GRU_ID'].values.astype(int)
+
+        if self.check_if_headwater_basin(shp_river):
+            shp_river = self.create_synthetic_river_network(shp_river, hru_ids)
+
+        num_seg = len(shp_river)
+        num_hru = len(shp_catchments)
+        hru_to_seg_ids = shp_catchments['GRU_ID'].values.astype(int)
+
+        total_basin_area = shp_basin[self.pp.basin_area_col].sum()
+        hru_areas = shp_catchments['avg_subbas'].values * total_basin_area
+
+        subcatchment_weights = shp_catchments['avg_subbas'].values
+        subcatchment_gru_ids = hru_ids
+
+        self._enforce_minimum_values(shp_river)
+        self._enforce_outlets(shp_river)
+        self._validate_downstream_refs(shp_river)
+
+        seg_ids = shp_river[self.pp.river_segid_col].values.astype(int)
+        down_seg_ids = shp_river[self.pp.river_downsegid_col].values.astype(int)
+        slopes = shp_river[self.pp.river_slope_col].values.astype(float)
+        lengths = shp_river[self.pp.river_length_col].values.astype(float)
+
+        return TopologyData(
+            seg_ids=seg_ids,
+            down_seg_ids=down_seg_ids,
+            slopes=slopes,
+            lengths=lengths,
+            hru_ids=hru_ids,
+            hru_to_seg_ids=hru_to_seg_ids,
+            hru_areas=hru_areas,
+            num_seg=num_seg,
+            num_hru=num_hru,
+            domain_type='lumped_to_distributed',
+            summa_uses_gru_runoff=True,
+            needs_remap_lumped_distributed=True,
+            subcatchment_weights=subcatchment_weights,
+            subcatchment_gru_ids=subcatchment_gru_ids,
+        )
+
+    def _build_grid_topology(self) -> TopologyData:
+        """Build topology from grid-based distributed domain."""
+        import geopandas as gpd
+
+        grid_path = (
+            self.pp.project_dir / 'shapefiles' / 'river_basins'
+            / f"{self.pp.domain_name}_riverBasins_distribute.shp"
+        )
+        if not grid_path.exists():
+            raise FileNotFoundError(f"Grid basins shapefile not found: {grid_path}")
+
+        grid_gdf = gpd.read_file(grid_path)
+        num_cells = len(grid_gdf)
+        self.pp.logger.info(f"Loaded {num_cells} grid cells from {grid_path}")
+
+        seg_ids = grid_gdf['GRU_ID'].values.astype(int)
+
+        # D8 downstream topology
+        if 'downstream_id' in grid_gdf.columns:
+            down_seg_ids = grid_gdf['downstream_id'].values.astype(int)
+        elif 'downstream' in grid_gdf.columns:
+            down_seg_ids = grid_gdf['downstream'].values.astype(int)
+        elif 'DSLINKNO' in grid_gdf.columns:
+            down_seg_ids = grid_gdf['DSLINKNO'].values.astype(int)
+        else:
+            self.pp.logger.warning("No D8 topology found, setting all cells as outlets")
+            down_seg_ids = np.zeros(num_cells, dtype=int)
+
+        slopes = grid_gdf['slope'].values.astype(float) if 'slope' in grid_gdf.columns else np.full(num_cells, 0.01)
+        slopes = np.maximum(slopes, 0.001)
+
+        elevations = grid_gdf['elev_mean'].values.astype(float) if 'elev_mean' in grid_gdf.columns else np.zeros(num_cells)
+
+        down_seg_ids = self.fix_routing_cycles(seg_ids, down_seg_ids, elevations)
+        self._validate_downstream_refs_arrays(seg_ids, down_seg_ids)
+
+        grid_cell_size = self.pp._get_config_value(
+            lambda: self.pp.config.model.mizuroute.grid_cell_size,  # type: ignore[attr-defined]
+            default=1000.0
+        )
+        lengths = np.full(num_cells, float(grid_cell_size))
+
+        hru_ids = seg_ids.copy()
+        hru_to_seg_ids = seg_ids.copy()
+        hru_areas = (
+            grid_gdf['GRU_area'].values.astype(float)
+            if 'GRU_area' in grid_gdf.columns
+            else np.full(num_cells, float(grid_cell_size) ** 2)
+        )
+
+        return TopologyData(
+            seg_ids=seg_ids,
+            down_seg_ids=down_seg_ids,
+            slopes=slopes,
+            lengths=lengths,
+            hru_ids=hru_ids,
+            hru_to_seg_ids=hru_to_seg_ids,
+            hru_areas=hru_areas,
+            elevations=elevations,
+            num_seg=num_cells,
+            num_hru=num_cells,
+            domain_type='grid',
+            summa_uses_gru_runoff=True,
+        )
+
+    def _build_point_topology(self) -> TopologyData:
+        """Build minimal single-segment topology for point-scale domains."""
+        self.pp.logger.info("Creating point-scale network topology")
+
+        return TopologyData(
+            seg_ids=np.array([1]),
+            down_seg_ids=np.array([0]),
+            slopes=np.array([0.01]),
+            lengths=np.array([100.0]),
+            hru_ids=np.array([1]),
+            hru_to_seg_ids=np.array([1]),
+            hru_areas=np.array([10000.0]),
+            num_seg=1,
+            num_hru=1,
+            domain_type='point',
+            summa_uses_gru_runoff=True,
+        )
+
+    # =========================================================================
+    # Shapefile loading
+    # =========================================================================
+
+    def _load_river_and_basin_shapefiles(
+        self, routing_suffix: Optional[str] = None
+    ) -> Tuple['gpd.GeoDataFrame', 'gpd.GeoDataFrame']:
+        """Load river network and basin shapefiles."""
+        import geopandas as gpd
+
+        if routing_suffix is None:
+            routing_suffix = self._get_method_suffix()
+
+        river_network_path = self.pp._get_config_value(
+            lambda: self.pp.config.paths.river_network_shp_path,  # type: ignore[attr-defined]
+            default='default'
+        )
+        river_network_name = self.pp._get_config_value(
+            lambda: self.pp.config.paths.river_network_shp_name,  # type: ignore[attr-defined]
+            default='default'
+        )
+
+        if river_network_name == 'default':
+            river_network_name = f"{self.pp.domain_name}_riverNetwork_{routing_suffix}.shp"
+        if river_network_path == 'default':
+            river_network_path = self.pp.project_dir / 'shapefiles/river_network'
+        else:
+            river_network_path = Path(river_network_path)
+
+        river_basin_path = self.pp._get_config_value(
+            lambda: self.pp.config.paths.river_basins_path,  # type: ignore[attr-defined]
+            default='default'
+        )
+        river_basin_name = self.pp._get_config_value(
+            lambda: self.pp.config.paths.river_basins_name,  # type: ignore[attr-defined]
+            default='default'
+        )
+
+        if river_basin_name == 'default':
+            river_basin_name = f"{self.pp.domain_name}_riverBasins_{routing_suffix}.shp"
+        if river_basin_path == 'default':
+            river_basin_path = self.pp.project_dir / 'shapefiles/river_basins'
+        else:
+            river_basin_path = Path(river_basin_path)
+
+        shp_river = gpd.read_file(river_network_path / river_network_name)
+        shp_basin = gpd.read_file(river_basin_path / river_basin_name)
+        return shp_river, shp_basin
+
+    def _get_method_suffix(self) -> str:
+        """Get the shapefile method suffix from config."""
+        method = self.pp.domain_definition_method
+        if method in ('lumped', 'point'):
+            return 'lumped'
+        return method
+
+    def _extract_basin_topology(
+        self, shp_river: 'gpd.GeoDataFrame', shp_basin: 'gpd.GeoDataFrame'
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, int]:
+        """Extract HRU topology from basin shapefile."""
+        closest_segment_id = self._find_closest_segment_to_pour_point(shp_river)
+
+        if len(shp_basin) == 1:
+            shp_basin.loc[shp_basin.index[0], self.pp.basin_hru_to_seg_col] = closest_segment_id
+            self.pp.logger.info(f"Set single HRU to drain to closest segment: {closest_segment_id}")
+
+        hru_ids = shp_basin[self.pp.basin_gruid_col].values.astype(int)
+        hru_to_seg_ids = shp_basin[self.pp.basin_hru_to_seg_col].values.astype(int)
+        hru_areas = shp_basin[self.pp.basin_area_col].values.astype(float)
+        return hru_ids, hru_to_seg_ids, hru_areas, len(shp_basin)
+
+    # =========================================================================
+    # Headwater basin handling
+    # =========================================================================
+
+    def check_if_headwater_basin(self, shp_river: 'gpd.GeoDataFrame') -> bool:
+        """Check if this is a headwater basin with None/invalid river network data."""
+        seg_id_col = self.pp.river_segid_col
+        downseg_id_col = self.pp.river_downsegid_col
+
+        if seg_id_col in shp_river.columns and downseg_id_col in shp_river.columns:
+            seg_ids_null = shp_river[seg_id_col].isna().all()
+            downseg_ids_null = shp_river[downseg_id_col].isna().all()
+
+            if seg_ids_null and downseg_ids_null:
+                self.pp.logger.info("Detected headwater basin: all river network IDs are None/null")
+                return True
+
+            if shp_river[seg_id_col].dtype == 'object':
+                seg_ids_none_str = (shp_river[seg_id_col] == 'None').all()
+                downseg_ids_none_str = (shp_river[downseg_id_col] == 'None').all()
+                if seg_ids_none_str and downseg_ids_none_str:
+                    self.pp.logger.info("Detected headwater basin: all river network IDs are 'None' strings")
+                    return True
+
+        return False
+
+    def create_synthetic_river_network(
+        self, shp_river: 'gpd.GeoDataFrame', hru_ids: np.ndarray
+    ) -> 'gpd.GeoDataFrame':
+        """Create a synthetic single-segment river network for headwater basins."""
+        import geopandas as gpd
+
+        self.pp.logger.info("Creating synthetic river network for headwater basin")
+
+        synthetic_seg_id = int(hru_ids[0]) if len(hru_ids) > 0 else 1
+
+        synthetic_data = {
+            self.pp.river_segid_col: synthetic_seg_id,
+            self.pp.river_downsegid_col: 0,
+            self.pp.river_length_col: 1000.0,
+            self.pp.river_slope_col: 0.001,
+        }
+
+        geom_col = shp_river.geometry.name
+        if not shp_river.empty and shp_river.geometry.iloc[0] is not None:
+            synthetic_geom = self.pp.calculate_feature_centroids(shp_river.iloc[[0]]).iloc[0]
+        else:
+            from shapely.geometry import Point
+            synthetic_geom = Point(0, 0)
+
+        synthetic_data[geom_col] = synthetic_geom
+        return gpd.GeoDataFrame([synthetic_data], crs=shp_river.crs)
+
+    # =========================================================================
+    # Pour point and segment lookup
+    # =========================================================================
+
+    def _find_closest_segment_to_pour_point(self, shp_river: 'gpd.GeoDataFrame') -> int:
+        """Find the river segment closest to the pour point."""
+        import geopandas as gpd
+
+        pour_point_dir = self.pp.project_dir / 'shapefiles' / 'pour_point'
+        pour_point_files = list(pour_point_dir.glob('*.shp'))
+
+        if not pour_point_files:
+            return self._fallback_outlet_segment(shp_river)
+
+        try:
+            shp_pour_point = gpd.read_file(pour_point_files[0])
+
+            if shp_river.crs != shp_pour_point.crs:
+                shp_pour_point = shp_pour_point.to_crs(shp_river.crs)
+
+            shp_river_proj = shp_river.to_crs(shp_river.estimate_utm_crs())
+            pour_point_centroids = self.pp.calculate_feature_centroids(shp_pour_point.iloc[[0]])
+            pour_point_proj = pour_point_centroids.to_crs(shp_river_proj.crs)
+            distances = shp_river_proj.geometry.distance(pour_point_proj.iloc[0])
+
+            closest_idx = distances.idxmin()
+            closest_segment_id = shp_river.loc[closest_idx, self.pp.river_segid_col]
+            self.pp.logger.info(f"Closest segment to pour point: {closest_segment_id}")
+            return closest_segment_id
+
+        except Exception as e:  # noqa: BLE001
+            self.pp.logger.error(f"Error finding closest segment: {e}")
+            return self._fallback_outlet_segment(shp_river)
+
+    def _fallback_outlet_segment(self, shp_river: 'gpd.GeoDataFrame') -> int:
+        """Find an outlet or first segment as fallback."""
+        outlet_mask = shp_river[self.pp.river_downsegid_col] == 0
+        if outlet_mask.any():
+            return shp_river.loc[outlet_mask, self.pp.river_segid_col].iloc[0]
+        return shp_river[self.pp.river_segid_col].iloc[0]
+
+    # =========================================================================
+    # Cycle detection and fixing
+    # =========================================================================
+
+    @staticmethod
+    def fix_routing_cycles(
+        seg_ids: np.ndarray,
+        down_seg_ids: np.ndarray,
+        elevations: np.ndarray,
+    ) -> np.ndarray:
+        """
+        Detect and fix cycles in the routing graph.
+
+        For each cycle found, the node with the lowest elevation is forced
+        to be an outlet (downSegId = 0).
+
+        This is a static method so it can be reused by external code (e.g.,
+        dRoute's network_adapter) without instantiating the full generator.
+        """
+        id_to_idx = {sid: i for i, sid in enumerate(seg_ids)}
+
+        adj = {}
+        for i, down_sid in enumerate(down_seg_ids):
+            if down_sid in id_to_idx:
+                adj[i] = id_to_idx[down_sid]
+            else:
+                adj[i] = -1
+
+        visited: Set[int] = set()
+        path_set: Set[int] = set()
+        cycles_found = 0
+        fixed_down_ids = down_seg_ids.copy()
+
+        for start_node_idx in range(len(seg_ids)):
+            if start_node_idx in visited:
+                continue
+
+            stack = [(start_node_idx, 0)]
+
+            while stack:
+                u, state = stack[-1]
+
+                if state == 0:
+                    visited.add(u)
+                    path_set.add(u)
+                    stack[-1] = (u, 1)
+
+                    v = adj.get(u, -1)
+                    if v != -1:
+                        if v in path_set:
+                            cycles_found += 1
+                            cycle_indices = []
+                            for node, _ in reversed(stack):
+                                cycle_indices.append(node)
+                                if node == v:
+                                    break
+
+                            min_elev = float('inf')
+                            sink_idx = -1
+                            for idx in cycle_indices:
+                                if elevations[idx] < min_elev:
+                                    min_elev = elevations[idx]
+                                    sink_idx = idx
+
+                            fixed_down_ids[sink_idx] = 0
+                            adj[sink_idx] = -1
+                        elif v not in visited:
+                            stack.append((v, 0))
+                else:
+                    path_set.remove(u)
+                    stack.pop()
+
+        if cycles_found > 0:
+            logger.warning(f"Detected and fixed {cycles_found} cycles in routing topology.")
+        else:
+            logger.info("No cycles detected in routing topology.")
+
+        return fixed_down_ids
+
+    # =========================================================================
+    # Topological sort
+    # =========================================================================
+
+    @staticmethod
+    def topological_sort(seg_ids: np.ndarray, down_seg_ids: np.ndarray) -> List[int]:
+        """
+        Topological sort of segment indices (Kahn's algorithm).
+
+        Returns indices in headwater-first (upstream-to-downstream) order.
+        """
+        n = len(seg_ids)
+        id_to_idx = {sid: i for i, sid in enumerate(seg_ids)}
+
+        in_degree = np.zeros(n, dtype=int)
+        children: dict = {i: [] for i in range(n)}
+
+        for i, down_sid in enumerate(down_seg_ids):
+            if down_sid in id_to_idx:
+                downstream_idx = id_to_idx[down_sid]
+                in_degree[downstream_idx] += 1
+                children[i].append(downstream_idx)
+
+        queue = [i for i in range(n) if in_degree[i] == 0]
+        order = []
+
+        while queue:
+            node = queue.pop(0)
+            order.append(node)
+            for child in children[node]:
+                in_degree[child] -= 1
+                if in_degree[child] == 0:
+                    queue.append(child)
+
+        # Append any remaining nodes (disconnected/cyclic) at end
+        if len(order) < n:
+            remaining = [i for i in range(n) if i not in set(order)]
+            order.extend(remaining)
+
+        return order
+
+    # =========================================================================
+    # Validation and enforcement
+    # =========================================================================
+
+    def _enforce_minimum_values(self, shp_river: 'gpd.GeoDataFrame') -> None:
+        """Ensure minimum values for length and slope."""
+        length_col = self.pp.river_length_col
+        if length_col in shp_river.columns:
+            shp_river[length_col] = shp_river[length_col].fillna(0)
+            shp_river.loc[shp_river[length_col] == 0, length_col] = 1
+
+        slope_col = self.pp.river_slope_col
+        if slope_col in shp_river.columns:
+            shp_river[slope_col] = shp_river[slope_col].fillna(0.001)
+            shp_river.loc[shp_river[slope_col] == 0, slope_col] = 0.001
+
+    def _enforce_outlets(self, shp_river: 'gpd.GeoDataFrame') -> None:
+        """Force configured segments to be outlets (downSegId = 0)."""
+        make_outlet = self.pp._get_config_value(
+            lambda: self.pp.config.model.mizuroute.make_outlet,  # type: ignore[attr-defined]
+            default='n/a',
+            dict_key='SETTINGS_MIZU_MAKE_OUTLET',
+        )
+        if not make_outlet or make_outlet == 'n/a':
+            return
+
+        seg_id_col = self.pp.river_segid_col
+        downseg_id_col = self.pp.river_downsegid_col
+
+        for outlet_id in [int(x) for x in make_outlet.split(',')]:
+            if outlet_id in shp_river[seg_id_col].values:
+                shp_river.loc[shp_river[seg_id_col] == outlet_id, downseg_id_col] = 0
+            else:
+                self.pp.logger.warning(f"Outlet ID {outlet_id} not found in river network")
+
+    def _validate_downstream_refs(self, shp_river: 'gpd.GeoDataFrame') -> None:
+        """Fix invalid downstream segment references in a GeoDataFrame."""
+        seg_id_col = self.pp.river_segid_col
+        downseg_id_col = self.pp.river_downsegid_col
+        valid_seg_ids = set(shp_river[seg_id_col].values.astype(int))
+
+        invalid_refs = []
+        for idx, row in shp_river.iterrows():
+            seg_id = int(row[seg_id_col])
+            down_seg_id = int(row[downseg_id_col])
+            if down_seg_id not in valid_seg_ids and down_seg_id != -9999 and down_seg_id != 0:
+                invalid_refs.append((seg_id, down_seg_id))
+                shp_river.loc[idx, downseg_id_col] = 0
+
+        if invalid_refs:
+            self.pp.logger.warning(f"Fixed {len(invalid_refs)} invalid downstream segment references")
+
+    def _validate_downstream_refs_arrays(
+        self, seg_ids: np.ndarray, down_seg_ids: np.ndarray
+    ) -> None:
+        """Fix invalid downstream refs in numpy arrays (modifies in place)."""
+        valid_seg_ids = set(seg_ids)
+        invalid_count = 0
+        for i, down_seg_id in enumerate(down_seg_ids):
+            if down_seg_id not in valid_seg_ids and down_seg_id != -9999 and down_seg_id != 0:
+                invalid_count += 1
+                down_seg_ids[i] = 0
+        if invalid_count > 0:
+            self.pp.logger.warning(f"Fixed {invalid_count} invalid downstream segment references")
+
+    def _validate_hru_to_seg_refs(
+        self,
+        hru_ids: np.ndarray,
+        hru_to_seg_ids: np.ndarray,
+        shp_river: 'gpd.GeoDataFrame',
+    ) -> np.ndarray:
+        """Fix invalid HRU-to-segment references."""
+        valid_seg_ids = set(shp_river[self.pp.river_segid_col].values.astype(int))
+        fixed = hru_to_seg_ids.copy()
+
+        for i, hru_to_seg in enumerate(fixed):
+            if hru_to_seg not in valid_seg_ids:
+                closest_seg = min(valid_seg_ids, key=lambda x: abs(x - hru_to_seg))
+                fixed[i] = closest_seg
+                self.pp.logger.warning(
+                    f"HRU {hru_ids[i]} had invalid segment ref {hru_to_seg} -> set to {closest_seg}"
+                )
+
+        return fixed

--- a/src/symfluence/models/utilities/base_topology_generator.py
+++ b/src/symfluence/models/utilities/base_topology_generator.py
@@ -223,12 +223,15 @@ class BaseTopologyGenerator(ABC):
             routing_suffix='delineate'
         )
 
-        catchment_path = (
-            self.pp.project_dir / 'shapefiles' / 'catchment'
-            / f"{self.pp.domain_name}_catchment_delineated.shp"
-        )
+        catchment_filename = f"{self.pp.domain_name}_catchment_delineated.shp"
+        catchment_path = self.pp.project_dir / 'shapefiles' / 'catchment' / catchment_filename
         if not catchment_path.exists():
-            raise FileNotFoundError(f"Delineated catchment shapefile not found: {catchment_path}")
+            # Search subdirectories (discretization may place it in catchment/{method}/{experiment}/)
+            candidates = list((self.pp.project_dir / 'shapefiles' / 'catchment').rglob(catchment_filename))
+            if candidates:
+                catchment_path = candidates[0]
+            else:
+                raise FileNotFoundError(f"Delineated catchment shapefile not found: {catchment_path}")
 
         shp_catchments = gpd.read_file(catchment_path)
         self.pp.logger.info(f"Loaded {len(shp_catchments)} delineated subcatchments")

--- a/src/symfluence/models/utilities/runoff_loader.py
+++ b/src/symfluence/models/utilities/runoff_loader.py
@@ -1,0 +1,387 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""
+Shared runoff loading utilities for routing models.
+
+Provides model-specific runoff file resolution, variable detection,
+and time precision fixing used by mizuRoute, tRoute, and dRoute.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ModelRunoffConfig:
+    """Configuration for model-specific runoff settings."""
+
+    output_dir_key: str
+    output_dir_name: str
+    default_var: str
+    default_units: str
+    default_dt: str
+    output_file_pattern: str
+    hru_dim: str = 'gru'
+    hru_var: str = 'gruId'
+    comment_name: str = 'model'
+
+
+MODEL_CONFIGS: Dict[str, ModelRunoffConfig] = {
+    'summa': ModelRunoffConfig(
+        output_dir_key='EXPERIMENT_OUTPUT_SUMMA',
+        output_dir_name='SUMMA',
+        default_var='averageRoutedRunoff',
+        default_units='m/s',
+        default_dt='3600',
+        output_file_pattern='{experiment_id}_timestep.nc',
+        hru_dim='hru',
+        hru_var='hruId',
+        comment_name='SUMMA',
+    ),
+    'fuse': ModelRunoffConfig(
+        output_dir_key='EXPERIMENT_OUTPUT_FUSE',
+        output_dir_name='FUSE',
+        default_var='q_routed',
+        default_units='m/s',
+        default_dt='86400',
+        output_file_pattern='{domain_name}_{experiment_id}_runs_def.nc',
+        hru_dim='gru',
+        hru_var='gruId',
+        comment_name='FUSE',
+    ),
+    'gr': ModelRunoffConfig(
+        output_dir_key='EXPERIMENT_OUTPUT_GR',
+        output_dir_name='GR',
+        default_var='q_routed',
+        default_units='m/s',
+        default_dt='86400',
+        output_file_pattern='{domain_name}_{experiment_id}_runs_def.nc',
+        hru_dim='gru',
+        hru_var='gruId',
+        comment_name='GR4J',
+    ),
+    'hype': ModelRunoffConfig(
+        output_dir_key='EXPERIMENT_OUTPUT_HYPE',
+        output_dir_name='HYPE',
+        default_var='cout',
+        default_units='m3/s',
+        default_dt='86400',
+        output_file_pattern='{experiment_id}_timestep.nc',
+        hru_dim='gru',
+        hru_var='gruId',
+        comment_name='HYPE',
+    ),
+    'ngen': ModelRunoffConfig(
+        output_dir_key='EXPERIMENT_OUTPUT_NGEN',
+        output_dir_name='NGEN',
+        default_var='runoff',
+        default_units='m/s',
+        default_dt='3600',
+        output_file_pattern='{experiment_id}_runoff.nc',
+        hru_dim='hru',
+        hru_var='hruId',
+        comment_name='NGEN',
+    ),
+}
+
+
+def get_model_config(source_model: str) -> ModelRunoffConfig:
+    """Get the runoff configuration for a source model."""
+    key = source_model.strip().upper()
+    # Normalize common variants
+    if key in ('GR4J', 'GR5J', 'GR6J'):
+        key = 'GR'
+    return MODEL_CONFIGS.get(key.lower(), MODEL_CONFIGS['summa'])
+
+
+def resolve_runoff_file(
+    source_model: str,
+    project_dir: Path,
+    experiment_id: str,
+    domain_name: str = '',
+    config: Any = None,
+) -> Optional[Path]:
+    """
+    Resolve the runoff output file path for a given source model.
+
+    Handles FUSE's 6-char file ID truncation and model-specific
+    output directory overrides from config.
+    """
+    model_cfg = get_model_config(source_model)
+    model_key = source_model.strip().upper()
+
+    # Resolve output directory
+    output_dir: Optional[Path] = None
+    if config is not None:
+        try:
+            config_dir_map = {
+                'SUMMA': lambda: config.model.summa.experiment_output,
+                'FUSE': lambda: config.model.fuse.experiment_output,
+                'GR': lambda: config.model.gr.experiment_output,
+                'HYPE': lambda: config.model.hype.experiment_output,
+                'NGEN': lambda: config.model.ngen.experiment_output,
+            }
+            getter = config_dir_map.get(model_key)
+            if getter:
+                configured = getter()
+                if configured and configured != 'default':
+                    output_dir = Path(configured)
+        except (AttributeError, TypeError):
+            pass
+
+    if output_dir is None:
+        output_dir = project_dir / f"simulations/{experiment_id}" / model_cfg.output_dir_name
+
+    # Resolve filename
+    file_id = experiment_id
+    if model_key == 'FUSE':
+        if config is not None:
+            try:
+                fuse_file_id = config.model.fuse.file_id
+                if fuse_file_id:
+                    file_id = fuse_file_id
+            except (AttributeError, TypeError):
+                pass
+        if len(file_id) > 6:
+            import hashlib
+            file_id = hashlib.md5(file_id.encode(), usedforsecurity=False).hexdigest()[:6]
+
+    filename = model_cfg.output_file_pattern.format(
+        experiment_id=file_id if model_key == 'FUSE' else experiment_id,
+        domain_name=domain_name,
+    )
+
+    runoff_path = output_dir / filename
+
+    if not runoff_path.exists():
+        # Fallback: find any .nc file in the directory
+        if output_dir.exists():
+            nc_files = [f for f in output_dir.glob("*.nc") if '_para_' not in f.name]
+            if nc_files:
+                logger.info(f"Using fallback output file: {nc_files[0]}")
+                return nc_files[0]
+        logger.warning(f"Runoff file not found: {runoff_path}")
+        return None
+
+    return runoff_path
+
+
+def detect_runoff_variable(ds: Any, source_model: str = 'SUMMA') -> Optional[str]:
+    """
+    Detect the runoff variable in a dataset based on source model.
+
+    Tries model-specific variable first, then falls through common names.
+    """
+    model_cfg = get_model_config(source_model)
+
+    # Model-specific variable first
+    candidates = [model_cfg.default_var]
+
+    # Common runoff variable names as fallback
+    common_vars = [
+        'averageRoutedRunoff', 'scalarTotalRunoff', 'q_routed',
+        'runoff', 'q_runoff', 'cout', 'streamflow',
+    ]
+    for v in common_vars:
+        if v not in candidates:
+            candidates.append(v)
+
+    for var in candidates:
+        if var in ds.data_vars:
+            return var
+
+    # Last resort: any variable with 'runoff' in name
+    for var in ds.data_vars:
+        if 'runoff' in str(var).lower():
+            return var
+
+    return None
+
+
+def fix_time_precision(
+    runoff_filepath: Path,
+    rounding_freq: str = 'h',
+) -> Optional[Path]:
+    """
+    Fix model output time precision by rounding to configurable frequency.
+
+    Detects time format (SUMMA seconds-since-1990, generic since, datetime64)
+    and applies appropriate rounding. Writes result to a temp file then
+    atomically replaces the original.
+
+    Args:
+        runoff_filepath: Path to the NetCDF runoff file
+        rounding_freq: Frequency to round to ('h', 'min', 'none' to disable)
+
+    Returns:
+        Path to the (fixed) runoff file, or None on failure.
+    """
+    if rounding_freq == 'none':
+        return runoff_filepath
+
+    import os
+
+    import pandas as pd
+    import xarray as xr
+
+    if not runoff_filepath.exists():
+        logger.error(f"Runoff file not found: {runoff_filepath}")
+        return None
+
+    if runoff_filepath.stat().st_size < 1000:
+        logger.error(f"Runoff file too small ({runoff_filepath.stat().st_size} bytes): {runoff_filepath}")
+        return None
+
+    try:
+        ds = xr.open_dataset(runoff_filepath, decode_times=False)
+    except (OSError, RuntimeError, ValueError) as nc_err:
+        logger.error(f"Failed to open runoff file: {runoff_filepath} - {nc_err}")
+        return None
+
+    time_attrs = ds.time.attrs
+    time_values = ds.time.values
+
+    if len(time_values) == 0:
+        ds.close()
+        logger.error(f"Empty time dimension in: {runoff_filepath}")
+        return None
+
+    needs_fix = False
+    time_format = None
+    time_unit = 's'
+
+    if 'units' in time_attrs:
+        units_str = time_attrs['units'].lower()
+
+        if 'since 1990-01-01' in units_str:
+            time_format = 'summa_seconds_1990'
+            first_time = pd.to_datetime(time_values[0], unit='s', origin='1990-01-01')
+            needs_fix = (first_time != first_time.round(rounding_freq))
+
+        elif 'since' in units_str:
+            since_match = re.search(r'since\s+([0-9-]+(?:\s+[0-9:]+)?)', units_str)
+            if since_match:
+                ref_time_str = since_match.group(1).strip()
+                time_format = f'generic_since_{ref_time_str}'
+
+                if 'second' in units_str:
+                    first_time = pd.to_datetime(time_values[0], unit='s', origin=ref_time_str)
+                    time_unit = 's'
+                elif 'hour' in units_str:
+                    first_time = pd.Timestamp(ref_time_str) + pd.Timedelta(hours=float(time_values[0]))
+                    time_unit = 'h'
+                elif 'day' in units_str:
+                    first_time = pd.to_datetime(time_values[0], unit='D', origin=ref_time_str)
+                    time_unit = 'D'
+                else:
+                    first_time = pd.to_datetime(time_values[0], unit='s', origin=ref_time_str)
+                    time_unit = 's'
+
+                needs_fix = (first_time != first_time.round(rounding_freq))
+        else:
+            time_format = _try_decode_datetime64(runoff_filepath, rounding_freq)
+            if time_format == 'datetime64':
+                needs_fix = True
+            else:
+                ds.close()
+                return runoff_filepath
+    else:
+        time_format = _try_decode_datetime64(runoff_filepath, rounding_freq)
+        if time_format != 'datetime64':
+            ds.close()
+            return runoff_filepath
+        needs_fix = True
+
+    if not needs_fix:
+        ds.close()
+        return runoff_filepath
+
+    # Apply fix based on format
+    if time_format == 'summa_seconds_1990':
+        time_stamps = pd.to_datetime(time_values, unit='s', origin='1990-01-01')
+        rounded_stamps = time_stamps.round(rounding_freq)
+        reference = pd.Timestamp('1990-01-01')
+        rounded_seconds = (rounded_stamps - reference).total_seconds().values
+
+        ds = ds.assign_coords(time=rounded_seconds)
+        ds.time.attrs.clear()
+        ds.time.attrs['units'] = 'seconds since 1990-01-01 00:00:00'
+        ds.time.attrs['calendar'] = 'standard'
+        ds.time.attrs['long_name'] = 'time'
+
+    elif time_format and time_format.startswith('generic_since_'):
+        ref_time_str = time_format.split('generic_since_')[1]
+        reference = pd.Timestamp(ref_time_str)
+
+        if time_unit == 's':
+            time_stamps = reference + pd.to_timedelta(time_values, unit='s')
+        elif time_unit == 'h':
+            time_stamps = reference + pd.to_timedelta(time_values, unit='h')
+        elif time_unit == 'D':
+            time_stamps = reference + pd.to_timedelta(time_values, unit='D')
+        else:
+            time_stamps = reference + pd.to_timedelta(time_values, unit='s')
+
+        rounded_stamps = time_stamps.round(rounding_freq)
+
+        if time_unit == 's':
+            rounded_values = (rounded_stamps - reference).total_seconds().values
+        elif time_unit == 'h':
+            rounded_values = (rounded_stamps - reference) / pd.Timedelta(hours=1)
+        elif time_unit == 'D':
+            rounded_values = (rounded_stamps - reference) / pd.Timedelta(days=1)
+        else:
+            rounded_values = (rounded_stamps - reference).total_seconds().values
+
+        ds = ds.assign_coords(time=rounded_values)
+        ds.time.attrs.clear()
+        _unit_names = {'s': 'seconds', 'h': 'hours', 'D': 'days'}
+        full_unit_name = _unit_names.get(time_unit, time_unit)
+        normalized_ref = reference.strftime('%Y-%m-%d %H:%M:%S')
+        ds.time.attrs['units'] = f"{full_unit_name} since {normalized_ref}"
+        ds.time.attrs['calendar'] = 'standard'
+        ds.time.attrs['long_name'] = 'time'
+
+    elif time_format == 'datetime64':
+        ds_decoded = xr.open_dataset(runoff_filepath, decode_times=True)
+        time_stamps = pd.to_datetime(ds_decoded.time.values)
+        rounded_stamps = time_stamps.round(rounding_freq)
+        ds = ds_decoded.assign_coords(time=rounded_stamps)
+        ds_decoded.close()
+
+    # Save atomically
+    ds.load()
+    temp_filepath = runoff_filepath.with_suffix('.tmp.nc')
+    ds.to_netcdf(temp_filepath, format='NETCDF4')
+    ds.close()
+
+    if os.name != 'nt':
+        os.chmod(temp_filepath, 0o664)  # nosec B103
+    temp_filepath.replace(runoff_filepath)
+
+    logger.info(f"Fixed time precision in {runoff_filepath}")
+    return runoff_filepath
+
+
+def _try_decode_datetime64(filepath: Path, rounding_freq: str) -> Optional[str]:
+    """Try to open file with decoded times to check if rounding needed."""
+    import pandas as pd
+    import xarray as xr
+
+    try:
+        ds_decoded = xr.open_dataset(filepath, decode_times=True)
+        first_time = pd.Timestamp(ds_decoded.time.values[0])
+        needs_fix = (first_time != first_time.round(rounding_freq))
+        ds_decoded.close()
+        if needs_fix:
+            return 'datetime64'
+        return None
+    except (ValueError, TypeError, KeyError):
+        return None

--- a/tools/quality/broad_exception_allowlist.txt
+++ b/tools/quality/broad_exception_allowlist.txt
@@ -1135,6 +1135,10 @@ src/symfluence/models/troute/plotter.py:TRoutePlotter._load_lateral_inflow:excep
 src/symfluence/models/troute/plotter.py:TRoutePlotter._load_observed_streamflow:except Exception:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/troute/plotter.py:TRoutePlotter.plot_routing_results:except Exception as e:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/troute/postprocessor.py:TRoutePostProcessor._extract_from_netcdf:except Exception as e:  # noqa: BLE001 — model execution resilience
+src/symfluence/models/troute/runner.py:TRouteRunner.run_troute:except Exception as e:  # noqa: BLE001
+src/symfluence/models/troute/topology_generator.py:TRouteTopologyGenerator._enrich_with_shapefile_data:except Exception:  # noqa: BLE001
+src/symfluence/models/troute/topology_generator.py:TRouteTopologyGenerator.write_topology_with_shapefiles:except Exception:  # noqa: BLE001
+src/symfluence/models/utilities/base_topology_generator.py:BaseTopologyGenerator._find_closest_segment_to_pour_point:except Exception as e:  # noqa: BLE001
 src/symfluence/models/utilities/forcing_data_processor.py:ForcingDataProcessor.load_forcing_data:except Exception as e:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/vic/calibration/parameter_manager.py:VICParameterManager.copy_params_to_worker_dir:except Exception as e:  # noqa: BLE001 — calibration resilience
 src/symfluence/models/vic/calibration/parameter_manager.py:VICParameterManager.get_initial_parameters:except Exception as e:  # noqa: BLE001 — calibration resilience


### PR DESCRIPTION
## Summary

- **Shared base infrastructure** for all routing models: `BaseTopologyGenerator` (cycle fix, headwater detection, all domain types), `BaseRemapGenerator` (area-weighted, equal-weight, EASYMORE), `runoff_loader` (MODEL_CONFIGS for SUMMA/FUSE/GR/HYPE/NGEN, `resolve_runoff_file()`, `detect_runoff_variable()`, `fix_time_precision()`)
- **tRoute adapter upgraded to mizuRoute parity**: 5 bug fixes (variable mismatch, destructive file overwrite, mizuRoute config reference, hardcoded SUMMA path, calibration variable search) + multi-model support, standalone topology generation, nwm_routing → built-in MC fallback
- **dRoute companion changes** pushed separately to [symfluence-org/dRoute](https://github.com/symfluence-org/dRoute): C++ bindings API fix (junction wiring), standalone topology from shapefiles, multi-model runoff, numpy fallback routing

## Verification

All three routing models run end-to-end on Bow at Banff distributed (29 segments, 70,127 hourly timesteps, SUMMA input):

| Model | Mean (m³/s) | Max (m³/s) | r vs mizu | Bias |
|-------|------------|-----------|-----------|------|
| mizuRoute (IRF) | 53.64 | 25,103 | ref | ref |
| tRoute (MC) | 35.86 | 7,603 | 0.824 | 0.67 |
| dRoute (MC/C++) | 35.97 | 8,013 | 0.845 | 0.67 |
| tRoute ↔ dRoute | — | — | 0.987 | 1.00 |

MC vs IRF bias (0.67) is expected — Muskingum-Cunge attenuates peaks more than Impulse Response Function. tRoute and dRoute MC implementations agree almost perfectly (r=0.987).

## Test plan

- [x] `python -m pytest tests/unit/ -x -q` — 5691 passed
- [x] `ruff check src/symfluence/models/utilities/ src/symfluence/models/troute/` — clean
- [x] Bow distributed SUMMA → tRoute end-to-end
- [x] Bow distributed SUMMA → dRoute end-to-end (separate repo)
- [x] Lumped-to-distributed domain test
- [ ] Phase 2: refactor mizuRoute to subclass base classes (separate PR)

> Repo and code assistance from [Claude](https://claude.ai) (Anthropic).