### PR TITLE
fix(summa): default vegeParTbl to MODIFIED_IGBP_MODIS_NOAH (match IGBP land classes)

### DIFF
--- a/src/symfluence/resources/base_settings/SUMMA/modelDecisions.txt
+++ b/src/symfluence/resources/base_settings/SUMMA/modelDecisions.txt
@@ -9,7 +9,7 @@
 ! ***********************************************************************************************************************
 ! ***********************************************************************************************************************
 soilCatTbl                      ROSETTA         ! (03) soil-category dataset
-vegeParTbl                      USGS            ! (04) vegetation category dataset
+vegeParTbl                      MODIFIED_IGBP_MODIS_NOAH ! (04) vegetation category dataset (matches the IGBP land-class indices written by attributes_manager.insert_land_class)
 soilStress                      NoahType        ! (05) choice of function for the soil moisture control on stomatal resistance
 stomResist                      BallBerry       ! (06) choice of function for stomatal resistance
 ! ***********************************************************************************************************************


### PR DESCRIPTION
## Problem

The base `resources/base_settings/SUMMA/modelDecisions.txt` hardcodes:

```
vegeParTbl                      USGS            ! (04) vegetation category dataset
```

But the attribute pipeline (`models/summa/attributes_manager.py::insert_land_class`) reads the **IGBP** zonal histogram (`IGBP_1..IGBP_17`) and writes the modal IGBP class index **directly** as `vegTypeIndex`. IGBP and USGS category indices do not align, so SUMMA interprets every HRU's vegetation type through the wrong legend unless a config explicitly overrides `vegeParTbl`.

Every shipped test/example config already sets `vegeParTbl: MODIFIED_IGBP_MODIS_NOAH` — i.e. they were all silently working around this bad default. Any domain that does **not** set it inherits the mismatch.

### Symptoms
- **Hard failure at index 16:** IGBP 16 = *Barren/Sparsely Vegetated*, but USGS 16 = *Water Bodies*. A barren/alpine HRU is read as open water, so SUMMA skips the land-surface water balance and writes the `-9999` missing sentinel for `averageRoutedRunoff` (constant across all timesteps; `-19998` after basin routing).
- **Silent mistyping elsewhere:** e.g. IGBP 1 (Evergreen Needleleaf) → USGS 1 (Urban & Built-up), degrading results without an obvious error.

### Discovered on
A Bow-at-Calgary domain: HRU `gruId 2` (alpine, 2332 m, modal class IGBP 16 = Barren at 36%, IGBP water only 6%) produced all-`-9999` routed runoff. Correcting `vegeParTbl` resolved it and fixed the broader mistyping.

## Fix

One line — set the default to match the IGBP indices the pipeline produces:

```
vegeParTbl                      MODIFIED_IGBP_MODIS_NOAH ! (04) vegetation category dataset (matches the IGBP land-class indices written by attributes_manager.insert_land_class)
```

`TBL_VEGPARM.TBL` already contains the `MODIFIED_IGBP_MODIS_NOAH` section (index 17 = Water, 16 = Barren), so the existing water-class handling (`tmp_lc == 17`) becomes correct under the right table.

## Safety
- `396 passed, 15 skipped` (skips are unrelated missing optional deps). **No test asserts the `USGS` default.**
- The only config that explicitly wants USGS (`examples/.../config_durance_france_summa_calibration.yaml`) sets it explicitly and is unaffected by a default change.
- This is a correctness fix: domains that relied on the old default were producing wrong/failed veg types; results will change for the better.

Assisted-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)