### PR TITLE
feat(attributes): pluggable attribute processors + climaclass climate classification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,14 @@ baseflow = [
 r = [
   "rpy2>=3.5.0,<4.0.0",
 ]
+# Climate classification attributes (Koppen-Geiger, Holdridge, Thornthwaite).
+# Pulls the standalone `climaclass` package from PyPI; its bundled SYMFLUENCE
+# attribute-processor plugin is discovered automatically via the
+# `symfluence.attribute_processors` entry point during acquire_attributes.
+# Install via: uv pip install "symfluence[climate-classification]"
+climate-classification = [
+  "climaclass[symfluence]>=0.1.0",
+]
 # Development tools
 dev = [
   "ruff>=0.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ r = [
 # `symfluence.attribute_processors` entry point during acquire_attributes.
 # Install via: uv pip install "symfluence[climate-classification]"
 climate-classification = [
-  "climaclass[symfluence]>=0.1.0",
+  "climaclass[symfluence]>=0.2.0",
 ]
 # Development tools
 dev = [

--- a/src/symfluence/data/preprocessing/attribute_processor.py
+++ b/src/symfluence/data/preprocessing/attribute_processor.py
@@ -96,6 +96,53 @@ class attributeProcessor(ConfigMixin):
             current_results = {}
         return self.hydrology.enhance_river_network_analysis(current_results)
 
+    def _process_plugin_attributes(self) -> Dict[str, Any]:
+        """Run attribute processors contributed by external packages.
+
+        Plugins advertise themselves under the ``symfluence.attribute_processors``
+        entry-point group and run automatically during ``acquire_attributes``.
+        Control via config:
+
+        * ``ATTRIBUTE_PLUGINS_ENABLED`` (bool, default ``True``) - master switch.
+        * ``ATTRIBUTE_PLUGINS_EXCLUDE`` (list[str], default ``[]``) - plugin
+          names to skip.
+
+        A plugin that errors is logged and skipped; it never aborts the run.
+        """
+        results: Dict[str, Any] = {}
+
+        enabled = self._get_config_value(
+            lambda: self.config.attributes.plugins_enabled,
+            default=True,
+            dict_key='ATTRIBUTE_PLUGINS_ENABLED',
+        )
+        if not enabled:
+            return results
+
+        from .attribute_processors.plugins import discover_attribute_plugins
+
+        exclude = self._get_config_value(
+            lambda: self.config.attributes.plugins_exclude,
+            default=[],
+            dict_key='ATTRIBUTE_PLUGINS_EXCLUDE',
+        ) or []
+        exclude = set(exclude)
+
+        for name, cls in discover_attribute_plugins(self.logger):
+            if name in exclude:
+                self.logger.info(f"Skipping excluded attribute plugin '{name}'")
+                continue
+            try:
+                self.logger.info(f"Processing attributes from plugin '{name}'")
+                plugin_results = cls(self._config, self.logger).process()
+                if plugin_results:
+                    results.update(plugin_results)
+                    self.logger.info(f"Plugin '{name}' contributed {len(plugin_results)} attributes")
+            except Exception as e:  # noqa: BLE001 — a plugin must not break attribute processing
+                self.logger.warning(f"Attribute plugin '{name}' failed and was skipped: {e}")
+
+        return results
+
     # Main processing method
     def process_attributes(self) -> pd.DataFrame:
         """
@@ -141,6 +188,11 @@ class attributeProcessor(ConfigMixin):
             self.logger.info("Processing hydrological attributes")
             hydrology_results = self.hydrology.process()
             all_results.update(hydrology_results)
+
+            # Process externally-registered attribute plugins (e.g. climaclass
+            # climate classification). Discovered via entry points; opt-out only.
+            plugin_results = self._process_plugin_attributes()
+            all_results.update(plugin_results)
 
             # Convert to DataFrame
             if all_results:

--- a/src/symfluence/data/preprocessing/attribute_processors/plugins.py
+++ b/src/symfluence/data/preprocessing/attribute_processors/plugins.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Discovery of externally-registered attribute processors.
+
+Third-party packages can contribute attribute processors without modifying
+SYMFLUENCE by advertising them under the ``symfluence.attribute_processors``
+entry-point group, e.g. in their ``pyproject.toml``::
+
+    [project.entry-points."symfluence.attribute_processors"]
+    climate_classification = "climaclass.integrations.symfluence:ClimateClassificationProcessor"
+
+Each entry point must resolve to a subclass of
+:class:`~symfluence.data.preprocessing.attribute_processors.base.BaseAttributeProcessor`
+(constructed with ``(config, logger)`` and exposing ``.process() -> dict``).
+
+Discovered plugins run automatically during the ``acquire_attributes`` step
+unless disabled via config (see
+:func:`symfluence.data.preprocessing.attribute_processor.attributeProcessor._process_plugin_attributes`).
+"""
+
+from __future__ import annotations
+
+import logging
+from importlib import metadata
+from typing import List, Tuple, Type
+
+from .base import BaseAttributeProcessor
+
+ENTRY_POINT_GROUP = "symfluence.attribute_processors"
+
+
+def discover_attribute_plugins(
+    logger: logging.Logger | None = None,
+) -> List[Tuple[str, Type[BaseAttributeProcessor]]]:
+    """Return ``(name, processor_class)`` for every registered plugin.
+
+    Failures to load an individual entry point are logged and skipped so a
+    broken third-party package never breaks attribute processing.
+    """
+    plugins: List[Tuple[str, Type[BaseAttributeProcessor]]] = []
+
+    try:
+        entry_points = metadata.entry_points(group=ENTRY_POINT_GROUP)
+    except TypeError:  # pragma: no cover - Python < 3.10 selection API
+        entry_points = metadata.entry_points().get(ENTRY_POINT_GROUP, [])  # type: ignore[attr-defined]
+
+    for ep in entry_points:
+        try:
+            cls = ep.load()
+        except Exception as exc:  # noqa: BLE001 - a bad plugin must not break the run
+            if logger:
+                logger.warning(f"Could not load attribute plugin '{ep.name}': {exc}")
+            continue
+
+        if not (isinstance(cls, type) and issubclass(cls, BaseAttributeProcessor)):
+            if logger:
+                logger.warning(
+                    f"Attribute plugin '{ep.name}' does not subclass BaseAttributeProcessor; skipping"
+                )
+            continue
+
+        plugins.append((ep.name, cls))
+
+    return plugins

--- a/tests/unit/preprocessing/attribute_processing/test_plugins.py
+++ b/tests/unit/preprocessing/attribute_processing/test_plugins.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Unit tests for external attribute-processor plugin discovery and dispatch."""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from symfluence.data.preprocessing.attribute_processor import attributeProcessor
+from symfluence.data.preprocessing.attribute_processors import plugins
+from symfluence.data.preprocessing.attribute_processors.base import BaseAttributeProcessor
+
+pytestmark = [pytest.mark.unit, pytest.mark.quick]
+
+
+class _GoodPlugin(BaseAttributeProcessor):
+    """A valid plugin that bypasses the heavy base __init__ for testing."""
+
+    def __init__(self, config, logger):  # noqa: D107
+        self.config = config
+        self.logger = logger
+
+    def process(self):
+        return {"climate.koppen_code": "Csb", "climate.holdridge_zone": "Boreal wet forest"}
+
+
+class _BrokenPlugin(BaseAttributeProcessor):
+    def __init__(self, config, logger):  # noqa: D107
+        self.config = config
+        self.logger = logger
+
+    def process(self):
+        raise RuntimeError("boom")
+
+
+class _NotAProcessor:
+    """Does not subclass BaseAttributeProcessor; must be rejected by discovery."""
+
+
+def _fake_ep(name, obj, raises=False):
+    ep = MagicMock()
+    ep.name = name
+    ep.load.side_effect = RuntimeError("load failed") if raises else None
+    if not raises:
+        ep.load.return_value = obj
+    return ep
+
+
+# --- discover_attribute_plugins ---------------------------------------------
+
+def test_discovery_keeps_only_valid_subclasses():
+    eps = [
+        _fake_ep("good", _GoodPlugin),
+        _fake_ep("not_a_processor", _NotAProcessor),
+        _fake_ep("explodes", None, raises=True),
+    ]
+    with patch.object(plugins.metadata, "entry_points", return_value=eps):
+        found = plugins.discover_attribute_plugins(logging.getLogger("t"))
+    assert [n for n, _ in found] == ["good"]
+    assert found[0][1] is _GoodPlugin
+
+
+# --- attributeProcessor._process_plugin_attributes --------------------------
+
+def _stub_processor(enabled=True, exclude=None):
+    """Minimal duck-typed host exposing just what the method touches."""
+    stub = MagicMock(spec=attributeProcessor)
+    stub.logger = logging.getLogger("t")
+    stub._config = {}
+
+    def _cfg(accessor, default=None, dict_key=None):
+        if dict_key == "ATTRIBUTE_PLUGINS_ENABLED":
+            return enabled
+        if dict_key == "ATTRIBUTE_PLUGINS_EXCLUDE":
+            return exclude if exclude is not None else []
+        return default
+
+    stub._get_config_value.side_effect = _cfg
+    # Bind the real method under test to the stub.
+    stub._process_plugin_attributes = attributeProcessor._process_plugin_attributes.__get__(stub)
+    return stub
+
+
+def test_plugins_aggregate_results():
+    stub = _stub_processor()
+    with patch.object(plugins, "discover_attribute_plugins", return_value=[("good", _GoodPlugin)]):
+        out = stub._process_plugin_attributes()
+    assert out["climate.koppen_code"] == "Csb"
+
+
+def test_plugins_disabled_returns_empty():
+    stub = _stub_processor(enabled=False)
+    with patch.object(plugins, "discover_attribute_plugins", return_value=[("good", _GoodPlugin)]) as disc:
+        out = stub._process_plugin_attributes()
+    assert out == {}
+    disc.assert_not_called()  # short-circuits before discovery
+
+
+def test_plugins_exclude_by_name():
+    stub = _stub_processor(exclude=["good"])
+    with patch.object(plugins, "discover_attribute_plugins", return_value=[("good", _GoodPlugin)]):
+        out = stub._process_plugin_attributes()
+    assert out == {}
+
+
+def test_plugin_failure_is_swallowed():
+    stub = _stub_processor()
+    order = [("broken", _BrokenPlugin), ("good", _GoodPlugin)]
+    with patch.object(plugins, "discover_attribute_plugins", return_value=order):
+        out = stub._process_plugin_attributes()
+    # Broken plugin is skipped; the good one's attributes still land.
+    assert out == {"climate.koppen_code": "Csb", "climate.holdridge_zone": "Boreal wet forest"}

--- a/tools/quality/broad_exception_allowlist.txt
+++ b/tools/quality/broad_exception_allowlist.txt
@@ -317,6 +317,7 @@ src/symfluence/data/observation/handlers/ssebop.py:SSEBopHandler._process_netcdf
 src/symfluence/data/observation/handlers/viirs_snow.py:VIIRSSnowHandler.acquire:except Exception as e:  # noqa: BLE001 — wrap-and-raise to domain error
 src/symfluence/data/observation/handlers/viirs_snow.py:VIIRSSnowHandler.get_processed_data:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/observation/handlers/viirs_snow.py:VIIRSSnowHandler.process:except Exception as e:  # noqa: BLE001 — preprocessing resilience
+src/symfluence/data/preprocessing/attribute_processor.py:attributeProcessor._process_plugin_attributes:except Exception as e:  # noqa: BLE001 — a plugin must not break attribute processing
 src/symfluence/data/preprocessing/attribute_processor.py:attributeProcessor.process_attributes:except Exception as e:  # noqa: BLE001 — wrap-and-raise to domain error
 src/symfluence/data/preprocessing/attribute_processor.py:attributeProcessor.process_profile_attributes:except Exception as e:  # noqa: BLE001
 src/symfluence/data/preprocessing/attribute_processors/elevation.py:ElevationProcessor.generate_slope_and_aspect:except Exception as e:  # noqa: BLE001 — wrap-and-raise to domain error
@@ -325,6 +326,7 @@ src/symfluence/data/preprocessing/attribute_processors/hydrology.py:HydrologyPro
 src/symfluence/data/preprocessing/attribute_processors/hydrology.py:HydrologyProcessor.calculate_streamflow_signatures:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/preprocessing/attribute_processors/hydrology.py:HydrologyProcessor.calculate_water_balance:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/preprocessing/attribute_processors/landcover.py:LandCoverProcessor._process_lai_from_netcdf:except Exception as e:  # noqa: BLE001
+src/symfluence/data/preprocessing/attribute_processors/plugins.py:discover_attribute_plugins:except Exception as exc:  # noqa: BLE001 - a bad plugin must not break the run
 src/symfluence/data/preprocessing/attribute_processors/soil.py:SoilProcessor._check_and_set_nodata_value:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/preprocessing/attribute_processors/soil.py:SoilProcessor._read_scale_and_offset:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/preprocessing/dataset_alignment_manager.py:DatasetAlignmentManager._align_single_dataset:except Exception as e:  # noqa: BLE001 — preprocessing resilience


### PR DESCRIPTION
## Summary

Adds an **entry-point plugin mechanism** for attribute processors and wires in
the new standalone [`climaclass`](https://github.com/DarriEy/climaclass) package
(Köppen–Geiger / Holdridge / Thornthwaite climate classification) as an optional,
pip-installed plugin — no Earth Engine, no bundled algorithm code.

## What's included

**1. Plugin discovery (`attribute_processors/plugins.py`)**
- Discovers any `BaseAttributeProcessor` subclass registered under the
  `symfluence.attribute_processors` entry-point group.
- Validates the subclass contract; isolates per-plugin load failures.

**2. Orchestrator hook (`attribute_processor.py`)**
- `process_attributes()` runs discovered plugins after the built-in processors.
- Gated by config: `ATTRIBUTE_PLUGINS_ENABLED` (default `True`) and
  `ATTRIBUTE_PLUGINS_EXCLUDE` (default `[]`).
- A failing plugin is logged and skipped — it never aborts attribute processing.

**3. Packaging (`pyproject.toml`)**
- New extra: `pip install "symfluence[climate-classification]"` pulls
  `climaclass[symfluence]` from PyPI. Its bundled processor is then discovered
  automatically — users get `climate.koppen_code`, `climate.holdridge_zone`,
  `climate.thornthwaite_code`, etc. computed from the WorldClim rasters
  SYMFLUENCE already acquires.

## Why

Lets third parties contribute catchment attributes without touching SYMFLUENCE
source, and gives a clean, reviewer-friendly climate-classification attribute
useful as a regionalization / PUB grouping variable.

## Tests

- New `tests/unit/preprocessing/attribute_processing/test_plugins.py` (5 tests):
  discovery filtering, disabled gate, exclude-by-name, aggregation, failure isolation.
- Full attribute-processing unit suite green (50 passed, 2 skipped); ruff clean.

---
Repo and code assistance from [Claude](https://claude.ai) (Anthropic).