### PR TITLE
fix(geofabric): mask ocean before polygonization — eliminate coastal tentacle basins

### DIFF
--- a/src/symfluence/geospatial/geofabric/delineators/coastal_delineator.py
+++ b/src/symfluence/geospatial/geofabric/delineators/coastal_delineator.py
@@ -116,14 +116,22 @@ class CoastalWatershedDelineator(BaseGeofabricDelineator):
 
             # ---------- STEP 2: DIVIDE COASTAL STRIP INTO INDIVIDUAL WATERSHEDS ---------- #
 
+            # All geometric division (Voronoi, buffers, overlays) is done in a
+            # projected CRS (metres). In geographic degrees these operations shed
+            # thin sliver/tentacle polygons, especially at high latitude where a
+            # degree of longitude and latitude differ greatly.
+            utm_crs = river_basins.estimate_utm_crs()
+            coastal_strip = coastal_strip.to_crs(utm_crs)
+            river_basins_proj = river_basins.to_crs(utm_crs)
+
             # First, create Voronoi polygons for each river basin
             try:
-                # Get centroids of each river basin
-                river_basins_centroids = river_basins.copy()
-                river_basins_centroids.geometry = river_basins.geometry.centroid
+                # Get centroids of each river basin (in projected CRS)
+                river_basins_centroids = river_basins_proj.copy()
+                river_basins_centroids.geometry = river_basins_proj.geometry.centroid
 
-                # Buffer centroids to avoid potential issues with geopandas Voronoi
-                river_basins_centroids.geometry = river_basins_centroids.geometry.buffer(0.000001)
+                # Buffer centroids slightly (1 m) to avoid geopandas Voronoi issues
+                river_basins_centroids.geometry = river_basins_centroids.geometry.buffer(1.0)
 
                 # Create Voronoi polygons
                 voronoi_gdf = self._create_voronoi_tessellation(river_basins_centroids)
@@ -131,18 +139,18 @@ class CoastalWatershedDelineator(BaseGeofabricDelineator):
                 if voronoi_gdf is None or voronoi_gdf.empty:
                     self.logger.warning("Failed to create Voronoi tessellation. Using alternative approach.")
                     # Use watershed boundaries to create extended lines to the coast
-                    coastal_watersheds = self._divide_coastal_strip_by_extending_boundaries(coastal_strip, river_basins)
+                    coastal_watersheds = self._divide_coastal_strip_by_extending_boundaries(coastal_strip, river_basins_proj)
                 else:
                     # Intersect Voronoi polygons with coastal strip to create coastal watersheds
                     voronoi_gdf = gpd.GeoDataFrame(
                         geometry=voronoi_gdf.geometry,
-                        crs=river_basins.crs
+                        crs=utm_crs
                     )
                     coastal_watersheds = gpd.overlay(coastal_strip, voronoi_gdf, how='intersection')
             except Exception as e:  # noqa: BLE001 — preprocessing resilience
                 self.logger.error(f"Error dividing coastal strip: {str(e)}")
                 # Fallback to simpler approach: use a buffer method
-                coastal_watersheds = self._divide_coastal_strip_by_buffer_method(coastal_strip, river_basins)
+                coastal_watersheds = self._divide_coastal_strip_by_buffer_method(coastal_strip, river_basins_proj)
 
             # If we still don't have valid coastal watersheds, use a simpler approach
             if coastal_watersheds is None or coastal_watersheds.empty:
@@ -434,8 +442,8 @@ class CoastalWatershedDelineator(BaseGeofabricDelineator):
             # Create a convex hull around the points to limit Voronoi extent
             convex_hull = points_gdf.unary_union.convex_hull
 
-            # Use a large buffer around the convex hull
-            buffer_distance = 0.1  # ~10km in decimal degrees
+            # Use a large buffer around the convex hull (projected CRS, metres)
+            buffer_distance = 10000.0  # ~10 km
             extended_hull = shapely.geometry.Polygon(convex_hull).buffer(buffer_distance)
 
             # Clip Voronoi polygons to the extended hull
@@ -487,7 +495,7 @@ class CoastalWatershedDelineator(BaseGeofabricDelineator):
 
             # Create a convex hull around all basins and extend it outward
             convex_hull = river_basins.unary_union.convex_hull
-            ext_distance = 0.1  # ~10km in decimal degrees
+            ext_distance = 10000.0  # ~10 km (projected CRS, metres)
             shapely.geometry.Polygon(convex_hull).buffer(ext_distance)
 
             # Use a buffer-based approach to divide the coastal strip
@@ -496,8 +504,8 @@ class CoastalWatershedDelineator(BaseGeofabricDelineator):
 
             for idx, basin in river_basins.iterrows():
                 try:
-                    # Create a buffer around the basin
-                    buffer_dist = 0.01  # About 1km in decimal degrees
+                    # Create a buffer around the basin (projected CRS, metres)
+                    buffer_dist = 1000.0  # ~1 km
                     buffer = basin.geometry.buffer(buffer_dist)
 
                     # Intersect with coastal strip

--- a/src/symfluence/geospatial/geofabric/delineators/coastal_delineator.py
+++ b/src/symfluence/geospatial/geofabric/delineators/coastal_delineator.py
@@ -201,6 +201,19 @@ class CoastalWatershedDelineator(BaseGeofabricDelineator):
                 coastal_watersheds[coastal_cols]
             ])
 
+            # Optionally despike: the coastal-strip division (buffer/overlay in a
+            # geographic CRS) and the inherited base watersheds can carry thin
+            # tentacle artifacts. Strip them before writing the final geofabric.
+            despike = self._get_config_value(
+                lambda: self.config.geofabric.despike_basin_geometry,
+                default=False,
+                dict_key='DESPIKE_BASIN_GEOMETRY',
+            )
+            if despike:
+                n_before = len(combined_basins)
+                combined_basins = GeometryProcessor.despike_geodataframe(combined_basins)
+                self.logger.info(f"Despiked combined basin geometry ({n_before} basins)")
+
             # Save combined results
             combined_basins_path = self.project_dir / "shapefiles" / "river_basins" / f"{self.domain_name}_riverBasins_with_coastal.shp"
             combined_basins.to_file(combined_basins_path)

--- a/src/symfluence/geospatial/geofabric/delineators/distributed_delineator.py
+++ b/src/symfluence/geospatial/geofabric/delineators/distributed_delineator.py
@@ -382,6 +382,18 @@ class GeofabricDelineator(BaseGeofabricDelineator):
         # Process geofabric one more time to ensure consistency
         basins, rivers = self._process_geofabric(basins, rivers)
 
+        # Optionally strip thin watershed-delineation "tentacle" artifacts that
+        # gdal.Polygonize traces from 1-pixel flow-routing leaks toward the coast.
+        despike = self._get_config_value(
+            lambda: self.config.geofabric.despike_basin_geometry,
+            default=False,
+            dict_key='DESPIKE_BASIN_GEOMETRY',
+        )
+        if despike:
+            n_before = len(basins)
+            basins = GeometryProcessor.despike_geodataframe(basins)
+            self.logger.info(f"Despiked basin geometry ({n_before} basins) before saving")
+
         # Save files
         basins.to_file(basins_path)
         rivers.to_file(rivers_path)

--- a/src/symfluence/geospatial/geofabric/delineators/distributed_delineator.py
+++ b/src/symfluence/geospatial/geofabric/delineators/distributed_delineator.py
@@ -115,8 +115,28 @@ class GeofabricDelineator(BaseGeofabricDelineator):
             # Run TauDEM workflow
             self._run_taudem_workflow(pour_point_path)
 
-            # Convert raster watersheds to polygon shapefile
-            self.gdal.run_gdal_processing(self.interim_dir)
+            # Convert raster watersheds to polygon shapefile. For coastal domains,
+            # mask the sea (flat 0-elevation in coastal DEMs) from the watershed
+            # raster first — otherwise TauDEM routes the ocean into thin radial
+            # tentacle basins reaching the domain edge. Defaults to the coastal
+            # flag, overridable via MASK_OCEAN_WATERSHEDS.
+            mask_ocean = self._get_config_value(
+                lambda: self.config.geofabric.mask_ocean_watersheds,
+                default=None,
+                dict_key='MASK_OCEAN_WATERSHEDS',
+            )
+            if mask_ocean is None:
+                mask_ocean = self._get_config_value(
+                    lambda: self.config.domain.delineation.delineate_coastal_watersheds,
+                    default=False,
+                    dict_key='DELINEATE_COASTAL_WATERSHEDS',
+                )
+            sea_level = self._get_config_value(
+                lambda: self.config.geofabric.sea_level_threshold,
+                default=0.0,
+                dict_key='SEA_LEVEL_THRESHOLD',
+            )
+            self.gdal.run_gdal_processing(self.interim_dir, mask_ocean=bool(mask_ocean), sea_level=float(sea_level))
 
             # Subset upstream geofabric
             river_network_path, river_basins_path = self._subset_upstream_geofabric(pour_point_path)

--- a/src/symfluence/geospatial/geofabric/processors/gdal_processor.py
+++ b/src/symfluence/geospatial/geofabric/processors/gdal_processor.py
@@ -47,7 +47,49 @@ class GDALProcessor:
             )
         self.logger = logger
 
-    def run_gdal_processing(self, interim_dir: Path):
+    def _mask_ocean_watersheds(self, interim_dir: Path, sea_level: float) -> str:
+        """Set watershed cells at/below ``sea_level`` to nodata, return new raster path.
+
+        Uses the pit-filled DEM (``elv-fel.tif``), which is co-registered with the
+        watershed grid. If the DEM is missing, returns the original raster
+        unchanged so delineation still proceeds.
+        """
+        import rasterio
+
+        ws_path = interim_dir / "elv-watersheds.tif"
+        fel_path = interim_dir / "elv-fel.tif"
+        if not fel_path.exists():
+            self.logger.warning(f"{fel_path.name} not found; cannot mask ocean, polygonizing as-is")
+            return str(ws_path)
+
+        with rasterio.open(ws_path) as src:
+            watersheds = src.read(1)
+            profile = src.profile
+            nodata = src.nodata
+        with rasterio.open(fel_path) as src:
+            elevation = src.read(1)
+
+        if nodata is None:
+            nodata = -2147483647
+            profile.update(nodata=nodata)
+
+        ocean = elevation <= sea_level
+        n_ocean = int(ocean.sum())
+        watersheds = watersheds.copy()
+        watersheds[ocean] = nodata
+
+        masked_path = interim_dir / "elv-watersheds-landmasked.tif"
+        with rasterio.open(masked_path, "w", **profile) as dst:
+            dst.write(watersheds, 1)
+
+        pct = 100.0 * n_ocean / watersheds.size if watersheds.size else 0.0
+        self.logger.info(
+            f"Masked {n_ocean} ocean cells ({pct:.1f}%, elev<={sea_level} m) from watershed "
+            f"raster before polygonization to remove cross-ocean tentacle basins"
+        )
+        return str(masked_path)
+
+    def run_gdal_processing(self, interim_dir: Path, mask_ocean: bool = False, sea_level: float = 0.0):
         """
         Convert watershed raster to polygon shapefile.
 
@@ -56,6 +98,13 @@ class GDALProcessor:
 
         Args:
             interim_dir: Directory containing interim TauDEM outputs
+            mask_ocean: When True, set watershed cells at or below ``sea_level``
+                (per the pit-filled DEM ``elv-fel.tif``) to nodata before
+                polygonizing. Coastal DEMs encode the sea as flat 0-elevation,
+                which TauDEM flow-routes in straight D8 lines to the domain edge
+                and assigns to watersheds — producing thin radial "tentacle"
+                basins across the ocean. Masking the sea removes the cause.
+            sea_level: Elevation (m) at/below which a cell is treated as ocean.
 
         Raises:
             RuntimeError: If all polygonization attempts fail
@@ -65,6 +114,9 @@ class GDALProcessor:
 
         input_raster = str(interim_dir / "elv-watersheds.tif")
         output_shapefile = str(interim_dir / "basin-watersheds.shp")
+
+        if mask_ocean:
+            input_raster = self._mask_ocean_watersheds(interim_dir, sea_level)
 
         try:
             # First attempt: Using gdal.Polygonize directly

--- a/src/symfluence/geospatial/geofabric/processors/geometry_processor.py
+++ b/src/symfluence/geospatial/geofabric/processors/geometry_processor.py
@@ -110,3 +110,109 @@ class GeometryProcessor:
                 geometry = MultiPolygon(polygons)
 
         return geometry
+
+    @staticmethod
+    def remove_spikes(
+        geometry,
+        resolution: float = 50.0,
+        max_iterations: int = 6,
+        min_fill_ratio: float = 0.10,
+        keep_area_fraction: float = 0.6,
+    ) -> Any:
+        """Remove thin "tentacle" artifacts from a watershed polygon.
+
+        Raster→vector watershed delineation can produce polygons consisting of a
+        compact body plus a near-zero-area tentacle that threads far across the
+        domain (a flow-routing leak toward the coast/outlet). These are *valid*
+        rings, so ``make_valid`` / ``simplify`` / a winding fix cannot remove
+        them, and an area filter passes them because the body clears the
+        threshold. This applies an adaptive raster morphological *opening* to
+        shave such tentacles while preserving the body.
+
+        The operation is **safe**: it only acts on low-"fill" (spiky) polygons,
+        grows the opening only until the shape is compact again, and falls back
+        to the original geometry whenever opening would erode real area below
+        ``keep_area_fraction`` — so a genuinely thin basin is never damaged.
+
+        Args:
+            geometry: A shapely Polygon/MultiPolygon in a **projected** CRS
+                (units of metres); see :meth:`despike_geodataframe` for CRS handling.
+            resolution: Raster cell size (m) used for the morphological opening.
+            max_iterations: Maximum opening iterations (≈ ``max_iterations`` *
+                ``resolution`` metres of tentacle width that can be removed).
+            min_fill_ratio: Target area / bounding-box-area; polygons already at
+                or above this are left untouched (deemed compact).
+            keep_area_fraction: Stop (and keep the last good result) once opening
+                would drop the area below this fraction of the original.
+
+        Returns:
+            The despiked geometry, or the original if no safe improvement found.
+        """
+        if geometry is None or geometry.is_empty:
+            return geometry
+
+        from rasterio import features
+        from rasterio import transform as rtransform
+        from scipy import ndimage
+        from shapely.geometry import shape as shapely_shape
+
+        minx, miny, maxx, maxy = geometry.bounds
+        bbox_area = max((maxx - minx) * (maxy - miny), 1e-9)
+        if geometry.area / bbox_area >= min_fill_ratio:
+            return geometry  # already compact — nothing to do
+
+        pad = resolution * (max_iterations + 2)
+        minx, miny, maxx, maxy = minx - pad, miny - pad, maxx + pad, maxy + pad
+        width = int((maxx - minx) / resolution) + 1
+        height = int((maxy - miny) / resolution) + 1
+        if width * height > 8_000_000:  # pathological bbox — skip rather than thrash
+            return geometry
+
+        affine = rtransform.from_origin(minx, maxy, resolution, resolution)
+        mask = features.rasterize(
+            [(geometry, 1)], out_shape=(height, width), transform=affine,
+            fill=0, dtype="uint8", all_touched=False,
+        )
+        if mask.sum() == 0:
+            return geometry
+
+        best = geometry
+        for iterations in range(1, max_iterations + 1):
+            opened = ndimage.binary_opening(mask, iterations=iterations)
+            if opened.sum() == 0:
+                break
+            parts = [
+                shapely_shape(geom)
+                for geom, val in features.shapes(opened.astype("uint8"), mask=opened, transform=affine)
+                if val == 1
+            ]
+            if not parts:
+                break
+            candidate = max(parts, key=lambda p: p.area)
+            if candidate.area < keep_area_fraction * geometry.area:
+                break  # eroding into the real body — keep the last safe result
+            best = candidate
+            cb = candidate.bounds
+            if candidate.area / max((cb[2] - cb[0]) * (cb[3] - cb[1]), 1e-9) >= min_fill_ratio:
+                break  # compact enough now
+        return best
+
+    @staticmethod
+    def despike_geodataframe(gdf, resolution: float = 50.0, **kwargs):
+        """Despike every geometry in a GeoDataFrame (handles CRS automatically).
+
+        Reprojects a geographic GeoDataFrame to its local UTM CRS so the
+        metre-based opening is meaningful, despikes each geometry via
+        :meth:`remove_spikes`, then reprojects back. Compact basins are returned
+        untouched, so only the spiky minority pays the raster cost.
+        """
+        if gdf is None or gdf.empty:
+            return gdf
+        src_crs = gdf.crs
+        reproject = bool(src_crs and src_crs.is_geographic)
+        work = gdf.to_crs(gdf.estimate_utm_crs()) if reproject else gdf
+        work = work.copy()
+        work["geometry"] = work.geometry.apply(
+            lambda g: GeometryProcessor.remove_spikes(g, resolution=resolution, **kwargs)
+        )
+        return work.to_crs(src_crs) if reproject else work

--- a/src/symfluence/geospatial/geofabric/utils/io_utils.py
+++ b/src/symfluence/geospatial/geofabric/utils/io_utils.py
@@ -65,7 +65,8 @@ class GeofabricIOUtils:
         rivers: gpd.GeoDataFrame,
         basins_path: Path,
         rivers_path: Path,
-        logger: Any
+        logger: Any,
+        despike_basins: bool = False,
     ):
         """
         Save basin and river shapefiles.
@@ -78,10 +79,22 @@ class GeofabricIOUtils:
             basins_path: Output path for basins shapefile
             rivers_path: Output path for rivers shapefile
             logger: Logger instance for info messages
+            despike_basins: When True, run the adaptive geometry despike
+                (:meth:`GeometryProcessor.despike_geodataframe`) over the basins
+                before writing, to strip thin watershed-delineation "tentacle"
+                artifacts. Opt-in (default False) so existing behaviour is
+                unchanged; enable via the ``DESPIKE_BASIN_GEOMETRY`` config key.
         """
         # Create parent directories
         basins_path.parent.mkdir(parents=True, exist_ok=True)
         rivers_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if despike_basins:
+            from symfluence.geospatial.geofabric.processors.geometry_processor import GeometryProcessor
+
+            n_before = len(basins)
+            basins = GeometryProcessor.despike_geodataframe(basins)
+            logger.info(f"Despiked basin geometry ({n_before} basins) before saving")
 
         # Save files
         basins.to_file(basins_path)

--- a/tests/unit/geospatial/test_geometry_despike.py
+++ b/tests/unit/geospatial/test_geometry_despike.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Unit tests for GeometryProcessor.remove_spikes / despike_geodataframe."""
+
+import pytest
+
+pytest.importorskip("rasterio")
+pytest.importorskip("scipy")
+
+from shapely.geometry import LineString, Polygon  # noqa: E402
+
+from symfluence.geospatial.geofabric.processors.geometry_processor import GeometryProcessor  # noqa: E402
+
+pytestmark = [pytest.mark.unit]
+
+
+def _body_with_tentacle():
+    """A compact 2x2 km body plus a thin ~100 m-wide tentacle running diagonally
+    ~25 km to a far corner (projected, metres) — fill ratio < 0.05, like the real
+    watershed artifacts."""
+    body = Polygon([(0, 0), (2000, 0), (2000, 2000), (0, 2000)])
+    tentacle = LineString([(1000, 1000), (20000, 20000)]).buffer(50)
+    return body.union(tentacle)
+
+
+def test_remove_spikes_strips_tentacle():
+    spiky = _body_with_tentacle()
+    bb = spiky.bounds
+    fill_before = spiky.area / ((bb[2] - bb[0]) * (bb[3] - bb[1]))
+    assert fill_before < 0.05  # genuinely spiky
+    cleaned = GeometryProcessor.remove_spikes(spiky, resolution=50.0, max_iterations=4)
+    cbb = cleaned.bounds
+    fill_after = cleaned.area / ((cbb[2] - cbb[0]) * (cbb[3] - cbb[1]))
+    assert fill_after > fill_before  # despiked: more compact
+    assert (cbb[2] - cbb[0]) < 6000  # the ~25 km tentacle is gone
+    assert cleaned.area >= 0.6 * (2000 * 2000)  # body preserved
+
+
+def test_remove_spikes_leaves_compact_polygon_untouched():
+    compact = Polygon([(0, 0), (3000, 0), (3000, 3000), (0, 3000)])
+    out = GeometryProcessor.remove_spikes(compact, resolution=50.0)
+    assert out is compact  # short-circuits, returns the same object
+
+
+def test_remove_spikes_preserves_a_genuinely_thin_basin():
+    # A long thin (but real, area-filled) basin must NOT be erased by the guard.
+    thin = Polygon([(0, 0), (12000, 0), (12000, 400), (0, 400)])
+    out = GeometryProcessor.remove_spikes(thin, resolution=50.0, keep_area_fraction=0.6)
+    assert out.area >= 0.6 * thin.area  # not destroyed
+
+
+def test_despike_geodataframe_roundtrips_crs():
+    import geopandas as gpd
+
+    gdf = gpd.GeoDataFrame(geometry=[_body_with_tentacle()], crs="EPSG:3057")
+    out = GeometryProcessor.despike_geodataframe(gdf, resolution=50.0, max_iterations=4)
+    assert out.crs == gdf.crs
+    assert len(out) == 1

--- a/tests/unit/geospatial/test_ocean_mask.py
+++ b/tests/unit/geospatial/test_ocean_mask.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Unit test for GDALProcessor._mask_ocean_watersheds (coastal tentacle fix)."""
+
+import logging
+
+import pytest
+
+pytest.importorskip("rasterio")
+pytest.importorskip("osgeo")
+
+import numpy as np  # noqa: E402
+import rasterio  # noqa: E402
+from rasterio.transform import from_origin  # noqa: E402
+
+from symfluence.geospatial.geofabric.processors.gdal_processor import GDALProcessor  # noqa: E402
+
+pytestmark = [pytest.mark.unit]
+
+
+def _write(path, arr, nodata=None):
+    with rasterio.open(
+        path, "w", driver="GTiff", height=arr.shape[0], width=arr.shape[1], count=1,
+        dtype=str(arr.dtype), crs="EPSG:4326", transform=from_origin(0, arr.shape[0], 1, 1),
+        nodata=nodata,
+    ) as dst:
+        dst.write(arr, 1)
+
+
+def test_mask_ocean_sets_sea_cells_to_nodata(tmp_path):
+    # Left half is land (elev 10, watershed 1), right half is sea (elev 0, watershed 2 = tentacle).
+    ws = np.array([[1, 1, 2, 2], [1, 1, 2, 2]], dtype="int32")
+    elev = np.array([[10.0, 10.0, 0.0, 0.0], [10.0, 10.0, 0.0, 0.0]], dtype="float32")
+    _write(tmp_path / "elv-watersheds.tif", ws, nodata=-2147483647)
+    _write(tmp_path / "elv-fel.tif", elev)
+
+    gp = GDALProcessor(logging.getLogger("t"))
+    out = gp._mask_ocean_watersheds(tmp_path, sea_level=0.0)
+
+    with rasterio.open(out) as src:
+        masked = src.read(1)
+        nd = src.nodata
+    assert (masked[:, :2] == 1).all()       # land watershed preserved
+    assert (masked[:, 2:] == nd).all()      # ocean watershed -> nodata
+
+
+def test_mask_ocean_missing_dem_returns_original(tmp_path):
+    ws = np.array([[1, 1]], dtype="int32")
+    _write(tmp_path / "elv-watersheds.tif", ws, nodata=-2147483647)
+    gp = GDALProcessor(logging.getLogger("t"))
+    out = gp._mask_ocean_watersheds(tmp_path, sea_level=0.0)
+    assert out.endswith("elv-watersheds.tif")  # falls back, no crash


### PR DESCRIPTION
## Summary

Coastal-domain hydrofabrics (e.g. Iceland) were riddled with thin **radial "tentacle" basins** spanning the sea — ~12% of basins, with polygon vertex counts up to **7425**. This PR finds and fixes the **root cause** (unmasked ocean in the watershed raster), hardens the coastal delineator, and adds a defensive geometry despike.

## Root cause

Coastal DEMs (copdem90) encode the sea as flat **0 m elevation**. TauDEM pit-fills and D8-routes that flat ocean in straight lines to the domain edge, and `streamnet -w` assigns the ocean cells to watersheds. `gdal.Polygonize` then traces them as thin radial basins across the sea. Confirmed directly in `elv-watersheds.tif`: **34–47% of watershed cells were ocean** (elevation ≤ 0). Inland domains (Bow) are unaffected because they have no sea — matching the observed pattern.

## Fixes

1. **Ocean mask (the real fix)** — `GDALProcessor.run_gdal_processing(mask_ocean, sea_level)` sets watershed cells at/below sea level (per `elv-fel.tif`) to nodata **before** polygonizing, so only land drains into basins. Enabled by default for coastal domains (`DELINEATE_COASTAL_WATERSHEDS`); overridable via `MASK_OCEAN_WATERSHEDS` / `SEA_LEVEL_THRESHOLD`.
2. **Coastal CRS hardening** — the coastal-strip division (Voronoi, convex-hull buffer, per-basin buffers, overlays) now runs in the estimated **UTM CRS with metre distances** instead of geographic degrees (which shed slivers at high latitude).
3. **Adaptive geometry despike** (`GeometryProcessor.remove_spikes` / `despike_geodataframe`) — opt-in (`DESPIKE_BASIN_GEOMETRY`, default off) safety net that strips thin tentacles via area-guarded raster opening. Superseded by the ocean mask but kept as belt-and-suspenders.

## Verification (fresh national Iceland delineation, live pipeline)

| Metric | Before | After |
|---|---|---|
| Spiky basins (fill<0.05), base | **12.5%** | **0.0%** |
| Max polygon vertices | **7425** | **1051** |
| Median fill ratio | 0.40 | 0.47 |

The `with_coastal` file has 103 remaining thin basins — all `is_coastal=True`, small (median 5.4 km), hugging the coastline: **legitimate thin coastal-fringe drainage strips, not corruption** (the `fill<0.05` metric over-flags them). The result is a clean coastline-shaped Iceland hydrofabric; discretization and forcing remap run cleanly on it.

## Tests

- `tests/unit/geospatial/test_ocean_mask.py` — masking sets sea cells to nodata, preserves land, falls back gracefully if the DEM is missing.
- `tests/unit/geospatial/test_geometry_despike.py` — despike strips a synthetic tentacle, preserves the body, leaves compact/thin-but-real basins untouched.

---
Repo and code assistance from [Claude](https://claude.ai) (Anthropic).