### PR TITLE
build: require climaclass>=0.3.0 for climate-classification extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ r = [
 # `symfluence.attribute_processors` entry point during acquire_attributes.
 # Install via: uv pip install "symfluence[climate-classification]"
 climate-classification = [
-  "climaclass[symfluence]>=0.2.0",
+  "climaclass[symfluence]>=0.3.0",
 ]
 # Development tools
 dev = [


### PR DESCRIPTION
Follow-up to #132 (already merged at `>=0.2.0`).

Bumps the `climate-classification` optional dependency to `climaclass[symfluence]>=0.3.0`. climaclass 0.3.0 (live on PyPI) adds the remapped-forcing classification path (per-HRU climatology at true HRU resolution, preferred over WorldClim zonal stats) and the polygon map visualization — both used by the SYMFLUENCE attribute-processor integration.

One-line change; no code impact.

---
Repo and code assistance from [Claude](https://claude.ai) (Anthropic).