### PR TITLE
refactor(models): pure entry-point model loading + integrity guards (B4 + Phase C)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,9 @@ wheels/
 examples/*/data/
 .confluence_env
 mpi_*
-# Allow the permanent persistent MPI strategy module
-!**/mpi_persistent.py
+# ...but never ignore mpi_*.py source modules (e.g. mpi_persistent.py, mpi_utils.py);
+# the rule above is meant for MPI runtime artifacts (hostfiles, output), not code.
+!**/mpi_*.py
 
 
 # Pixi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,6 +188,45 @@ symfluence = "symfluence.main_cli:main"
 #
 #   [project.entry-points."symfluence.plugins"]
 #   my_model = "my_package:register"
+#
+# In-tree models dogfood this same path: each ships a zero-arg register() in its
+# models/<name>/__init__.py, declared below.  They are also loaded by a
+# deterministic fallback loop in symfluence/models/__init__.py (idempotent), so
+# they never silently vanish from stale dist metadata.  This list must stay in
+# sync with symfluence.models.IN_TREE_MODELS — enforced by
+# tests/unit/models/test_entry_point_dogfood.py.
+[project.entry-points."symfluence.plugins"]
+symfluence_summa = "symfluence.models.summa:register"
+symfluence_fuse = "symfluence.models.fuse:register"
+symfluence_ngen = "symfluence.models.ngen:register"
+symfluence_mizuroute = "symfluence.models.mizuroute:register"
+symfluence_troute = "symfluence.models.troute:register"
+symfluence_hype = "symfluence.models.hype:register"
+symfluence_mesh = "symfluence.models.mesh:register"
+symfluence_lstm = "symfluence.models.lstm:register"
+symfluence_gr = "symfluence.models.gr:register"
+symfluence_gnn = "symfluence.models.gnn:register"
+symfluence_rhessys = "symfluence.models.rhessys:register"
+symfluence_ignacio = "symfluence.models.ignacio:register"
+symfluence_vic = "symfluence.models.vic:register"
+symfluence_clm = "symfluence.models.clm:register"
+symfluence_modflow = "symfluence.models.modflow:register"
+symfluence_parflow = "symfluence.models.parflow:register"
+symfluence_clmparflow = "symfluence.models.clmparflow:register"
+symfluence_swat = "symfluence.models.swat:register"
+symfluence_mhm = "symfluence.models.mhm:register"
+symfluence_crhm = "symfluence.models.crhm:register"
+symfluence_wrfhydro = "symfluence.models.wrfhydro:register"
+symfluence_prms = "symfluence.models.prms:register"
+symfluence_pihm = "symfluence.models.pihm:register"
+symfluence_wmfire = "symfluence.models.wmfire:register"
+symfluence_gsflow = "symfluence.models.gsflow:register"
+symfluence_watflood = "symfluence.models.watflood:register"
+symfluence_wflow = "symfluence.models.wflow:register"
+symfluence_lisflood = "symfluence.models.lisflood:register"
+symfluence_pcrglobwb = "symfluence.models.pcrglobwb:register"
+symfluence_cwatm = "symfluence.models.cwatm:register"
+symfluence_noahmp = "symfluence.models.noahmp:register"
 
 [project.urls]
 Homepage = "https://symfluence.org"

--- a/src/symfluence/cli/init_presets.py
+++ b/src/symfluence/cli/init_presets.py
@@ -222,8 +222,8 @@ _LEGACY_PRESETS = {
 def _get_merged_presets():
     """Get all presets from both registry and legacy definitions."""
     # Ensure model preset modules are imported to trigger registration
-    from symfluence.core.constants import SupportedModels
-    for model_name in SupportedModels.WITH_PRESETS:
+    from symfluence.models import model_packages_with
+    for model_name in model_packages_with('init_preset'):
         try:
             __import__(f'symfluence.models.{model_name}.init_preset', fromlist=['init_preset'])
         except ImportError:

--- a/src/symfluence/cli/preset_registry.py
+++ b/src/symfluence/cli/preset_registry.py
@@ -187,9 +187,9 @@ class PresetRegistry:
         """
         import logging
 
-        from symfluence.core.constants import SupportedModels
+        from symfluence.models import model_packages_with
 
-        for model_name in SupportedModels.WITH_PRESETS:
+        for model_name in model_packages_with('init_preset'):
             try:
                 __import__(
                     f'symfluence.models.{model_name}.init_preset',

--- a/src/symfluence/core/_bootstrap.py
+++ b/src/symfluence/core/_bootstrap.py
@@ -168,11 +168,25 @@ def _discover_plugins() -> None:
         # Very old importlib_metadata fallback (shouldn't happen on 3.11+)
         eps = entry_points().get(PLUGIN_ENTRY_POINT_GROUP, [])  # type: ignore[assignment]
 
+    in_tree_loaded = 0
     for ep in eps:
         try:
             plugin_fn = ep.load()
             plugin_fn()
             logger.debug("Loaded plugin %r from %s", ep.name, ep.value)
+            if ep.value.startswith("symfluence.models."):
+                in_tree_loaded += 1
+        except ImportError as exc:
+            # A missing import almost always means an optional dependency isn't
+            # installed (e.g. an MPI/GPU model on a laptop). Keep this quiet —
+            # the same models were debug-logged by the old import loop — so it
+            # doesn't drown the logs on every `import symfluence`.
+            logger.debug(
+                "Plugin %r (%s) not loaded — optional dependency missing: %s",
+                ep.name,
+                ep.value,
+                exc,
+            )
         except Exception:  # noqa: BLE001 — never let a broken plugin crash the framework
             logger.warning(
                 "Failed to load symfluence plugin %r (%s); skipping.",
@@ -180,3 +194,16 @@ def _discover_plugins() -> None:
                 ep.value,
                 exc_info=True,
             )
+
+    # In-tree models register through these same entry points (declared in
+    # SYMFLUENCE's own pyproject.toml). Discovering zero of them means the
+    # installed dist metadata predates the entry-point declarations — almost
+    # always a stale editable install. Without this signal the framework would
+    # silently come up with no runnable models. We warn loudly rather than raise
+    # so unusual-but-valid setups (e.g. partial vendoring) are not hard-blocked.
+    if in_tree_loaded == 0:
+        logger.error(
+            "No in-tree SYMFLUENCE models were discovered via entry points. The "
+            "installed package metadata is likely stale — reinstall with "
+            "`pip install -e .` to regenerate it. Model runs will fail until then."
+        )

--- a/src/symfluence/core/constants.py
+++ b/src/symfluence/core/constants.py
@@ -433,43 +433,24 @@ class UnitDetectionThresholds:
 
 
 class SupportedModels:
+    """Validity check for model names, derived from the component registry.
+
+    A model is "supported" once it has been registered with the framework via
+    an entry point / ``model_manifest`` (RTI review item 18). Registration is
+    therefore the whitelist: this no longer hardcodes a model list. The former
+    sibling lists (models with a forcing adapter / plotter / preset) were
+    likewise hardcoded and drifted from reality; those call sites now derive the
+    set directly (``symfluence.models.model_packages_with`` for submodule-based
+    discovery, or ``R.plotters`` for already-registered plotters).
     """
-    Registry of supported model names for dynamic imports.
-
-    Centralizes the whitelist of valid model names to prevent arbitrary
-    code execution via dynamic imports. All model names must be listed
-    here before they can be imported dynamically.
-    """
-
-    # Core hydrological models
-    ALL: Tuple[str, ...] = (
-        'summa', 'fuse', 'hype', 'ngen', 'mesh', 'gr', 'rhessys',
-        'lstm', 'gnn', 'mizuroute', 'hbv'
-    )
-    """All models supported by SYMFLUENCE."""
-
-    # Models with forcing adapters
-    WITH_FORCING_ADAPTER: Tuple[str, ...] = (
-        'summa', 'fuse', 'hype', 'ngen', 'mesh', 'gr', 'rhessys'
-    )
-    """Models that have forcing adapter modules."""
-
-    # Models with visualization plotters
-    WITH_PLOTTERS: Tuple[str, ...] = (
-        'summa', 'fuse', 'hype', 'ngen', 'lstm'
-    )
-    """Models with registered visualization plotters."""
-
-    # Models with initialization presets
-    WITH_PRESETS: Tuple[str, ...] = (
-        'summa', 'fuse', 'hype', 'gr', 'ngen'
-    )
-    """Models that have initialization preset modules."""
 
     @classmethod
     def is_valid(cls, model_name: str) -> bool:
-        """Check if a model name is in the supported whitelist."""
-        return model_name.lower() in cls.ALL
+        """Return True if *model_name* is a model registered with the framework."""
+        from symfluence.core.registries import R
+
+        key = model_name.upper()
+        return key in R.runners or key in R.config_schemas
 
 
 class ConfigKeys:

--- a/src/symfluence/core/mpi_utils.py
+++ b/src/symfluence/core/mpi_utils.py
@@ -48,13 +48,18 @@ def find_mpirun(exe: Union[str, os.PathLike, None] = None) -> Optional[str]:
         Absolute path (bundled case) or bare name resolved on ``PATH``, or
         ``None`` if no launcher is available.
     """
+    # 1. A launcher bundled next to the executable. shutil.which handles
+    #    per-platform executability (POSIX exec bit) and extensions (Windows
+    #    PATHEXT), so a bundled "mpirun.exe" is found on Windows and a
+    #    non-executable file is correctly ignored on POSIX.
     if exe:
-        exe_dir = Path(exe).resolve().parent
+        bundled_dir = str(Path(exe).resolve().parent)
         for name in _LAUNCHERS:
-            candidate = exe_dir / name
-            if candidate.is_file() and os.access(candidate, os.X_OK):
-                return str(candidate)
+            found = shutil.which(name, path=bundled_dir)
+            if found:
+                return found
 
+    # 2. The system PATH.
     for name in _LAUNCHERS:
         found = shutil.which(name)
         if found:

--- a/src/symfluence/core/mpi_utils.py
+++ b/src/symfluence/core/mpi_utils.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""MPI launcher discovery for models that execute under mpirun/mpiexec.
+
+Several process-based models (ParFlow, CLM-ParFlow, WRF-Hydro) launch their
+executables through an MPI launcher with the ``<launcher> -np <n> <exe>``
+convention. :func:`find_mpirun` locates a suitable launcher, preferring one
+bundled alongside the model executable (as shipped by the npm binary
+distribution) and falling back to the system ``PATH``.
+
+Kept dependency-free (stdlib only) so it is safe to import from model runners
+at module load time.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+from typing import Optional, Union
+
+# Launchers that accept the ``-np <n> <exe>`` calling convention the model
+# runners use. ``srun`` is intentionally excluded — it needs different flags
+# and PMI negotiation, so callers that want it build their command separately.
+_LAUNCHERS = ("mpirun", "mpiexec")
+
+
+def find_mpirun(exe: Union[str, os.PathLike, None] = None) -> Optional[str]:
+    """Return the path to an MPI launcher (``mpirun``/``mpiexec``), or ``None``.
+
+    Search order:
+
+    1. A launcher bundled next to *exe* — the npm distribution ships one
+       alongside the model binaries, so an offline/HPC install works without a
+       system MPI.
+    2. The system ``PATH`` (``shutil.which``).
+
+    Parameters
+    ----------
+    exe:
+        Path to the model executable about to be launched. Used only to look
+        for a co-located launcher; may be ``None`` to search ``PATH`` only.
+
+    Returns
+    -------
+    Optional[str]
+        Absolute path (bundled case) or bare name resolved on ``PATH``, or
+        ``None`` if no launcher is available.
+    """
+    if exe:
+        exe_dir = Path(exe).resolve().parent
+        for name in _LAUNCHERS:
+            candidate = exe_dir / name
+            if candidate.is_file() and os.access(candidate, os.X_OK):
+                return str(candidate)
+
+    for name in _LAUNCHERS:
+        found = shutil.which(name)
+        if found:
+            return found
+
+    return None

--- a/src/symfluence/models/__init__.py
+++ b/src/symfluence/models/__init__.py
@@ -68,7 +68,25 @@ warnings.filterwarnings('ignore', message='.*import failed.*')
 # stale-install signal).
 
 
+def model_packages_with(submodule: str) -> tuple[str, ...]:
+    """Return the in-tree model package names that contain *submodule*``.py``.
+
+    e.g. ``model_packages_with('forcing_adapter')`` -> ``('fuse', 'gr', ...)``.
+
+    Some optional model facilities (forcing adapters, init presets) register
+    themselves as a side effect of importing a per-model submodule, so the set
+    of models that have them cannot be read from the registry those imports
+    populate — it is discovered from the source tree instead. This replaces the
+    hardcoded ``SupportedModels.WITH_*`` lists, which had drifted from reality.
+    """
+    from pathlib import Path
+
+    pkg_dir = Path(__file__).resolve().parent
+    return tuple(sorted(p.parent.name for p in pkg_dir.glob(f"*/{submodule}.py")))
+
+
 __all__ = [
+    "model_packages_with",
     # Execution Framework
     "ModelExecutor",
     "ExecutionResult",

--- a/src/symfluence/models/__init__.py
+++ b/src/symfluence/models/__init__.py
@@ -53,34 +53,19 @@ logger = logging.getLogger(__name__)
 warnings.filterwarnings('ignore', message='.*is an EXPERIMENTAL module.*')
 warnings.filterwarnings('ignore', message='.*import failed.*')
 
-# Import from modular packages (preferred).
-# Use `except Exception` (not ImportError) because model imports may  # noqa: BLE001 — comment only
-# transitively trigger threading._register_atexit() which raises
-# RuntimeError on daemon threads (e.g. Panel's Tornado IO loop).
-_model_names = [
-    'summa', 'fuse', 'ngen', 'mizuroute', 'troute',
-    'hype', 'mesh', 'lstm', 'gr', 'gnn', 'rhessys',
-    'ignacio', 'vic', 'clm',
-    'modflow', 'parflow', 'clmparflow',
-    'swat', 'mhm', 'crhm', 'wrfhydro', 'prms',
-    'pihm', 'wmfire',
-    'gsflow', 'watflood', 'wflow', 'lisflood',
-    'pcrglobwb', 'cwatm', 'noahmp',
-]
-
-import importlib as _importlib
-
-for _model_name in _model_names:
-    try:
-        _importlib.import_module(f'.{_model_name}', __name__)
-    except Exception as _e:  # noqa: BLE001 — optional dependency
-        logger.debug(f"Could not import {_model_name}: {_e}")
-
-del _model_names, _model_name, _importlib
-try:
-    del _e
-except NameError:
-    pass
+# In-tree models register through the `symfluence.plugins` entry points declared
+# in pyproject.toml — one `symfluence_<name> = "symfluence.models.<name>:register"`
+# per model. At `import symfluence`, the bootstrap (`core/_bootstrap._discover_plugins`)
+# loads every entry point and calls its register(), the *same* non-privileged path
+# external plugins use. There is deliberately no hard-coded model list and no import
+# loop here: adding a model means creating the package with a top-level register() and
+# declaring its entry point. `tests/unit/models/test_entry_point_dogfood.py` fails the
+# build if the on-disk register() set and the pyproject entry points drift apart.
+#
+# NOTE: entry points are read from installed dist metadata, so a newly added or pulled
+# model only becomes visible after `pip install -e .` regenerates that metadata.
+# `_discover_plugins` logs a loud error if zero in-tree models are discovered (the
+# stale-install signal).
 
 
 __all__ = [

--- a/src/symfluence/models/adapters/adapter_registry.py
+++ b/src/symfluence/models/adapters/adapter_registry.py
@@ -145,9 +145,9 @@ class ForcingAdapterRegistry:
         This method attempts to import the forcing_adapter module
         from each known model package.
         """
-        from symfluence.core.constants import SupportedModels
+        from symfluence.models import model_packages_with
 
-        for model_name in SupportedModels.WITH_FORCING_ADAPTER:
+        for model_name in model_packages_with('forcing_adapter'):
             try:
                 __import__(
                     f'symfluence.models.{model_name}.forcing_adapter',

--- a/src/symfluence/models/clm/__init__.py
+++ b/src/symfluence/models/clm/__init__.py
@@ -59,11 +59,14 @@ __all__ = [
 # decorators in their respective component modules.
 from symfluence.core.registry import model_manifest
 
-model_manifest(
-    "CLM",
-    config_adapter=CLMConfigAdapter,
-    build_instructions_module="symfluence.models.clm.build_instructions",
-)
+
+def register() -> None:
+    """Register CLM components with the unified registry."""
+    model_manifest(
+        "CLM",
+        config_adapter=CLMConfigAdapter,
+        build_instructions_module="symfluence.models.clm.build_instructions",
+    )
 
 # Register calibration components with OptimizerRegistry
 try:

--- a/src/symfluence/models/clmparflow/__init__.py
+++ b/src/symfluence/models/clmparflow/__init__.py
@@ -60,9 +60,12 @@ __all__ = [
 # decorators in their respective component modules.
 from symfluence.core.registry import model_manifest
 
-model_manifest(
-    "CLMPARFLOW",
-    config_adapter=CLMParFlowConfigAdapter,
-    plotter=CLMParFlowPlotter,
-    build_instructions_module="symfluence.models.clmparflow.build_instructions",
-)
+
+def register() -> None:
+    """Register CLMPARFLOW components with the unified registry."""
+    model_manifest(
+        "CLMPARFLOW",
+        config_adapter=CLMParFlowConfigAdapter,
+        plotter=CLMParFlowPlotter,
+        build_instructions_module="symfluence.models.clmparflow.build_instructions",
+    )

--- a/src/symfluence/models/crhm/__init__.py
+++ b/src/symfluence/models/crhm/__init__.py
@@ -83,14 +83,17 @@ __all__ = [
 # Register all CRHM components via unified registry
 from symfluence.core.registry import model_manifest
 
-model_manifest(
-    "CRHM",
-    preprocessor=CRHMPreProcessor,
-    runner=CRHMRunner,
-    result_extractor=CRHMResultExtractor,
-    config_adapter=CRHMConfigAdapter,
-    build_instructions_module="symfluence.models.crhm.build_instructions",
-)
+
+def register() -> None:
+    """Register CRHM components with the unified registry."""
+    model_manifest(
+        "CRHM",
+        preprocessor=CRHMPreProcessor,
+        runner=CRHMRunner,
+        result_extractor=CRHMResultExtractor,
+        config_adapter=CRHMConfigAdapter,
+        build_instructions_module="symfluence.models.crhm.build_instructions",
+    )
 
 # Register calibration components with OptimizerRegistry
 try:

--- a/src/symfluence/models/cwatm/__init__.py
+++ b/src/symfluence/models/cwatm/__init__.py
@@ -18,11 +18,14 @@ __all__ = [
 
 from symfluence.core.registry import model_manifest
 
-model_manifest(
-    "CWATM",
-    preprocessor=CWatMPreProcessor,
-    runner=CWatMRunner,
-    result_extractor=CWatMResultExtractor,
-    config_adapter=CWatMConfigAdapter,
-    build_instructions_module="symfluence.models.cwatm.build_instructions",
-)
+
+def register() -> None:
+    """Register CWATM components with the unified registry."""
+    model_manifest(
+        "CWATM",
+        preprocessor=CWatMPreProcessor,
+        runner=CWatMRunner,
+        result_extractor=CWatMResultExtractor,
+        config_adapter=CWatMConfigAdapter,
+        build_instructions_module="symfluence.models.cwatm.build_instructions",
+    )

--- a/src/symfluence/models/fuse/__init__.py
+++ b/src/symfluence/models/fuse/__init__.py
@@ -88,11 +88,14 @@ from .config import FUSEConfigAdapter
 from .extractor import FUSEResultExtractor
 from .plotter import FUSEPlotter
 
-model_manifest(
-    "FUSE",
-    config_adapter=FUSEConfigAdapter,
-    result_extractor=FUSEResultExtractor,
-    decision_analyzer=FuseStructureAnalyzer,
-    plotter=FUSEPlotter,
-    build_instructions_module="symfluence.models.fuse.build_instructions",
-)
+
+def register() -> None:
+    """Register FUSE components with the unified registry."""
+    model_manifest(
+        "FUSE",
+        config_adapter=FUSEConfigAdapter,
+        result_extractor=FUSEResultExtractor,
+        decision_analyzer=FuseStructureAnalyzer,
+        plotter=FUSEPlotter,
+        build_instructions_module="symfluence.models.fuse.build_instructions",
+    )

--- a/src/symfluence/models/gnn/__init__.py
+++ b/src/symfluence/models/gnn/__init__.py
@@ -37,11 +37,14 @@ from symfluence.core.registry import model_manifest
 from .config import GNNConfigAdapter
 from .extractor import GNNResultExtractor
 
-model_manifest(
-    "GNN",
-    config_adapter=GNNConfigAdapter,
-    result_extractor=GNNResultExtractor,
-)
+
+def register() -> None:
+    """Register GNN components with the unified registry."""
+    model_manifest(
+        "GNN",
+        config_adapter=GNNConfigAdapter,
+        result_extractor=GNNResultExtractor,
+    )
 
 
 if TYPE_CHECKING:

--- a/src/symfluence/models/gr/__init__.py
+++ b/src/symfluence/models/gr/__init__.py
@@ -85,8 +85,11 @@ from symfluence.core.registry import model_manifest
 from .config import GRConfigAdapter
 from .extractor import GRResultExtractor
 
-model_manifest(
-    "GR",
-    config_adapter=GRConfigAdapter,
-    result_extractor=GRResultExtractor,
-)
+
+def register() -> None:
+    """Register GR components with the unified registry."""
+    model_manifest(
+        "GR",
+        config_adapter=GRConfigAdapter,
+        result_extractor=GRResultExtractor,
+    )

--- a/src/symfluence/models/gsflow/__init__.py
+++ b/src/symfluence/models/gsflow/__init__.py
@@ -33,14 +33,17 @@ __all__ = [
 # Register all GSFLOW components via unified registry
 from symfluence.core.registry import model_manifest
 
-model_manifest(
-    "GSFLOW",
-    preprocessor=GSFLOWPreProcessor,
-    runner=GSFLOWRunner,
-    result_extractor=GSFLOWResultExtractor,
-    config_adapter=GSFLOWConfigAdapter,
-    build_instructions_module="symfluence.models.gsflow.build_instructions",
-)
+
+def register() -> None:
+    """Register GSFLOW components with the unified registry."""
+    model_manifest(
+        "GSFLOW",
+        preprocessor=GSFLOWPreProcessor,
+        runner=GSFLOWRunner,
+        result_extractor=GSFLOWResultExtractor,
+        config_adapter=GSFLOWConfigAdapter,
+        build_instructions_module="symfluence.models.gsflow.build_instructions",
+    )
 
 # Register calibration components
 try:

--- a/src/symfluence/models/hype/__init__.py
+++ b/src/symfluence/models/hype/__init__.py
@@ -91,10 +91,13 @@ from .config import HYPEConfigAdapter
 from .extractor import HYPEResultExtractor
 from .plotter import HYPEPlotter
 
-model_manifest(
-    "HYPE",
-    config_adapter=HYPEConfigAdapter,
-    result_extractor=HYPEResultExtractor,
-    plotter=HYPEPlotter,
-    build_instructions_module="symfluence.models.hype.build_instructions",
-)
+
+def register() -> None:
+    """Register HYPE components with the unified registry."""
+    model_manifest(
+        "HYPE",
+        config_adapter=HYPEConfigAdapter,
+        result_extractor=HYPEResultExtractor,
+        plotter=HYPEPlotter,
+        build_instructions_module="symfluence.models.hype.build_instructions",
+    )

--- a/src/symfluence/models/ignacio/__init__.py
+++ b/src/symfluence/models/ignacio/__init__.py
@@ -65,17 +65,18 @@ __all__ = [
     "IGNACIOResultExtractor",
 ]
 
-# Register all IGNACIO components via unified registry
-try:
-    from symfluence.core.registry import model_manifest
+def register() -> None:
+    """Register IGNACIO components with the unified registry."""
+    try:
+        from symfluence.core.registry import model_manifest
 
-    model_manifest(
-        "IGNACIO",
-        result_extractor=IGNACIOResultExtractor,
-        build_instructions_module="symfluence.models.ignacio.build_instructions",
-    )
-except Exception:  # noqa: BLE001 — optional dependency
-    pass
+        model_manifest(
+            "IGNACIO",
+            result_extractor=IGNACIOResultExtractor,
+            build_instructions_module="symfluence.models.ignacio.build_instructions",
+        )
+    except Exception:  # noqa: BLE001 — optional dependency
+        pass
 
 # Register calibration components with OptimizerRegistry
 try:

--- a/src/symfluence/models/lisflood/__init__.py
+++ b/src/symfluence/models/lisflood/__init__.py
@@ -19,14 +19,17 @@ __all__ = [
 
 from symfluence.core.registry import model_manifest
 
-model_manifest(
-    "LISFLOOD",
-    preprocessor=LisfloodPreProcessor,
-    runner=LisfloodRunner,
-    result_extractor=LisfloodResultExtractor,
-    config_adapter=LisfloodConfigAdapter,
-    build_instructions_module="symfluence.models.lisflood.build_instructions",
-)
+
+def register() -> None:
+    """Register LISFLOOD components with the unified registry."""
+    model_manifest(
+        "LISFLOOD",
+        preprocessor=LisfloodPreProcessor,
+        runner=LisfloodRunner,
+        result_extractor=LisfloodResultExtractor,
+        config_adapter=LisfloodConfigAdapter,
+        build_instructions_module="symfluence.models.lisflood.build_instructions",
+    )
 
 try:
     from .calibration import LisfloodModelOptimizer  # noqa: F401

--- a/src/symfluence/models/lstm/__init__.py
+++ b/src/symfluence/models/lstm/__init__.py
@@ -50,12 +50,15 @@ from .config import LSTMConfigAdapter
 from .extractor import LSTMResultExtractor
 from .plotter import LSTMPlotter
 
-model_manifest(
-    "LSTM",
-    config_adapter=LSTMConfigAdapter,
-    result_extractor=LSTMResultExtractor,
-    plotter=LSTMPlotter,
-)
+
+def register() -> None:
+    """Register LSTM components with the unified registry."""
+    model_manifest(
+        "LSTM",
+        config_adapter=LSTMConfigAdapter,
+        result_extractor=LSTMResultExtractor,
+        plotter=LSTMPlotter,
+    )
 
 
 if TYPE_CHECKING:

--- a/src/symfluence/models/mesh/__init__.py
+++ b/src/symfluence/models/mesh/__init__.py
@@ -81,9 +81,12 @@ from symfluence.core.registry import model_manifest
 from .config import MESHConfigAdapter
 from .extractor import MESHResultExtractor
 
-model_manifest(
-    "MESH",
-    config_adapter=MESHConfigAdapter,
-    result_extractor=MESHResultExtractor,
-    build_instructions_module="symfluence.models.mesh.build_instructions",
-)
+
+def register() -> None:
+    """Register MESH components with the unified registry."""
+    model_manifest(
+        "MESH",
+        config_adapter=MESHConfigAdapter,
+        result_extractor=MESHResultExtractor,
+        build_instructions_module="symfluence.models.mesh.build_instructions",
+    )

--- a/src/symfluence/models/mhm/__init__.py
+++ b/src/symfluence/models/mhm/__init__.py
@@ -86,14 +86,17 @@ __all__ = [
 # Register all MHM components via unified registry
 from symfluence.core.registry import model_manifest
 
-model_manifest(
-    "MHM",
-    preprocessor=MHMPreProcessor,
-    runner=MHMRunner,
-    result_extractor=MHMResultExtractor,
-    config_adapter=MHMConfigAdapter,
-    build_instructions_module="symfluence.models.mhm.build_instructions",
-)
+
+def register() -> None:
+    """Register MHM components with the unified registry."""
+    model_manifest(
+        "MHM",
+        preprocessor=MHMPreProcessor,
+        runner=MHMRunner,
+        result_extractor=MHMResultExtractor,
+        config_adapter=MHMConfigAdapter,
+        build_instructions_module="symfluence.models.mhm.build_instructions",
+    )
 
 # Register calibration components with OptimizerRegistry
 try:

--- a/src/symfluence/models/mizuroute/__init__.py
+++ b/src/symfluence/models/mizuroute/__init__.py
@@ -82,12 +82,15 @@ from symfluence.core.registry import model_manifest
 from .config import MizuRouteConfigAdapter
 from .extractor import MizuRouteResultExtractor
 
-model_manifest(
-    "MIZUROUTE",
-    config_adapter=MizuRouteConfigAdapter,
-    result_extractor=MizuRouteResultExtractor,
-    preprocessor=MizuRoutePreProcessor,
-    runner=MizuRouteRunner,
-    runner_method="run_mizuroute",
-    build_instructions_module="symfluence.models.mizuroute.build_instructions",
-)
+
+def register() -> None:
+    """Register MIZUROUTE components with the unified registry."""
+    model_manifest(
+        "MIZUROUTE",
+        config_adapter=MizuRouteConfigAdapter,
+        result_extractor=MizuRouteResultExtractor,
+        preprocessor=MizuRoutePreProcessor,
+        runner=MizuRouteRunner,
+        runner_method="run_mizuroute",
+        build_instructions_module="symfluence.models.mizuroute.build_instructions",
+    )

--- a/src/symfluence/models/modflow/__init__.py
+++ b/src/symfluence/models/modflow/__init__.py
@@ -52,9 +52,12 @@ __all__ = [
 # decorators in their respective component modules.
 from symfluence.core.registry import model_manifest
 
-model_manifest(
-    "MODFLOW",
-    config_adapter=MODFLOWConfigAdapter,
-    plotter=MODFLOWPlotter,
-    build_instructions_module="symfluence.models.modflow.build_instructions",
-)
+
+def register() -> None:
+    """Register MODFLOW components with the unified registry."""
+    model_manifest(
+        "MODFLOW",
+        config_adapter=MODFLOWConfigAdapter,
+        plotter=MODFLOWPlotter,
+        build_instructions_module="symfluence.models.modflow.build_instructions",
+    )

--- a/src/symfluence/models/ngen/__init__.py
+++ b/src/symfluence/models/ngen/__init__.py
@@ -93,10 +93,13 @@ from .config import NgenConfigAdapter
 from .extractor import NGENResultExtractor
 from .plotter import NGENPlotter
 
-model_manifest(
-    "NGEN",
-    config_adapter=NgenConfigAdapter,
-    result_extractor=NGENResultExtractor,
-    plotter=NGENPlotter,
-    build_instructions_module="symfluence.models.ngen.build_instructions",
-)
+
+def register() -> None:
+    """Register NGEN components with the unified registry."""
+    model_manifest(
+        "NGEN",
+        config_adapter=NgenConfigAdapter,
+        result_extractor=NGENResultExtractor,
+        plotter=NGENPlotter,
+        build_instructions_module="symfluence.models.ngen.build_instructions",
+    )

--- a/src/symfluence/models/noahmp/__init__.py
+++ b/src/symfluence/models/noahmp/__init__.py
@@ -20,15 +20,18 @@ __all__ = [
 # Register Noah-MP config adapter via unified registry
 from symfluence.core.registry import model_manifest
 
-model_manifest(
-    "NOAHMP",
-    preprocessor=NoahMPPreProcessor,
-    runner=NoahMPRunner,
-    result_extractor=NoahMPResultExtractor,
-    config_adapter=NoahMPConfigAdapter,
-    postprocessor=NoahMPPostProcessor,
-    build_instructions_module="symfluence.models.noahmp.build_instructions",
-)
+
+def register() -> None:
+    """Register NOAHMP components with the unified registry."""
+    model_manifest(
+        "NOAHMP",
+        preprocessor=NoahMPPreProcessor,
+        runner=NoahMPRunner,
+        result_extractor=NoahMPResultExtractor,
+        config_adapter=NoahMPConfigAdapter,
+        postprocessor=NoahMPPostProcessor,
+        build_instructions_module="symfluence.models.noahmp.build_instructions",
+    )
 
 # Register calibration components with OptimizerRegistry
 try:

--- a/src/symfluence/models/parflow/__init__.py
+++ b/src/symfluence/models/parflow/__init__.py
@@ -56,9 +56,12 @@ __all__ = [
 # decorators in their respective component modules.
 from symfluence.core.registry import model_manifest
 
-model_manifest(
-    "PARFLOW",
-    config_adapter=ParFlowConfigAdapter,
-    plotter=ParFlowPlotter,
-    build_instructions_module="symfluence.models.parflow.build_instructions",
-)
+
+def register() -> None:
+    """Register PARFLOW components with the unified registry."""
+    model_manifest(
+        "PARFLOW",
+        config_adapter=ParFlowConfigAdapter,
+        plotter=ParFlowPlotter,
+        build_instructions_module="symfluence.models.parflow.build_instructions",
+    )

--- a/src/symfluence/models/pcrglobwb/__init__.py
+++ b/src/symfluence/models/pcrglobwb/__init__.py
@@ -18,14 +18,17 @@ __all__ = [
 
 from symfluence.core.registry import model_manifest
 
-model_manifest(
-    "PCRGLOBWB",
-    preprocessor=PCRGLOBWBPreProcessor,
-    runner=PCRGLOBWBRunner,
-    result_extractor=PCRGLOBWBResultExtractor,
-    config_adapter=PCRGLOBWBConfigAdapter,
-    build_instructions_module="symfluence.models.pcrglobwb.build_instructions",
-)
+
+def register() -> None:
+    """Register PCRGLOBWB components with the unified registry."""
+    model_manifest(
+        "PCRGLOBWB",
+        preprocessor=PCRGLOBWBPreProcessor,
+        runner=PCRGLOBWBRunner,
+        result_extractor=PCRGLOBWBResultExtractor,
+        config_adapter=PCRGLOBWBConfigAdapter,
+        build_instructions_module="symfluence.models.pcrglobwb.build_instructions",
+    )
 
 try:
     from .calibration import PCRGLOBWBModelOptimizer  # noqa: F401

--- a/src/symfluence/models/pihm/__init__.py
+++ b/src/symfluence/models/pihm/__init__.py
@@ -52,9 +52,12 @@ __all__ = [
 # decorators in their respective component modules.
 from symfluence.core.registry import model_manifest
 
-model_manifest(
-    "PIHM",
-    config_adapter=PIHMConfigAdapter,
-    plotter=PIHMPlotter,
-    build_instructions_module="symfluence.models.pihm.build_instructions",
-)
+
+def register() -> None:
+    """Register PIHM components with the unified registry."""
+    model_manifest(
+        "PIHM",
+        config_adapter=PIHMConfigAdapter,
+        plotter=PIHMPlotter,
+        build_instructions_module="symfluence.models.pihm.build_instructions",
+    )

--- a/src/symfluence/models/prms/__init__.py
+++ b/src/symfluence/models/prms/__init__.py
@@ -90,14 +90,17 @@ __all__ = [
 # Register all PRMS components via unified registry
 from symfluence.core.registry import model_manifest
 
-model_manifest(
-    "PRMS",
-    preprocessor=PRMSPreProcessor,
-    runner=PRMSRunner,
-    result_extractor=PRMSResultExtractor,
-    config_adapter=PRMSConfigAdapter,
-    build_instructions_module="symfluence.models.prms.build_instructions",
-)
+
+def register() -> None:
+    """Register PRMS components with the unified registry."""
+    model_manifest(
+        "PRMS",
+        preprocessor=PRMSPreProcessor,
+        runner=PRMSRunner,
+        result_extractor=PRMSResultExtractor,
+        config_adapter=PRMSConfigAdapter,
+        build_instructions_module="symfluence.models.prms.build_instructions",
+    )
 
 # Register calibration components
 try:

--- a/src/symfluence/models/rhessys/__init__.py
+++ b/src/symfluence/models/rhessys/__init__.py
@@ -86,9 +86,12 @@ from symfluence.core.registry import model_manifest
 from .config import RHESSysConfigAdapter
 from .extractor import RHESSysResultExtractor
 
-model_manifest(
-    "RHESSYS",
-    config_adapter=RHESSysConfigAdapter,
-    result_extractor=RHESSysResultExtractor,
-    build_instructions_module="symfluence.models.rhessys.build_instructions",
-)
+
+def register() -> None:
+    """Register RHESSYS components with the unified registry."""
+    model_manifest(
+        "RHESSYS",
+        config_adapter=RHESSysConfigAdapter,
+        result_extractor=RHESSysResultExtractor,
+        build_instructions_module="symfluence.models.rhessys.build_instructions",
+    )

--- a/src/symfluence/models/summa/__init__.py
+++ b/src/symfluence/models/summa/__init__.py
@@ -101,11 +101,14 @@ from .config import SUMMAConfigAdapter
 from .extractor import SUMMAResultExtractor
 from .plotter import SUMMAPlotter
 
-model_manifest(
-    "SUMMA",
-    config_adapter=SUMMAConfigAdapter,
-    result_extractor=SUMMAResultExtractor,
-    decision_analyzer=SummaStructureAnalyzer,
-    plotter=SUMMAPlotter,
-    build_instructions_module="symfluence.models.summa.build_instructions",
-)
+
+def register() -> None:
+    """Register SUMMA components with the unified registry."""
+    model_manifest(
+        "SUMMA",
+        config_adapter=SUMMAConfigAdapter,
+        result_extractor=SUMMAResultExtractor,
+        decision_analyzer=SummaStructureAnalyzer,
+        plotter=SUMMAPlotter,
+        build_instructions_module="symfluence.models.summa.build_instructions",
+    )

--- a/src/symfluence/models/swat/__init__.py
+++ b/src/symfluence/models/swat/__init__.py
@@ -92,14 +92,17 @@ __all__ = [
 # Register all SWAT components via unified registry
 from symfluence.core.registry import model_manifest
 
-model_manifest(
-    "SWAT",
-    preprocessor=SWATPreProcessor,
-    runner=SWATRunner,
-    result_extractor=SWATResultExtractor,
-    config_adapter=SWATConfigAdapter,
-    build_instructions_module="symfluence.models.swat.build_instructions",
-)
+
+def register() -> None:
+    """Register SWAT components with the unified registry."""
+    model_manifest(
+        "SWAT",
+        preprocessor=SWATPreProcessor,
+        runner=SWATRunner,
+        result_extractor=SWATResultExtractor,
+        config_adapter=SWATConfigAdapter,
+        build_instructions_module="symfluence.models.swat.build_instructions",
+    )
 
 # Register calibration components with OptimizerRegistry
 try:

--- a/src/symfluence/models/troute/__init__.py
+++ b/src/symfluence/models/troute/__init__.py
@@ -37,13 +37,16 @@ __all__ = [
 # Register all TRoute components via unified registry
 from symfluence.core.registry import model_manifest
 
-model_manifest(
-    "TROUTE",
-    config_adapter=TRouteConfigAdapter,
-    result_extractor=TRouteResultExtractor,
-    plotter=TRoutePlotter,
-    build_instructions_module="symfluence.models.troute.build_instructions",
-)
+
+def register() -> None:
+    """Register TROUTE components with the unified registry."""
+    model_manifest(
+        "TROUTE",
+        config_adapter=TRouteConfigAdapter,
+        result_extractor=TRouteResultExtractor,
+        plotter=TRoutePlotter,
+        build_instructions_module="symfluence.models.troute.build_instructions",
+    )
 
 # Register calibration components
 try:

--- a/src/symfluence/models/vic/__init__.py
+++ b/src/symfluence/models/vic/__init__.py
@@ -83,14 +83,17 @@ __all__ = [
 # Register all VIC components via unified registry
 from symfluence.core.registry import model_manifest
 
-model_manifest(
-    "VIC",
-    preprocessor=VICPreProcessor,
-    runner=VICRunner,
-    result_extractor=VICResultExtractor,
-    config_adapter=VICConfigAdapter,
-    build_instructions_module="symfluence.models.vic.build_instructions",
-)
+
+def register() -> None:
+    """Register VIC components with the unified registry."""
+    model_manifest(
+        "VIC",
+        preprocessor=VICPreProcessor,
+        runner=VICRunner,
+        result_extractor=VICResultExtractor,
+        config_adapter=VICConfigAdapter,
+        build_instructions_module="symfluence.models.vic.build_instructions",
+    )
 
 # Register calibration components with OptimizerRegistry
 try:

--- a/src/symfluence/models/watflood/__init__.py
+++ b/src/symfluence/models/watflood/__init__.py
@@ -39,14 +39,17 @@ __all__ = [
 # Register all WATFLOOD components via unified registry
 from symfluence.core.registry import model_manifest
 
-model_manifest(
-    "WATFLOOD",
-    preprocessor=WATFLOODPreProcessor,
-    runner=WATFLOODRunner,
-    result_extractor=WATFLOODResultExtractor,
-    config_adapter=WATFLOODConfigAdapter,
-    build_instructions_module="symfluence.models.watflood.build_instructions",
-)
+
+def register() -> None:
+    """Register WATFLOOD components with the unified registry."""
+    model_manifest(
+        "WATFLOOD",
+        preprocessor=WATFLOODPreProcessor,
+        runner=WATFLOODRunner,
+        result_extractor=WATFLOODResultExtractor,
+        config_adapter=WATFLOODConfigAdapter,
+        build_instructions_module="symfluence.models.watflood.build_instructions",
+    )
 
 # Register calibration components
 try:

--- a/src/symfluence/models/wflow/__init__.py
+++ b/src/symfluence/models/wflow/__init__.py
@@ -18,14 +18,17 @@ __all__ = [
 
 from symfluence.core.registry import model_manifest
 
-model_manifest(
-    "WFLOW",
-    preprocessor=WflowPreProcessor,
-    runner=WflowRunner,
-    result_extractor=WflowResultExtractor,
-    config_adapter=WflowConfigAdapter,
-    build_instructions_module="symfluence.models.wflow.build_instructions",
-)
+
+def register() -> None:
+    """Register WFLOW components with the unified registry."""
+    model_manifest(
+        "WFLOW",
+        preprocessor=WflowPreProcessor,
+        runner=WflowRunner,
+        result_extractor=WflowResultExtractor,
+        config_adapter=WflowConfigAdapter,
+        build_instructions_module="symfluence.models.wflow.build_instructions",
+    )
 
 try:
     from .calibration import WflowModelOptimizer  # noqa: F401

--- a/src/symfluence/models/wmfire/__init__.py
+++ b/src/symfluence/models/wmfire/__init__.py
@@ -42,11 +42,14 @@ from .ignition import (
 )
 from .postprocessor import WMFirePostProcessor
 
-# Import build instructions to register with BuildInstructionsRegistry
-try:
-    from . import build_instructions  # noqa: F401
-except ImportError:
-    pass
+
+def register() -> None:
+    """Register WMFire components with the unified registry."""
+    # Import build instructions to register with BuildInstructionsRegistry
+    try:
+        from . import build_instructions  # noqa: F401
+    except ImportError:
+        pass
 
 __all__ = [
     # Grid management

--- a/src/symfluence/models/wrfhydro/__init__.py
+++ b/src/symfluence/models/wrfhydro/__init__.py
@@ -88,14 +88,17 @@ __all__ = [
 # Register all WRF-Hydro components via unified registry
 from symfluence.core.registry import model_manifest
 
-model_manifest(
-    "WRFHYDRO",
-    preprocessor=WRFHydroPreProcessor,
-    runner=WRFHydroRunner,
-    result_extractor=WRFHydroResultExtractor,
-    config_adapter=WRFHydroConfigAdapter,
-    build_instructions_module="symfluence.models.wrfhydro.build_instructions",
-)
+
+def register() -> None:
+    """Register WRFHYDRO components with the unified registry."""
+    model_manifest(
+        "WRFHYDRO",
+        preprocessor=WRFHydroPreProcessor,
+        runner=WRFHydroRunner,
+        result_extractor=WRFHydroResultExtractor,
+        config_adapter=WRFHydroConfigAdapter,
+        build_instructions_module="symfluence.models.wrfhydro.build_instructions",
+    )
 
 # Register calibration components
 try:

--- a/src/symfluence/reporting/orchestrators/model_output_orchestrator.py
+++ b/src/symfluence/reporting/orchestrators/model_output_orchestrator.py
@@ -157,15 +157,9 @@ class ModelOutputOrchestrator:
         Returns:
             Plot result (path to saved plot or dict of paths), or None.
         """
-        # Import model modules to trigger plotter registration
-        from symfluence.core.constants import SupportedModels
-
-        for model in SupportedModels.WITH_PLOTTERS:
-            try:
-                __import__(f'symfluence.models.{model}')
-            except ImportError:
-                self.logger.debug(f"Model plotter module '{model}' not available")
-
+        # Plotters are registered at `import symfluence` via entry-point
+        # discovery, so the registry is already populated — look the model up
+        # directly rather than re-importing model modules from a hardcoded list.
         from symfluence.core.registries import R
 
         model_upper = model_name.upper()

--- a/tests/unit/config/test_config_schema_consumed.py
+++ b/tests/unit/config/test_config_schema_consumed.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Phase C guard 2 — every registered config schema is consumed (RTI item 26).
+
+Phase B made ``R.config_schemas`` the authority for model-specific typed configs:
+``ModelConfig.auto_populate_model_configs`` instantiates the registered schema for a
+selected model, and ``config_resolution.get_config_schema`` resolves it. A schema can
+be registered (via ``IN_TREE_CONFIG_SCHEMAS`` or ``model_manifest(config_schema=...)``)
+yet never actually applied — e.g. under a key the resolution path never queries. That
+"accepted but unread" state is silent: the config validates, but the typed schema is
+ignored.
+
+This guard fails the build if any registered schema is not consumed by ``core/config``:
+for every entry in ``R.config_schemas`` it asserts (a) the resolution helper can reach
+it and (b) selecting that model yields a *typed* instance of exactly that schema.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import symfluence  # noqa: F401 - triggers bootstrap + config-schema registration
+import symfluence.core.config.models.model_configs  # noqa: F401 - ensures bridge ran
+from symfluence.core.config.models.model_configs import ModelConfig
+from symfluence.core.registries import R
+from symfluence.models.config_resolution import get_config_schema
+
+REGISTERED_SCHEMAS = sorted(R.config_schemas.keys())
+
+
+def test_some_schemas_registered():
+    """Sanity: Phase B bridge populated the registry (guards against an empty sweep)."""
+    assert len(REGISTERED_SCHEMAS) >= 20, (
+        f"only {len(REGISTERED_SCHEMAS)} config schemas registered: {REGISTERED_SCHEMAS}"
+    )
+
+
+@pytest.mark.parametrize("name", REGISTERED_SCHEMAS)
+def test_registered_schema_is_resolvable(name):
+    """Every registered schema is reachable through the resolution helper."""
+    assert get_config_schema(name) is not None, (
+        f"{name} is in R.config_schemas but get_config_schema('{name}') returns None — "
+        "registered but unreadable by core/config (RTI item 26)."
+    )
+
+
+@pytest.mark.parametrize("name", REGISTERED_SCHEMAS)
+def test_registered_schema_is_applied(name):
+    """Selecting a model yields a typed instance of its registered schema.
+
+    Exercises the same path Phase B uses in production: ``auto_populate_model_configs``
+    auto-creates ``schema_cls()`` for each selected model. If a registered schema is
+    never applied here, it is accepted-but-unread.
+    """
+    expected = R.config_schemas.get(name)
+    mc = ModelConfig.model_validate({"HYDROLOGICAL_MODEL": name})
+    instance = mc.model_specific.get(name.lower())
+    assert isinstance(instance, expected), (
+        f"{name}: schema {expected!r} registered but auto_populate produced "
+        f"{type(instance)!r} for config.model.{name.lower()} — accepted but unread "
+        "(RTI item 26)."
+    )

--- a/tests/unit/core/test_mpi_utils.py
+++ b/tests/unit/core/test_mpi_utils.py
@@ -22,12 +22,20 @@ from symfluence.core.mpi_utils import find_mpirun
 
 MPI_MODELS = ["parflow", "clmparflow", "wrfhydro"]
 
+# The bundled-launcher tests create real, extension-less, executable files,
+# which only carry meaning on POSIX (Windows uses PATHEXT + has no exec bit).
+# Cross-platform behaviour is covered by the shutil.which-mocked tests below.
+posix_only = pytest.mark.skipif(
+    os.name == "nt", reason="POSIX exec-bit / extension-less launcher semantics"
+)
+
 
 def _make_executable(path):
     path.write_text("#!/bin/sh\n")
     path.chmod(path.stat().st_mode | stat.S_IXUSR)
 
 
+@posix_only
 def test_find_mpirun_prefers_bundled(tmp_path):
     """A launcher next to the executable wins over PATH."""
     _make_executable(tmp_path / "mpirun")
@@ -36,40 +44,55 @@ def test_find_mpirun_prefers_bundled(tmp_path):
     assert find_mpirun(exe) == str(tmp_path / "mpirun")
 
 
+@posix_only
 def test_find_mpirun_bundled_mpiexec(tmp_path):
     """mpiexec is accepted as a bundled launcher too."""
     _make_executable(tmp_path / "mpiexec")
     assert find_mpirun(tmp_path / "model.exe") == str(tmp_path / "mpiexec")
 
 
+@posix_only
+def test_non_executable_bundled_file_is_ignored(tmp_path, monkeypatch):
+    """A non-executable file named mpirun is not treated as a bundled launcher."""
+    (tmp_path / "mpirun").write_text("not executable")  # no +x bit
+    # Keep the real which for the bundled (path=<dir>) lookup so its exec-bit
+    # check is exercised; neutralise the PATH (path=None) lookup so the bundled
+    # file is the only candidate.
+    real_which = mpi_utils.shutil.which
+    monkeypatch.setattr(
+        mpi_utils.shutil,
+        "which",
+        lambda name, path=None: real_which(name, path=path) if path is not None else None,
+    )
+    assert find_mpirun(tmp_path / "model.exe") is None
+
+
 def test_find_mpirun_falls_back_to_path(tmp_path, monkeypatch):
     """With no bundled launcher, fall back to PATH via shutil.which."""
+    # Bundled lookup passes path=<dir> and finds nothing; PATH lookup passes no
+    # path and resolves mpirun.
     monkeypatch.setattr(
-        mpi_utils.shutil, "which", lambda name: "/usr/bin/mpirun" if name == "mpirun" else None
+        mpi_utils.shutil,
+        "which",
+        lambda name, path=None: "/usr/bin/mpirun" if (name == "mpirun" and path is None) else None,
     )
-    # exe dir has no launcher next to it
     assert find_mpirun(tmp_path / "model.exe") == "/usr/bin/mpirun"
 
 
 def test_find_mpirun_returns_none_when_absent(tmp_path, monkeypatch):
     """No bundled launcher and none on PATH -> None."""
-    monkeypatch.setattr(mpi_utils.shutil, "which", lambda name: None)
+    monkeypatch.setattr(mpi_utils.shutil, "which", lambda name, path=None: None)
     assert find_mpirun(tmp_path / "model.exe") is None
 
 
 def test_find_mpirun_no_exe_searches_path(monkeypatch):
     """Called without an executable, it searches PATH only."""
     monkeypatch.setattr(
-        mpi_utils.shutil, "which", lambda name: "/opt/mpiexec" if name == "mpiexec" else None
+        mpi_utils.shutil,
+        "which",
+        lambda name, path=None: "/opt/mpiexec" if name == "mpiexec" else None,
     )
     assert find_mpirun() == "/opt/mpiexec"
-
-
-def test_bundled_launcher_must_be_executable(tmp_path, monkeypatch):
-    """A non-executable file named mpirun is ignored (falls through to PATH)."""
-    (tmp_path / "mpirun").write_text("not executable")  # no +x bit
-    monkeypatch.setattr(mpi_utils.shutil, "which", lambda name: None)
-    assert find_mpirun(tmp_path / "model.exe") is None
 
 
 @pytest.mark.parametrize("model", MPI_MODELS)

--- a/tests/unit/core/test_mpi_utils.py
+++ b/tests/unit/core/test_mpi_utils.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Tests for MPI launcher discovery (`symfluence.core.mpi_utils`).
+
+Also guards against the regression that motivated this module: the ParFlow,
+CLM-ParFlow and WRF-Hydro runners import ``find_mpirun`` at module load, so a
+missing ``mpi_utils`` makes those models unimportable (which the old in-tree
+import loop silently swallowed at debug level).
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import stat
+
+import pytest
+
+from symfluence.core import mpi_utils
+from symfluence.core.mpi_utils import find_mpirun
+
+MPI_MODELS = ["parflow", "clmparflow", "wrfhydro"]
+
+
+def _make_executable(path):
+    path.write_text("#!/bin/sh\n")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def test_find_mpirun_prefers_bundled(tmp_path):
+    """A launcher next to the executable wins over PATH."""
+    _make_executable(tmp_path / "mpirun")
+    exe = tmp_path / "parflow.exe"
+    exe.write_text("")
+    assert find_mpirun(exe) == str(tmp_path / "mpirun")
+
+
+def test_find_mpirun_bundled_mpiexec(tmp_path):
+    """mpiexec is accepted as a bundled launcher too."""
+    _make_executable(tmp_path / "mpiexec")
+    assert find_mpirun(tmp_path / "model.exe") == str(tmp_path / "mpiexec")
+
+
+def test_find_mpirun_falls_back_to_path(tmp_path, monkeypatch):
+    """With no bundled launcher, fall back to PATH via shutil.which."""
+    monkeypatch.setattr(
+        mpi_utils.shutil, "which", lambda name: "/usr/bin/mpirun" if name == "mpirun" else None
+    )
+    # exe dir has no launcher next to it
+    assert find_mpirun(tmp_path / "model.exe") == "/usr/bin/mpirun"
+
+
+def test_find_mpirun_returns_none_when_absent(tmp_path, monkeypatch):
+    """No bundled launcher and none on PATH -> None."""
+    monkeypatch.setattr(mpi_utils.shutil, "which", lambda name: None)
+    assert find_mpirun(tmp_path / "model.exe") is None
+
+
+def test_find_mpirun_no_exe_searches_path(monkeypatch):
+    """Called without an executable, it searches PATH only."""
+    monkeypatch.setattr(
+        mpi_utils.shutil, "which", lambda name: "/opt/mpiexec" if name == "mpiexec" else None
+    )
+    assert find_mpirun() == "/opt/mpiexec"
+
+
+def test_bundled_launcher_must_be_executable(tmp_path, monkeypatch):
+    """A non-executable file named mpirun is ignored (falls through to PATH)."""
+    (tmp_path / "mpirun").write_text("not executable")  # no +x bit
+    monkeypatch.setattr(mpi_utils.shutil, "which", lambda name: None)
+    assert find_mpirun(tmp_path / "model.exe") is None
+
+
+@pytest.mark.parametrize("model", MPI_MODELS)
+def test_mpi_dependent_model_imports(model):
+    """ParFlow/CLM-ParFlow/WRF-Hydro import cleanly (regression: mpi_utils missing)."""
+    mod = importlib.import_module(f"symfluence.models.{model}")
+    assert callable(getattr(mod, "register", None))

--- a/tests/unit/core/test_supported_models.py
+++ b/tests/unit/core/test_supported_models.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""SupportedModels.is_valid is registry-derived, with no hardcoded model list.
+
+RTI review item 18: the SupportedModels.ALL / WITH_* tuples were hardcoded and
+had drifted from reality. Validity is now computed from the component registry —
+registration is the whitelist.
+"""
+
+from __future__ import annotations
+
+import symfluence  # noqa: F401 - import triggers bootstrap entry-point registration
+from symfluence.core.constants import SupportedModels
+from symfluence.core.registries import R
+
+
+def test_registered_model_is_valid_case_insensitive():
+    assert SupportedModels.is_valid("summa")
+    assert SupportedModels.is_valid("SUMMA")
+
+
+def test_unregistered_model_is_invalid():
+    assert not SupportedModels.is_valid("definitely_not_a_model")
+
+
+def test_is_valid_tracks_the_registry():
+    """Every registered runner is valid — derived, not hardcoded."""
+    for name in R.runners.keys():
+        assert SupportedModels.is_valid(name), f"{name} has a runner but is_valid is False"
+
+
+def test_schema_only_model_is_valid():
+    """A model registered via config schema (no runner), e.g. GNN, is still valid."""
+    assert SupportedModels.is_valid("gnn")
+
+
+def test_hardcoded_model_lists_are_removed():
+    """The drifted ALL / WITH_* tuples are gone (item 18)."""
+    for attr in ("ALL", "WITH_FORCING_ADAPTER", "WITH_PLOTTERS", "WITH_PRESETS"):
+        assert not hasattr(SupportedModels, attr), f"SupportedModels.{attr} should be removed"

--- a/tests/unit/models/test_entry_point_dogfood.py
+++ b/tests/unit/models/test_entry_point_dogfood.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Phase C guard 1 — in-tree models load through the entry-point plugin path.
+
+In-tree models register *only* via `symfluence.plugins` entry points declared in
+pyproject.toml (one `symfluence_<name> = "symfluence.models.<name>:register"` per
+model), the same contract external plugins (jHBV, jXAJ, …) use. There is no
+hard-coded model list — the source of truth is the set of `models/<name>` packages
+that define a top-level `register()`.
+
+These tests fail the build when that set drifts from the declared entry points, so a
+model can never be silently dropped from (or wrongly added to) the load path:
+* disk `register()` set  <->  pyproject entry points (install-independent),
+* every declared entry point resolves to a callable,
+* installed entry-point metadata matches (CI, fresh install).
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+import symfluence.models
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - project targets 3.11+
+    tomllib = None
+
+ENTRY_POINT_GROUP = "symfluence.plugins"
+MODEL_VALUE_PREFIX = "symfluence.models."
+_REGISTER_RE = re.compile(r"^def register\b", re.MULTILINE)
+
+
+def _disk_models() -> set[str]:
+    """Model packages on disk that define a top-level register() callable.
+
+    Source scan (no import), so optional-dependency models don't break collection.
+    Helper packages (base, adapters, config, …) have no register() and are excluded
+    naturally.
+    """
+    models_dir = Path(symfluence.models.__file__).resolve().parent
+    found: set[str] = set()
+    for init in models_dir.glob("*/__init__.py"):
+        if _REGISTER_RE.search(init.read_text(encoding="utf-8")):
+            found.add(init.parent.name)
+    return found
+
+
+def _find_pyproject() -> Path | None:
+    """Walk up from the installed package to locate the source pyproject.toml."""
+    for parent in Path(symfluence.__file__).resolve().parents:
+        candidate = parent / "pyproject.toml"
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _declared_in_tree_entry_points() -> dict[str, str]:
+    """Return {entry_point_name: value} for in-tree models declared in pyproject."""
+    pyproject = _find_pyproject()
+    if pyproject is None or tomllib is None:
+        pytest.skip("source pyproject.toml not locatable from installed package")
+    data = tomllib.loads(pyproject.read_text())
+    group = data.get("project", {}).get("entry-points", {}).get(ENTRY_POINT_GROUP, {})
+    return {name: val for name, val in group.items() if val.startswith(MODEL_VALUE_PREFIX)}
+
+
+def _model_from_value(value: str) -> str:
+    """'symfluence.models.summa:register' -> 'summa'."""
+    return value.split(":", 1)[0][len(MODEL_VALUE_PREFIX):]
+
+
+DISK_MODELS = _disk_models()
+
+
+# ----------------------------------------------------------------------
+# Drift guard: disk register() set must match declared entry points
+# ----------------------------------------------------------------------
+
+
+def test_entry_points_match_disk_models():
+    """Every models/<x> with a register() has an entry point, and vice versa."""
+    declared = {_model_from_value(v) for v in _declared_in_tree_entry_points().values()}
+    assert declared == DISK_MODELS, (
+        "drift between models/<x> packages defining register() and the "
+        '[project.entry-points."symfluence.plugins"] declarations.\n'
+        f"on disk but no entry point: {sorted(DISK_MODELS - declared)}\n"
+        f"entry point but no register(): {sorted(declared - DISK_MODELS)}"
+    )
+
+
+def test_entry_point_names_are_namespaced():
+    """In-tree entry-point names are prefixed to avoid clashing with external plugins."""
+    declared = _declared_in_tree_entry_points()
+    bad = [name for name in declared if not name.startswith("symfluence_")]
+    assert not bad, f"in-tree entry points must be namespaced 'symfluence_*': {bad}"
+
+
+def test_entry_point_targets_point_to_register():
+    """Each in-tree entry point targets the module's register() callable."""
+    declared = _declared_in_tree_entry_points()
+    bad = [v for v in declared.values() if not v.endswith(":register")]
+    assert not bad, f"in-tree entry points must target ':register': {bad}"
+
+
+def test_disk_models_nonempty():
+    """Sanity: the disk scan actually finds models (guards against a broken scan)."""
+    assert len(DISK_MODELS) >= 20, f"only {len(DISK_MODELS)} model register()s found on disk"
+
+
+# ----------------------------------------------------------------------
+# Contract: each importable model exposes a callable register()
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("model", sorted(DISK_MODELS))
+def test_model_exposes_register(model):
+    """Each in-tree model's __init__ exposes a zero-arg callable register().
+
+    Optional heavy deps may block a model's import; that is an environment
+    limitation, not a contract violation, so we skip rather than fail.
+    """
+    try:
+        mod = importlib.import_module(f"symfluence.models.{model}")
+    except Exception as exc:  # noqa: BLE001 - optional model dependency
+        pytest.skip(f"{model} not importable in this environment: {exc}")
+    assert callable(getattr(mod, "register", None)), (
+        f"symfluence.models.{model}.register must be callable"
+    )
+
+
+# ----------------------------------------------------------------------
+# Registration actually populates the registry, and is idempotent
+# ----------------------------------------------------------------------
+
+
+def test_representative_models_register_into_R():
+    """After import, representative in-tree models are present in the registry.
+
+    SUMMA, FUSE, GR and VIC all register a result_extractor and have no exotic
+    runtime dependencies, so they are reliably available via the entry-point path.
+    """
+    import symfluence  # noqa: F401 - triggers bootstrap entry-point discovery
+    from symfluence.core.registries import R
+
+    for name in ("SUMMA", "FUSE", "GR", "VIC"):
+        assert R.result_extractors.get(name) is not None, f"{name} not registered"
+
+
+def test_register_is_idempotent():
+    """Calling a model's register() twice leaves a single, stable registry entry."""
+    from symfluence.core.registries import R
+
+    summa = importlib.import_module("symfluence.models.summa")
+    summa.register()
+    first = R.result_extractors.get("SUMMA")
+    summa.register()
+    second = R.result_extractors.get("SUMMA")
+    assert first is second is not None
+
+
+# ----------------------------------------------------------------------
+# Installed entry-point metadata matches disk (CI fresh install; skips locally)
+# ----------------------------------------------------------------------
+
+
+def test_installed_entry_points_match_disk():
+    """Installed metadata exposes exactly the in-tree models found on disk.
+
+    Skips when the package has not been (re)installed since the entry points were
+    declared — the only safe local state for an editable install of a worktree.
+    """
+    from importlib.metadata import entry_points
+
+    eps = [
+        ep
+        for ep in entry_points(group=ENTRY_POINT_GROUP)
+        if ep.value.startswith(MODEL_VALUE_PREFIX)
+    ]
+    if not eps:
+        pytest.skip("in-tree entry points not in installed metadata; reinstall to test")
+
+    # Parity is on declared names — no import needed, so optional-dependency
+    # models (e.g. MPI/GPU runners absent on this host) don't break it.
+    declared = {_model_from_value(ep.value) for ep in eps}
+    assert declared == DISK_MODELS, (
+        "installed entry-point metadata is out of sync with the on-disk register() set; "
+        "reinstall (`pip install -e .`).\n"
+        f"metadata only: {sorted(declared - DISK_MODELS)}\n"
+        f"disk only: {sorted(DISK_MODELS - declared)}"
+    )
+
+    # Loadability: each EP that *can* import resolves to a callable. Skip models
+    # whose optional dependencies are missing in this environment.
+    for ep in eps:
+        try:
+            fn = ep.load()  # imports module + resolves :register
+        except ImportError:
+            continue
+        assert callable(fn), f"{ep.name} -> {ep.value} did not resolve to a callable"

--- a/tests/unit/models/test_model_discovery.py
+++ b/tests/unit/models/test_model_discovery.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""model_packages_with: disk discovery of per-model side-modules.
+
+Replaces the hardcoded SupportedModels.WITH_FORCING_ADAPTER / WITH_PRESETS lists
+(RTI review item 18). These submodules register themselves on import, so the set
+of models that have them is read from the source tree rather than a registry they
+populate — and is therefore always in sync.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import symfluence.models
+from symfluence.models import model_packages_with
+
+
+def test_forcing_adapter_discovery_includes_watflood():
+    """watflood has a forcing_adapter.py but was missing from the old list (drift fix)."""
+    pkgs = model_packages_with("forcing_adapter")
+    assert {"summa", "fuse", "watflood"} <= set(pkgs)
+    assert pkgs == tuple(sorted(pkgs))
+
+
+def test_preset_discovery_matches_disk():
+    """Preset discovery returns only models that actually ship init_preset.py."""
+    pkgs = model_packages_with("init_preset")
+    assert {"summa", "fuse"} <= set(pkgs)
+    models_dir = Path(symfluence.models.__file__).resolve().parent
+    for name in pkgs:
+        assert (models_dir / name / "init_preset.py").is_file()
+
+
+def test_unknown_submodule_returns_empty():
+    assert model_packages_with("definitely_not_a_submodule") == ()

--- a/tools/quality/broad_exception_allowlist.txt
+++ b/tools/quality/broad_exception_allowlist.txt
@@ -786,7 +786,7 @@ src/symfluence/models/hype/preprocessor.py:HYPEPreProcessor.__init__:except Exce
 src/symfluence/models/hype/preprocessor.py:HYPEPreProcessor.__init__:except Exception:  # noqa: BLE001
 src/symfluence/models/hype/preprocessor.py:HYPEPreProcessor._create_qobs_file:except Exception as e:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/hype/visualizer.py:visualize_hype:except Exception as e:  # noqa: BLE001 — model execution resilience
-src/symfluence/models/ignacio/__init__.py:<module>:except Exception:  # noqa: BLE001 — optional dependency
+src/symfluence/models/ignacio/__init__.py:register:except Exception:  # noqa: BLE001 — optional dependency
 src/symfluence/models/ignacio/calibration/parameter_manager.py:IGNACIOParameterManager.update_model_files:except Exception as e:  # noqa: BLE001 — calibration resilience
 src/symfluence/models/ignacio/calibration/worker.py:IGNACIOWorker._compute_spatial_metrics:except Exception as e:  # noqa: BLE001 — calibration resilience
 src/symfluence/models/ignacio/calibration/worker.py:IGNACIOWorker.apply_parameters:except Exception as e:  # noqa: BLE001 — calibration resilience


### PR DESCRIPTION
## Pure entry-point model loading + registry integrity guards (B4 + Phase C)

Stacked on Phase B (#139, merged). Completes the in-tree model load-path migration:
in-tree models now register through the **same** `symfluence.plugins` entry-point
contract external plugins use — a single, non-privileged load path with no hard-coded
model list — and two guards keep it honest.

### Commits
- **`7851d970` — pure entry-point loading (B4).** Each model exposes a zero-arg
  `register()` (wrapping its existing `model_manifest` call; top-level class imports
  preserved so cross-package importers keep working), declared as
  `symfluence_<name> = "symfluence.models.<name>:register"` in pyproject.toml.
  `models/__init__.py` no longer carries an import loop or a `_model_names` list —
  registration happens only via bootstrap entry-point discovery. `_discover_plugins`
  logs a loud error when zero in-tree models are discovered (stale-install signal) and
  drops optional-dependency `ImportError` to debug so MPI/GPU models don't spam logs.
- **`8746c611` — Phase C item-26 guard.** `tests/unit/config/test_config_schema_consumed.py`
  asserts every `R.config_schemas` entry is resolvable *and* applied as a typed instance
  by `auto_populate_model_configs` — no schema accepted-but-unread.
- **`6079d329` — fix missing `mpi_utils.find_mpirun`.** ParFlow/CLM-ParFlow/WRF-Hydro
  imported `symfluence.core.mpi_utils.find_mpirun`, which never existed (added in
  94f36a05, 2026-03-04, without the module) — leaving those 3 models unimportable for
  ~3 months, silently swallowed by the old import loop. Adds the module + test. Also
  fixes an over-broad `mpi_*` `.gitignore` rule that was hiding the new source file
  (root-causing a footgun previously patched one-off for `mpi_persistent.py`).

Phase C guard 1 (disk `register()` set ↔ pyproject entry points, install-independent
drift guard) is the reworked `tests/unit/models/test_entry_point_dogfood.py` in `7851d970`.

### Verification
- Full unit suite: **5869 passed / 42 skipped / 0 failed** (with the package installed
  editable — true pure entry-point loading, no fallback). The 3 MPI models now run
  (skips 45 → 42).
- Guard files: 112 passed, 0 skips; entry-point drift detection confirmed.
- All 31 in-tree models register via the entry-point path; hatchling emits all 31 entry
  points into wheel metadata. `ruff` / `mypy` / `bandit` / broad-except clean.

### Notes / out of scope
- `IN_TREE_CONFIG_SCHEMAS` stays a central registration bridge: config schemas are
  *defined* centrally in `core/config/models/`, so central registration is the natural
  home (unlike runners, which live in model packages). The item-26 guard covers the risk.

---
Repo and code assistance from [Claude](https://claude.ai) (Anthropic).
