### PR TITLE
fix(security): Tier 2 security cluster — GUI bind, TauDEM shell, safe extract (items 12/13/14)

### DIFF
--- a/src/symfluence/cli/argument_parser.py
+++ b/src/symfluence/cli/argument_parser.py
@@ -685,6 +685,10 @@ For more help on a specific command:
         )
         launch_parser.add_argument('--port', type=int, default=5006,
                                    help='Server port (default: 5006)')
+        launch_parser.add_argument('--address', type=str, default='127.0.0.1', metavar='HOST',
+                                   help='Interface to bind (default: 127.0.0.1, local only). '
+                                        'A non-loopback value such as 0.0.0.0 exposes the GUI '
+                                        'on the network.')
         launch_parser.add_argument('--no-browser', action='store_true', dest='no_browser',
                                    help='Do not auto-open a browser tab')
         launch_parser.add_argument('--demo', type=str, default=None, metavar='NAME',

--- a/src/symfluence/cli/commands/gui_commands.py
+++ b/src/symfluence/cli/commands/gui_commands.py
@@ -44,8 +44,15 @@ class GUICommands(BaseCommand):
         port = BaseCommand.get_arg(args, 'port', 5006)
         no_browser = BaseCommand.get_arg(args, 'no_browser', False)
         demo = BaseCommand.get_arg(args, 'demo', None)
+        address = BaseCommand.get_arg(args, 'address', '127.0.0.1')
 
-        BaseCommand._console.info(f"Launching SYMFLUENCE GUI on port {port}...")
+        from symfluence.gui import is_loopback_address
+
+        BaseCommand._console.info(f"Launching SYMFLUENCE GUI on {address}:{port}...")
+        if not is_loopback_address(address):
+            BaseCommand._console.indent(
+                f"Warning: binding to {address} exposes the GUI on the network."
+            )
         if demo:
             BaseCommand._console.indent(f"Demo mode: {demo}")
         if config_path:
@@ -56,6 +63,7 @@ class GUICommands(BaseCommand):
             port=port,
             show=not no_browser,
             demo=demo,
+            address=address,
         )
 
         return ExitCode.SUCCESS

--- a/src/symfluence/core/archive_extraction.py
+++ b/src/symfluence/core/archive_extraction.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Safe archive extraction guarding against path traversal (CVE-2007-4559 family).
+
+``zipfile.ZipFile.extractall`` and ``tarfile.TarFile.extractall`` do not, by
+default, stop an archive member from writing outside the destination directory
+via an absolute path, a ``..`` traversal, or (for tar) a symlink whose target
+escapes the destination. These helpers validate every member's resolved
+destination *before* extracting, then extract members individually, and replace
+the bare ``extractall`` calls across the data handlers.
+
+The tar ``filter='data'`` argument (Python 3.11.4+/3.12+) is used as additional
+defense in depth where available, but correctness does not depend on it — the
+containment checks here are version-independent.
+"""
+
+from __future__ import annotations
+
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+from typing import Iterable, Optional, Union
+
+__all__ = ["ArchiveExtractionError", "safe_zip_extract", "safe_tar_extract"]
+
+
+class ArchiveExtractionError(Exception):
+    """Raised when an archive member would extract outside the destination."""
+
+
+def _resolved_within(dest: Path, name: str) -> bool:
+    """True if *name*, resolved under *dest*, stays inside *dest*."""
+    if Path(name).is_absolute():
+        return False
+    try:
+        (dest / name).resolve().relative_to(dest.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def safe_zip_extract(
+    zf: zipfile.ZipFile,
+    dest: Union[str, Path],
+    members: Optional[Iterable[str]] = None,
+) -> None:
+    """Extract *zf* into *dest*, rejecting any member that escapes *dest*."""
+    dest = Path(dest)
+    names = list(members) if members is not None else zf.namelist()
+    for name in names:
+        if not _resolved_within(dest, name):
+            raise ArchiveExtractionError(
+                f"Refusing to extract unsafe zip member {name!r}: escapes {dest}"
+            )
+    for name in names:
+        zf.extract(name, dest)
+
+
+def safe_tar_extract(
+    tar: tarfile.TarFile,
+    dest: Union[str, Path],
+    members: Optional[Iterable[tarfile.TarInfo]] = None,
+) -> None:
+    """Extract *tar* into *dest*, rejecting members or links that escape *dest*."""
+    dest = Path(dest)
+    infos = list(members) if members is not None else tar.getmembers()
+    for info in infos:
+        if not _resolved_within(dest, info.name):
+            raise ArchiveExtractionError(
+                f"Refusing to extract unsafe tar member {info.name!r}: escapes {dest}"
+            )
+        if info.issym() or info.islnk():
+            # A link's target must also stay within dest (resolved relative to the
+            # link's own directory).
+            link_dir = (dest / info.name).parent
+            if Path(info.linkname).is_absolute():
+                raise ArchiveExtractionError(
+                    f"Refusing absolute link target {info.linkname!r} for {info.name!r}"
+                )
+            try:
+                (link_dir / info.linkname).resolve().relative_to(dest.resolve())
+            except ValueError:
+                raise ArchiveExtractionError(
+                    f"Refusing link {info.name!r} -> {info.linkname!r}: escapes {dest}"
+                ) from None
+    for info in infos:
+        if sys.version_info >= (3, 12):
+            tar.extract(info, dest, filter="data")
+        else:
+            tar.extract(info, dest)

--- a/src/symfluence/data/acquisition/handlers/aridity_index.py
+++ b/src/symfluence/data/acquisition/handlers/aridity_index.py
@@ -145,13 +145,15 @@ class AridityIndexAcquirer(BaseAcquisitionHandler, RetryMixin):
         self.logger.info("Extracting archive...")
         try:
             with zipfile.ZipFile(zip_path, 'r') as zf:
-                zf.extractall(cache_dir)
+                from symfluence.core.archive_extraction import safe_zip_extract
+                safe_zip_extract(zf, cache_dir)
             # Also extract any nested zips
             for nested_zip in cache_dir.rglob("*.zip"):
                 if nested_zip != zip_path:
                     try:
                         with zipfile.ZipFile(nested_zip, 'r') as zf:
-                            zf.extractall(nested_zip.parent)
+                            from symfluence.core.archive_extraction import safe_zip_extract
+                            safe_zip_extract(zf, nested_zip.parent)
                     except zipfile.BadZipFile:
                         pass
         except zipfile.BadZipFile:

--- a/src/symfluence/data/acquisition/handlers/glacier.py
+++ b/src/symfluence/data/acquisition/handlers/glacier.py
@@ -253,7 +253,8 @@ class GlacierAcquirer(BaseAcquisitionHandler):
             # Extract shapefile from zip
             import zipfile
             with zipfile.ZipFile(zip_path, 'r') as zf:
-                zf.extractall(cache_dir)
+                from symfluence.core.archive_extraction import safe_zip_extract
+                safe_zip_extract(zf, cache_dir)
 
             # Find the extracted shapefile
             for shp_file in cache_dir.glob(f"RGI2000-v7.0-G-{region_id:02d}*.shp"):

--- a/src/symfluence/data/acquisition/handlers/glhymps.py
+++ b/src/symfluence/data/acquisition/handlers/glhymps.py
@@ -193,7 +193,8 @@ class GLHYMPSAcquirer(BaseAcquisitionHandler):
 
                 self.logger.info("Download complete, extracting...")
                 with zipfile.ZipFile(zip_path, 'r') as zf:
-                    zf.extractall(cache_dir)
+                    from symfluence.core.archive_extraction import safe_zip_extract
+                    safe_zip_extract(zf, cache_dir)
 
                 zip_path.unlink(missing_ok=True)
 

--- a/src/symfluence/data/acquisition/handlers/glwd.py
+++ b/src/symfluence/data/acquisition/handlers/glwd.py
@@ -124,7 +124,8 @@ class GLWDAcquirer(BaseAcquisitionHandler, RetryMixin):
         self.logger.info("Extracting archive...")
         try:
             with zipfile.ZipFile(zip_path, 'r') as zf:
-                zf.extractall(cache_dir)
+                from symfluence.core.archive_extraction import safe_zip_extract
+                safe_zip_extract(zf, cache_dir)
         except zipfile.BadZipFile:
             self.logger.error("Downloaded file is not a valid zip")
             zip_path.unlink(missing_ok=True)

--- a/src/symfluence/data/acquisition/handlers/hydrolakes.py
+++ b/src/symfluence/data/acquisition/handlers/hydrolakes.py
@@ -206,7 +206,8 @@ class HydroLAKESAcquirer(BaseAcquisitionHandler):
 
             # Extract shapefile components
             with zipfile.ZipFile(zip_path, "r") as zf:
-                zf.extractall(cache_dir)
+                from symfluence.core.archive_extraction import safe_zip_extract
+                safe_zip_extract(zf, cache_dir)
 
             # Remove zip to save space
             zip_path.unlink(missing_ok=True)

--- a/src/symfluence/data/acquisition/handlers/hydrosheds.py
+++ b/src/symfluence/data/acquisition/handlers/hydrosheds.py
@@ -197,7 +197,8 @@ class HydroSHEDSAcquirer(BaseAcquisitionHandler, RetryMixin):
 
                 self.logger.info(f"Extracting {description}")
                 with zipfile.ZipFile(zip_path, 'r') as zf:
-                    zf.extractall(output_dir)
+                    from symfluence.core.archive_extraction import safe_zip_extract
+                    safe_zip_extract(zf, output_dir)
 
                 self.logger.info(f"Downloaded and extracted {description}")
             finally:

--- a/src/symfluence/data/acquisition/handlers/merit_basins.py
+++ b/src/symfluence/data/acquisition/handlers/merit_basins.py
@@ -190,7 +190,8 @@ class MERITBasinsAcquirer(BaseAcquisitionHandler, RetryMixin):
 
                 self.logger.info(f"Extracting {description}")
                 with zipfile.ZipFile(zip_path, 'r') as zf:
-                    zf.extractall(output_dir)
+                    from symfluence.core.archive_extraction import safe_zip_extract
+                    safe_zip_extract(zf, output_dir)
 
                 self.logger.info(f"Downloaded and extracted {description}")
             finally:

--- a/src/symfluence/data/acquisition/handlers/wokam.py
+++ b/src/symfluence/data/acquisition/handlers/wokam.py
@@ -169,7 +169,8 @@ class WOKAMAcquirer(BaseAcquisitionHandler, RetryMixin):
         self.logger.info("Download complete, extracting...")
         try:
             with zipfile.ZipFile(zip_path, 'r') as zf:
-                zf.extractall(cache_dir)
+                from symfluence.core.archive_extraction import safe_zip_extract
+                safe_zip_extract(zf, cache_dir)
         except zipfile.BadZipFile:
             self.logger.error("Downloaded file is not a valid zip archive")
             zip_path.unlink(missing_ok=True)

--- a/src/symfluence/data/acquisition/handlers/worldclim.py
+++ b/src/symfluence/data/acquisition/handlers/worldclim.py
@@ -137,7 +137,8 @@ class WorldClimAcquirer(BaseAcquisitionHandler, RetryMixin):
             if not extract_dir.exists():
                 self.logger.info(f"  Extracting {zip_name}")
                 with zipfile.ZipFile(zip_path, 'r') as zf:
-                    zf.extractall(extract_dir)
+                    from symfluence.core.archive_extraction import safe_zip_extract
+                    safe_zip_extract(zf, extract_dir)
 
             for month in range(1, 13):
                 out_name = f"wc2.1_30s_{var}_{month:02d}.tif"

--- a/src/symfluence/data/observation/handlers/gleam.py
+++ b/src/symfluence/data/observation/handlers/gleam.py
@@ -117,11 +117,13 @@ class GLEAMETHandler(BaseObservationHandler):
         if archive_path.suffix in {".tar", ".gz", ".tgz"} or archive_path.name.endswith(".tar.gz"):
             with tarfile.open(archive_path, "r:*") as tar:
                 # nosec B202 - Extracting from trusted GLEAM data archive
-                tar.extractall(path=target_dir, filter='data')
+                from symfluence.core.archive_extraction import safe_tar_extract
+                safe_tar_extract(tar, target_dir)
             return
         if archive_path.suffix == ".zip":
             with zipfile.ZipFile(archive_path, "r") as zf:
-                zf.extractall(path=target_dir)  # nosec B202 - Extracting from trusted GLEAM data archive
+                from symfluence.core.archive_extraction import safe_zip_extract
+                safe_zip_extract(zf, target_dir)
 
     def _select_et_variable(self, ds: xr.Dataset) -> Optional[str]:
         preferred = self._get_config_value(lambda: None, default=None, dict_key='ET_VARIABLE_NAME')

--- a/src/symfluence/geospatial/geofabric/processors/taudem_executor.py
+++ b/src/symfluence/geospatial/geofabric/processors/taudem_executor.py
@@ -17,11 +17,32 @@ Refactored from geofabric_utils.py (2026-01-01)
 """
 
 import os
+import re
 import shlex
 import shutil
 import subprocess
 import time
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
+
+# A `module load` command must be run through a shell (``module`` is a shell
+# function, not a binary), which is otherwise an injection surface. We constrain
+# what the shell may run: module names must look like module names, and the
+# command being launched must be a known TauDEM executable. Everything is then
+# shlex-quoted and handed to ``bash -lc`` as an argv (shell=False).
+_MODULE_NAME_RE = re.compile(r"^[A-Za-z0-9._/+-]+$")
+
+#: Official TauDEM executable names SYMFLUENCE may launch under `module load`.
+_ALLOWED_TAUDEM_CMDS = frozenset({
+    "aread8", "areadinf", "catchhydrogeo", "catchoutlets", "connectdown",
+    "d8flowdir", "d8flowpathextremeup", "d8hdisttostrm",
+    "dinfavalanche", "dinfconcentration", "dinfdecayaccum", "dinfdistdown",
+    "dinfdistup", "dinfflowdir", "dinfrevaccum", "dinftranslimaccum",
+    "dinfupdependence", "dropanalysis", "gagewatershed", "gridnet", "lengtharea",
+    "moveoutletstostrm", "moveoutletstostreams", "peukerdouglas",
+    "peukerdouglasstreamdef", "pitremove", "slopearea", "slopeavedown",
+    "streamnet", "threshold", "twi",
+})
 
 
 class TauDEMExecutor:
@@ -162,6 +183,43 @@ class TauDEMExecutor:
 
         return parts
 
+    def _safe_module_load_command(
+        self, command: str, run_cmd: Optional[str], has_mpi_prefix: bool
+    ) -> str:
+        """Validate and quote a ``module load ... && <taudem>`` command for ``bash -lc``.
+
+        ``module load`` must run in a shell (``module`` is a shell function), so we
+        constrain what the shell may execute: module names must match a conservative
+        pattern and the launched command must be a known TauDEM executable. Every
+        token is shlex-quoted. Raises ``ValueError`` on anything outside the allowlists.
+        """
+        parts = command.split(" && ")
+        if len(parts) != 2:
+            raise ValueError(f"Unexpected module-load command shape: {command!r}")
+        module_part, actual_cmd = parts
+
+        mod_tokens = module_part.split()
+        if mod_tokens[:2] != ["module", "load"] or len(mod_tokens) < 3:
+            raise ValueError(f"Unexpected 'module load' clause: {module_part!r}")
+        for name in mod_tokens[2:]:
+            if not _MODULE_NAME_RE.match(name):
+                raise ValueError(f"Disallowed module name: {name!r}")
+
+        cmd_tokens = shlex.split(actual_cmd)
+        if not cmd_tokens:
+            raise ValueError("Empty TauDEM command after 'module load'")
+        if not ({Path(t).name for t in cmd_tokens} & _ALLOWED_TAUDEM_CMDS):
+            raise ValueError(f"No allowlisted TauDEM command in: {actual_cmd!r}")
+
+        safe_module = "module load " + " ".join(shlex.quote(n) for n in mod_tokens[2:])
+        safe_actual = " ".join(shlex.quote(t) for t in cmd_tokens)
+        if has_mpi_prefix or not run_cmd:
+            return f"{safe_module} && {safe_actual}"
+        return (
+            f"{safe_module} && {shlex.quote(run_cmd)} "
+            f"-n {int(self.num_processes)} {safe_actual}"
+        )
+
     def run_command(self, command: str, retry: bool = True) -> None:
         """
         Run a TauDEM command with MPI support and retry logic.
@@ -202,20 +260,16 @@ class TauDEMExecutor:
                     # module load is a shell function and requires shell=True
                     needs_shell = "module load" in command
 
-                    if run_cmd and needs_shell:
-                        # Handle commands with module load specially - requires shell=True
-                        # Security note: module load commands require shell execution
-                        # as 'module' is a shell function, not an executable
-                        parts = command.split(" && ")
-                        if len(parts) == 2:
-                            module_part = parts[0]
-                            actual_cmd = parts[1]
-                            if not has_mpi_prefix:
-                                full_command: Union[str, List[str]] = f"{module_part} && {run_cmd} -n {self.num_processes} {actual_cmd}"
-                            else:
-                                full_command = command
-                        else:
-                            full_command = command
+                    if needs_shell:
+                        # `module load` requires a shell (module is a shell
+                        # function, not a binary). Instead of interpolating
+                        # untrusted tokens into a shell=True string, build a
+                        # validated, fully shlex-quoted command and run it via an
+                        # explicit `bash -lc` argv with shell=False.
+                        shell_cmd = self._safe_module_load_command(
+                            command, run_cmd, has_mpi_prefix
+                        )
+                        full_command: Union[str, List[str]] = ["bash", "-lc", shell_cmd]
                     elif run_cmd and not has_mpi_prefix:
                         # Add MPI prefix for regular commands - use list format
                         # Export LD_LIBRARY_PATH to MPI child processes so TauDEM
@@ -241,7 +295,7 @@ class TauDEMExecutor:
                     result = subprocess.run(
                         full_command,
                         check=True,
-                        shell=needs_shell,  # nosec B602 - shell controlled by MPI config
+                        shell=False,
                         capture_output=True,
                         text=True
                     )

--- a/src/symfluence/gui/__init__.py
+++ b/src/symfluence/gui/__init__.py
@@ -11,8 +11,16 @@ Install dependencies: pip install "symfluence[gui]"
 Launch: symfluence gui launch
 """
 
+#: Bind addresses that keep the GUI reachable only from the local machine.
+_LOOPBACK_ADDRESSES = frozenset({"127.0.0.1", "localhost", "::1"})
 
-def serve_app(config_path=None, port=5006, show=True, demo=None):
+
+def is_loopback_address(address: str) -> bool:
+    """Return True if *address* keeps the server local-only (loopback)."""
+    return address in _LOOPBACK_ADDRESSES
+
+
+def serve_app(config_path=None, port=5006, show=True, demo=None, address="127.0.0.1"):
     """
     Build and serve the SYMFLUENCE GUI as a Panel web application.
 
@@ -25,6 +33,7 @@ def serve_app(config_path=None, port=5006, show=True, demo=None):
         port: Server port (default 5006).
         show: Open a browser tab automatically.
         demo: Optional demo name (e.g. 'bow') to load a built-in config.
+        address: Interface to bind (default 127.0.0.1, loopback only).
     """
     try:
         import panel  # noqa: F401
@@ -35,7 +44,7 @@ def serve_app(config_path=None, port=5006, show=True, demo=None):
         ) from None
 
     from .server import _serve_app
-    _serve_app(config_path=config_path, port=port, show=show, demo=demo)
+    _serve_app(config_path=config_path, port=port, show=show, demo=demo, address=address)
 
 
-__all__ = ['serve_app']
+__all__ = ['serve_app', 'is_loopback_address']

--- a/src/symfluence/gui/server.py
+++ b/src/symfluence/gui/server.py
@@ -12,12 +12,17 @@ its own instance with the Panel event loop running for periodic
 log flushing.
 """
 
+import logging
+
 import panel as pn
 
+from . import is_loopback_address
 from .app import GUI_THEME_CSS, SymfluenceApp
 
+logger = logging.getLogger(__name__)
 
-def _serve_app(config_path=None, port=5006, show=True, demo=None):
+
+def _serve_app(config_path=None, port=5006, show=True, demo=None, address="127.0.0.1"):
     """
     Build and serve the SYMFLUENCE GUI as a Panel web application.
 
@@ -26,6 +31,9 @@ def _serve_app(config_path=None, port=5006, show=True, demo=None):
         port: Port number for the web server (default 5006)
         show: Whether to auto-open a browser tab (default True)
         demo: Optional demo name (e.g. 'bow') to load on startup
+        address: Network interface to bind. Defaults to 127.0.0.1 (loopback);
+            the GUI is reachable only from the local machine. A non-loopback
+            value (e.g. 0.0.0.0) exposes it on the network and is opt-in.
     """
     # Pre-import model modules on the main thread so config adapters
     # are registered before the Tornado daemon thread starts.
@@ -52,9 +60,24 @@ def _serve_app(config_path=None, port=5006, show=True, demo=None):
 
         return template
 
+    serve_kwargs = {}
+    if not is_loopback_address(address):
+        # Non-loopback bind exposes the GUI on the network; restrict the
+        # websocket origin to the bound host:port and warn loudly.
+        serve_kwargs['websocket_origin'] = f"{address}:{port}"
+        logger.warning(
+            "SYMFLUENCE GUI is binding to %s:%s, which is reachable from other "
+            "machines on the network. Use the default 127.0.0.1 unless you intend "
+            "to expose it.",
+            address,
+            port,
+        )
+
     pn.serve(
         {'/': create_app},
         port=port,
+        address=address,
         show=show,
         title='SYMFLUENCE',
+        **serve_kwargs,
     )

--- a/tests/unit/core/test_archive_extraction.py
+++ b/tests/unit/core/test_archive_extraction.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""safe_zip_extract / safe_tar_extract reject path traversal (CVE-2007-4559 family)."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+import zipfile
+
+import pytest
+
+from symfluence.core.archive_extraction import (
+    ArchiveExtractionError,
+    safe_tar_extract,
+    safe_zip_extract,
+)
+
+
+def _add_tar_file(tf: tarfile.TarFile, name: str, data: bytes = b"x") -> None:
+    info = tarfile.TarInfo(name)
+    info.size = len(data)
+    tf.addfile(info, io.BytesIO(data))
+
+
+# ---- zip ----------------------------------------------------------------
+
+
+def test_zip_benign_extracts(tmp_path):
+    archive = tmp_path / "a.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("sub/ok.txt", b"hi")
+    dest = tmp_path / "out"
+    dest.mkdir()
+    with zipfile.ZipFile(archive) as zf:
+        safe_zip_extract(zf, dest)
+    assert (dest / "sub" / "ok.txt").read_bytes() == b"hi"
+
+
+@pytest.mark.parametrize("evil", ["../escape.txt", "a/../../escape.txt"])
+def test_zip_traversal_rejected(tmp_path, evil):
+    archive = tmp_path / "evil.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr(evil, b"x")
+    dest = tmp_path / "out"
+    dest.mkdir()
+    with zipfile.ZipFile(archive) as zf:
+        with pytest.raises(ArchiveExtractionError):
+            safe_zip_extract(zf, dest)
+    assert not (tmp_path / "escape.txt").exists()
+
+
+# ---- tar ----------------------------------------------------------------
+
+
+def test_tar_benign_extracts(tmp_path):
+    archive = tmp_path / "a.tar"
+    with tarfile.open(archive, "w") as tf:
+        _add_tar_file(tf, "sub/ok.txt", b"hi")
+    dest = tmp_path / "out"
+    dest.mkdir()
+    with tarfile.open(archive) as tf:
+        safe_tar_extract(tf, dest)
+    assert (dest / "sub" / "ok.txt").read_bytes() == b"hi"
+
+
+def test_tar_traversal_rejected(tmp_path):
+    archive = tmp_path / "evil.tar"
+    with tarfile.open(archive, "w") as tf:
+        _add_tar_file(tf, "../escape.txt")
+    dest = tmp_path / "out"
+    dest.mkdir()
+    with tarfile.open(archive) as tf:
+        with pytest.raises(ArchiveExtractionError):
+            safe_tar_extract(tf, dest)
+    assert not (tmp_path / "escape.txt").exists()
+
+
+def test_tar_symlink_escape_rejected(tmp_path):
+    archive = tmp_path / "link.tar"
+    with tarfile.open(archive, "w") as tf:
+        info = tarfile.TarInfo("link")
+        info.type = tarfile.SYMTYPE
+        info.linkname = "../../outside"
+        tf.addfile(info)
+    dest = tmp_path / "out"
+    dest.mkdir()
+    with tarfile.open(archive) as tf:
+        with pytest.raises(ArchiveExtractionError):
+            safe_tar_extract(tf, dest)

--- a/tests/unit/geospatial/test_taudem_security.py
+++ b/tests/unit/geospatial/test_taudem_security.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""TauDEM `module load` execution is hardened against shell injection (review item 13).
+
+The module-load path must run through a shell, so the command is validated (module
+names + an allowlisted TauDEM executable), fully shlex-quoted, and executed via an
+explicit ``bash -lc`` argv with ``shell=False`` instead of ``shell=True`` on a raw
+interpolated string.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from symfluence.geospatial.geofabric.processors import taudem_executor
+from symfluence.geospatial.geofabric.processors.taudem_executor import TauDEMExecutor
+
+
+def _executor(num_processes=4):
+    return TauDEMExecutor(
+        {"NUM_PROCESSES": num_processes}, logging.getLogger("test"), "/opt/taudem"
+    )
+
+
+def test_valid_command_is_quoted_and_prefixed():
+    ex = _executor()
+    out = ex._safe_module_load_command(
+        "module load gdal taudem && pitremove -z dem.tif", "mpirun", has_mpi_prefix=False
+    )
+    assert out == "module load gdal taudem && mpirun -n 4 pitremove -z dem.tif"
+
+
+def test_already_prefixed_command_not_double_prefixed():
+    ex = _executor()
+    out = ex._safe_module_load_command(
+        "module load taudem && mpirun -n 4 pitremove -z dem.tif", "mpirun", has_mpi_prefix=True
+    )
+    assert out == "module load taudem && mpirun -n 4 pitremove -z dem.tif"
+
+
+def test_no_mpi_launcher_omits_prefix():
+    ex = _executor()
+    out = ex._safe_module_load_command(
+        "module load taudem && pitremove -z dem.tif", None, has_mpi_prefix=False
+    )
+    assert out == "module load taudem && pitremove -z dem.tif"
+
+
+def test_rejects_non_allowlisted_executable():
+    ex = _executor()
+    with pytest.raises(ValueError, match="allowlisted TauDEM"):
+        ex._safe_module_load_command(
+            "module load taudem && rm -rf /", "mpirun", has_mpi_prefix=False
+        )
+
+
+def test_rejects_injection_in_module_name():
+    ex = _executor()
+    with pytest.raises(ValueError, match="module name"):
+        ex._safe_module_load_command(
+            "module load evil;rm && pitremove -z dem.tif", "mpirun", has_mpi_prefix=False
+        )
+
+
+def test_injection_metacharacters_are_quoted_not_executed():
+    """A ';' smuggled into an argument is shlex-quoted, so it cannot chain a command."""
+    ex = _executor()
+    out = ex._safe_module_load_command(
+        "module load taudem && pitremove -z 'dem.tif; rm -rf /'", "mpirun", has_mpi_prefix=False
+    )
+    # The dangerous token is a single quoted argument, not a shell separator.
+    assert "'dem.tif; rm -rf /'" in out
+    assert out.count("&&") == 1
+
+
+def test_module_load_runs_via_bash_lc_without_shell():
+    """End-to-end: the module-load path uses ['bash','-lc',...] with shell=False."""
+    ex = _executor()
+    completed = MagicMock(stdout="", stderr="", returncode=0)
+    with patch.object(TauDEMExecutor, "_get_mpi_command", return_value="mpirun"), patch.object(
+        taudem_executor.subprocess, "run", return_value=completed
+    ) as mock_run:
+        ex.run_command("module load gdal && pitremove -z dem.tif", retry=False)
+
+    args, kwargs = mock_run.call_args
+    full_command = args[0]
+    assert full_command[:2] == ["bash", "-lc"]
+    assert kwargs["shell"] is False
+    assert "pitremove" in full_command[2]

--- a/tests/unit/gui/test_server_bind.py
+++ b/tests/unit/gui/test_server_bind.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""The Panel GUI binds loopback by default; non-loopback is opt-in (review item 12)."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from symfluence.gui import is_loopback_address
+
+# --- panel-free: the bind decision (always runs) -------------------------
+
+
+@pytest.mark.parametrize("addr", ["127.0.0.1", "localhost", "::1"])
+def test_loopback_addresses(addr):
+    assert is_loopback_address(addr) is True
+
+
+@pytest.mark.parametrize("addr", ["0.0.0.0", "192.168.1.5", "10.0.0.1", ""])  # nosec B104
+def test_non_loopback_addresses(addr):
+    assert is_loopback_address(addr) is False
+
+
+# --- integration: kwargs passed to pn.serve (needs Panel) ----------------
+
+
+def _call_serve(**kwargs):
+    """Run _serve_app with Panel fully mocked; return the pn.serve kwargs.
+
+    Skips when Panel (the optional [gui] extra) is not installed.
+    """
+    pytest.importorskip("panel")
+    from symfluence.gui import server
+
+    with patch.object(server, "pn", MagicMock()) as mock_pn:
+        server._serve_app(**kwargs)
+    _, serve_kwargs = mock_pn.serve.call_args
+    return serve_kwargs
+
+
+def test_default_binds_loopback():
+    serve_kwargs = _call_serve()
+    assert serve_kwargs["address"] == "127.0.0.1"
+    assert "websocket_origin" not in serve_kwargs
+
+
+def test_nonloopback_sets_websocket_origin_and_warns(caplog):
+    with caplog.at_level(logging.WARNING, logger="symfluence.gui.server"):
+        serve_kwargs = _call_serve(address="0.0.0.0", port=9999)  # nosec B104 - test input
+    assert serve_kwargs["address"] == "0.0.0.0"  # nosec B104
+    assert serve_kwargs["websocket_origin"] == "0.0.0.0:9999"  # nosec B104
+    assert any("reachable from other machines" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Tier 2 security cluster — review items 12, 13, 14

Closes the three Tier 2 security items from the RTI architectural review (§11.2),
each with the review's prescribed approach. One PR, one commit per item.

### Item 12 — web GUI binds loopback by default
`gui/server.py` called `pn.serve()` with no address, so Panel bound `0.0.0.0` — the GUI
was network-reachable the moment it started. Now defaults to `127.0.0.1`, threaded through
`serve_app`/`_serve_app` and a new `--address` CLI flag. A non-loopback bind is opt-in and,
when used, restricts `websocket_origin` to the bound host:port and logs a loud warning. The
loopback check is factored into `is_loopback_address` so it's testable without the optional
Panel dependency.

### Item 13 — TauDEM `module load` shell hardening
`taudem_executor.py` ran `subprocess.run(raw_fstring, shell=True)` for `module load`
commands — a shell-injection surface. The module-load path now routes through
`_safe_module_load_command`, which validates module names + requires an allowlisted TauDEM
executable, `shlex.quote`s every token, and runs via an explicit `["bash", "-lc", ...]`
argv with `shell=False`. Non-module argv paths are unchanged. Also fixes a latent
no-MPI + module-load case that fell through to `shlex.split`.

### Item 14 — safe archive extraction
The 11 `zipfile` `extractall` sites in the data handlers had no path-traversal protection
(CVE-2007-4559 family). New `core/archive_extraction.py` provides `safe_zip_extract` /
`safe_tar_extract`, which validate every member's resolved path stays within the destination
(and that tar link targets do too) before extracting. All 11 zip sites plus the one tar site
route through the helpers; the bare `extractall` calls and a stale `# nosec B202` are gone.

### Verification
- Full unit suite: **5897 passed / 44 skipped / 0 failed**.
- New tests: `tests/unit/core/test_archive_extraction.py` (traversal/symlink rejection),
  `tests/unit/geospatial/test_taudem_security.py` (allowlist, quoting, `bash -lc`/`shell=False`),
  `tests/unit/gui/test_server_bind.py` (loopback default + non-loopback warning).
- `ruff` / `mypy` / `bandit` (the B602 and B202 findings are removed) / broad-except guard clean.

---
Repo and code assistance from [Claude](https://claude.ai) (Anthropic).
