### PR TITLE
build: move JAX plugins + openai to optional dependencies (review item 15)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,15 +71,19 @@ dependencies = [
   "numexpr>=2.8.0,<3.0.0",
   "bottleneck>=1.3.0,<2.0.0",
   "networkx>=3.0.0,<4.0.0",
-  # AI/LLM integration
-  "openai>=1.0.0,<2.0.0",
   # CLI
   "rich>=13.0.0,<14.0.0",
   # Configuration models
   "pydantic>=2.0.0,<3.0.0",
   # Differentiable coupling framework
   "dcoupler>=0.2.0",
-  # JAX-based model plugins
+]
+
+[project.optional-dependencies]
+# JAX-based model plugins (Snow-17, SAC-SMA, Xinanjiang, HBV, HEC-HMS, TOPMODEL).
+# Optional: only needed to run those models, discovered via entry points at runtime.
+#   pip install "symfluence[jax]"
+jax = [
   "jsnow17>=0.1.0",
   "jsacsma>=0.1.0",
   "jxaj>=0.1.0",
@@ -87,8 +91,11 @@ dependencies = [
   "jhechms>=0.1.0",
   "jtopmodel>=0.1.0",
 ]
-
-[project.optional-dependencies]
+# LLM agent integration. Optional: only needed for `symfluence agent` features.
+#   pip install "symfluence[llm]"
+llm = [
+  "openai>=1.0.0,<2.0.0",
+]
 # GDAL Python bindings - optional, system GDAL installs are auto-detected.
 # Only needed for DEM slope/aspect generation and GeoTIFF metadata reading.
 # Install via: uv pip install "symfluence[gdal]", or rely on system install
@@ -131,6 +138,9 @@ test = [
   "pytest-cov>=4.0.0",
   "pytest-timeout>=2.0.0",
   "hypothesis>=6.0.0,<7.0.0",
+  # The test suite imports the JAX plugins and the LLM agent, so the full
+  # test extra pulls in those optional groups (the baseline install does not).
+  "symfluence[jax,llm]",
 ]
 # Documentation tools
 docs = [
@@ -165,7 +175,7 @@ hpc = [
 ]
 # All development dependencies
 all = [
-  "symfluence[r,dev,test,docs,notebook,gui,tui,alos]",
+  "symfluence[r,dev,test,docs,notebook,gui,tui,alos,jax,llm]",
 ]
 
 [project.scripts]

--- a/src/symfluence/agent/api_client.py
+++ b/src/symfluence/agent/api_client.py
@@ -14,9 +14,11 @@ from typing import Any, Dict, List, Optional
 
 try:
     from openai import APIConnectionError, AuthenticationError, BadRequestError, OpenAI, RateLimitError
-except ImportError:
-    print("Error: openai package not installed. Install it with: pip install openai>=1.0.0", file=sys.stderr)
-    sys.exit(1)
+except ImportError as exc:
+    raise ImportError(
+        "The SYMFLUENCE agent requires the openai package. "
+        'Install it with: pip install "symfluence[llm]"'
+    ) from exc
 
 from . import system_prompts
 

--- a/src/symfluence/optimization/parameter_managers/__init__.py
+++ b/src/symfluence/optimization/parameter_managers/__init__.py
@@ -56,12 +56,9 @@ def _register_parameter_managers():
 # Trigger registration on import
 _register_parameter_managers()
 
-# Re-export from canonical locations (avoids deprecation warnings for internal use)
-# Users who import directly from the stub modules will still see deprecation warnings
-from jhbv.calibration.parameter_manager import HBVParameterManager
-from jsacsma.calibration.parameter_manager import SacSmaParameterManager
-from jxaj.calibration.parameter_manager import XinanjiangParameterManager
-
+# Re-export in-tree parameter managers from their canonical locations.
+# (HBV / SAC-SMA / Xinanjiang come from the optional JAX plugins and are
+# re-exported lazily via __getattr__ below.)
 from symfluence.models.fuse.calibration.parameter_manager import FUSEParameterManager
 from symfluence.models.gnn.calibration.parameter_manager import MLParameterManager
 from symfluence.models.gr.calibration.parameter_manager import GRParameterManager
@@ -92,3 +89,31 @@ __all__ = [
     'GSFLOWParameterManager',
     'WATFLOODParameterManager',
 ]
+
+# HBV / SAC-SMA / Xinanjiang parameter managers live in the optional JAX model
+# plugins (the ``jax`` extra). Re-export them lazily (PEP 562) so importing this
+# package never requires the plugins, while
+# ``from ...parameter_managers import HBVParameterManager`` still works when they
+# are installed. Accessing one without the plugin raises a clear ImportError.
+_OPTIONAL_JAX_PARAM_MANAGERS = {
+    'HBVParameterManager': 'jhbv.calibration.parameter_manager',
+    'SacSmaParameterManager': 'jsacsma.calibration.parameter_manager',
+    'XinanjiangParameterManager': 'jxaj.calibration.parameter_manager',
+}
+
+
+def __getattr__(name):
+    """Lazily resolve the optional JAX-plugin parameter managers (PEP 562)."""
+    module_path = _OPTIONAL_JAX_PARAM_MANAGERS.get(name)
+    if module_path is not None:
+        import importlib
+
+        try:
+            module = importlib.import_module(module_path)
+        except ImportError as exc:
+            raise ImportError(
+                f"{name} is provided by the optional JAX model plugins. "
+                'Install them with: pip install "symfluence[jax]"'
+            ) from exc
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/unit/optimization/test_optional_param_managers.py
+++ b/tests/unit/optimization/test_optional_param_managers.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""The JAX-plugin parameter managers are re-exported lazily (review item 15).
+
+HBV / SAC-SMA / Xinanjiang parameter managers come from the optional ``jax`` extra.
+``symfluence.optimization.parameter_managers`` must import without them, while still
+exposing the names (PEP 562 ``__getattr__``) and giving a clear install hint when the
+plugin is absent.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from symfluence.optimization import parameter_managers
+
+
+def test_jax_param_manager_resolves_when_installed():
+    # The JAX plugins are present in the test environment (the `jax` extra).
+    assert isinstance(parameter_managers.HBVParameterManager, type)
+    assert isinstance(parameter_managers.XinanjiangParameterManager, type)
+
+
+def test_missing_plugin_raises_clear_install_hint(monkeypatch):
+    real_import = importlib.import_module
+
+    def fake_import(name, *args, **kwargs):
+        if name == "jsacsma.calibration.parameter_manager":
+            raise ImportError("No module named 'jsacsma'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    with pytest.raises(ImportError, match=r"symfluence\[jax\]"):
+        _ = parameter_managers.SacSmaParameterManager
+
+
+def test_unknown_attribute_raises_attribute_error():
+    with pytest.raises(AttributeError):
+        _ = parameter_managers.DefinitelyNotARealParameterManager


### PR DESCRIPTION
## Slim the baseline install: JAX plugins + openai are now optional (review item 15)

RTI review §11.2 item 15. The six JAX model plugins (`jsnow17`, `jsacsma`, `jxaj`,
`jhbv`, `jhechms`, `jtopmodel`) and `openai` were **required** dependencies, inflating
`pip install symfluence` for every user who runs neither a JAX model nor the LLM agent.

### Changes
- **pyproject.toml**: moved those seven out of `[dependencies]` into two new optional
  groups — `jax` (the six plugins) and `llm` (openai). The `test` and `all` extras now
  include `jax,llm`, so CI (`.[test]`) and full dev installs are unchanged; only the
  baseline shrinks.
- **optimization/parameter_managers/__init__.py**: dropped the top-level
  `jhbv`/`jsacsma`/`jxaj` imports (which ran during *any* calibration and would have
  broken all of it). HBV/SAC-SMA/Xinanjiang parameter managers are re-exported lazily via
  PEP 562 `__getattr__`, raising a clear `install "symfluence[jax]"` message on access
  without the plugin. Registration itself is unaffected (the existing resilient
  `_register_parameter_managers()` loop already tolerates their absence).
- **agent/api_client.py**: the missing-openai guard now `raise`s `ImportError` with an
  `install "symfluence[llm]"` hint instead of `print` + `sys.exit(1)` (which could kill a
  host process / pytest).

### Verification
- Wheel metadata: `openai` / `j*` are gone from core `Requires-Dist` and present under the
  `jax` / `llm` / `test` / `all` extras.
- New `tests/unit/optimization/test_optional_param_managers.py`: lazy resolution works when
  installed; clear `ImportError` (naming `symfluence[jax]`) when absent; `AttributeError`
  for unknown names.
- Full unit suite: **5880 passed / 42 skipped / 0 failed**; `ruff` / `mypy` / `bandit` /
  broad-except clean.

The JAX models still register via their `symfluence.plugins` entry points when the `jax`
extra is installed; without it they are simply unavailable (discovery already tolerates that).

---
Repo and code assistance from [Claude](https://claude.ai) (Anthropic).
