### PR TITLE
test(core): highest-priority missing core/ tests (review item 17)

### DIFF
--- a/tests/unit/config/conftest.py
+++ b/tests/unit/config/conftest.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Shared fixtures for config unit tests (item 17 coverage)."""
+
+from __future__ import annotations
+
+import pytest
+
+from symfluence.core.config.flattening import flatten_nested_config
+from symfluence.core.config.models import SymfluenceConfig
+
+
+def build_minimal_config(**overrides) -> SymfluenceConfig:
+    """A valid minimal SymfluenceConfig via the documented from_minimal factory."""
+    params = dict(
+        domain_name="test_basin",
+        model="SUMMA",
+        EXPERIMENT_TIME_START="2020-01-01 00:00",
+        EXPERIMENT_TIME_END="2020-12-31 23:00",
+    )
+    params.update(overrides)
+    return SymfluenceConfig.from_minimal(**params)
+
+
+@pytest.fixture
+def minimal_config() -> SymfluenceConfig:
+    """A valid minimal typed config."""
+    return build_minimal_config()
+
+
+@pytest.fixture
+def minimal_flat_config(minimal_config) -> dict:
+    """The minimal config as a flat dict (round-trippable into SymfluenceConfig)."""
+    return flatten_nested_config(minimal_config)

--- a/tests/unit/config/test_coercion.py
+++ b/tests/unit/config/test_coercion.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Tests for config coercion helpers (review item 17 — core/config/coercion.py).
+
+These convert dict/SymfluenceConfig inputs at the ~60 call sites that accept either,
+and were previously untested.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from symfluence.core.config.coercion import coerce_config, ensure_config
+from symfluence.core.config.models import SymfluenceConfig
+
+from .conftest import build_minimal_config
+
+# ---- ensure_config -------------------------------------------------------
+
+
+def test_ensure_config_passes_through_typed(minimal_config):
+    assert ensure_config(minimal_config) is minimal_config
+
+
+def test_ensure_config_coerces_valid_dict(minimal_flat_config):
+    cfg = ensure_config(minimal_flat_config)
+    assert isinstance(cfg, SymfluenceConfig)
+    assert cfg.domain.name == "test_basin"
+
+
+def test_ensure_config_rejects_non_mapping():
+    with pytest.raises(TypeError):
+        ensure_config(42)  # type: ignore[arg-type]
+
+
+def test_ensure_config_raises_on_invalid_dict():
+    # A dict missing required fields is still a dict, so ensure_config attempts
+    # construction and surfaces the validation error (not a silent fallback).
+    with pytest.raises(Exception):  # noqa: B017 - pydantic ValidationError (ValueError subclass)
+        ensure_config({"DOMAIN_NAME": "x"})
+
+
+# ---- coerce_config -------------------------------------------------------
+
+
+def test_coerce_config_passes_through_typed(minimal_config):
+    assert coerce_config(minimal_config) is minimal_config
+
+
+def test_coerce_config_coerces_valid_dict(minimal_flat_config):
+    cfg = coerce_config(minimal_flat_config)
+    assert isinstance(cfg, SymfluenceConfig)
+
+
+def test_coerce_config_partial_falls_back_with_warning():
+    partial = {"DOMAIN_NAME": "x"}
+    with pytest.warns(DeprecationWarning):
+        result = coerce_config(partial, warn=True)
+    assert result is partial  # original dict returned unchanged
+
+
+def test_coerce_config_partial_no_warn_is_silent(recwarn):
+    partial = {"DOMAIN_NAME": "x"}
+    result = coerce_config(partial, warn=False)
+    assert result is partial
+    assert not [w for w in recwarn.list if issubclass(w.category, DeprecationWarning)]
+
+
+def test_coerce_config_strict_raises():
+    with pytest.raises((TypeError, ValueError)):
+        coerce_config({"DOMAIN_NAME": "x"}, strict=True)
+
+
+def test_coerce_config_strict_via_env(monkeypatch):
+    monkeypatch.setenv("SYMFLUENCE_STRICT_CONFIG", "true")
+    with pytest.raises((TypeError, ValueError)):
+        coerce_config({"DOMAIN_NAME": "x"})  # strict resolved from env
+
+
+def test_coerce_config_env_false_allows_fallback(monkeypatch):
+    monkeypatch.setenv("SYMFLUENCE_STRICT_CONFIG", "false")
+    result = coerce_config({"DOMAIN_NAME": "x"}, warn=False)
+    assert result == {"DOMAIN_NAME": "x"}
+
+
+def test_round_trip_flatten_then_coerce(minimal_config):
+    """A config flattened and re-coerced preserves key fields."""
+    from symfluence.core.config.flattening import flatten_nested_config
+
+    flat = flatten_nested_config(build_minimal_config())
+    cfg2 = ensure_config(flat)
+    assert cfg2.domain.name == minimal_config.domain.name
+    assert cfg2.model.hydrological_model == minimal_config.model.hydrological_model

--- a/tests/unit/config/test_config_properties.py
+++ b/tests/unit/config/test_config_properties.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Property-based tests over the configuration model (review item 17).
+
+Hypothesis exercises invariants of the flat<->nested transform and the
+stage-marker hash that are easy to regress when the config schema changes.
+"""
+
+from __future__ import annotations
+
+import string
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from symfluence.core.config.flattening import flatten_nested_config
+from symfluence.core.config.models import SymfluenceConfig
+from symfluence.core.stage_marker import compute_config_hash
+
+from .conftest import build_minimal_config
+
+_NAME = st.text(alphabet=string.ascii_letters + string.digits + "_-", min_size=1, max_size=24)
+_HASH_SECTIONS = ["domain", "forcing", "model", "system"]
+
+
+@settings(max_examples=50, deadline=None)
+@given(domain_name=_NAME, num_processes=st.integers(min_value=1, max_value=64))
+def test_flatten_round_trip_preserves_key_fields(domain_name, num_processes):
+    cfg = build_minimal_config(domain_name=domain_name, NUM_PROCESSES=num_processes)
+    flat = flatten_nested_config(cfg)
+    cfg2 = SymfluenceConfig(**flat)
+    assert cfg2.domain.name == cfg.domain.name
+    assert cfg2.model.hydrological_model == cfg.model.hydrological_model
+    assert cfg2.system.num_processes == cfg.system.num_processes
+
+
+@settings(max_examples=50, deadline=None)
+@given(domain_name=_NAME)
+def test_hash_is_deterministic_and_order_independent(domain_name):
+    cfg = build_minimal_config(domain_name=domain_name)
+    h1 = compute_config_hash(cfg, _HASH_SECTIONS)
+    h2 = compute_config_hash(cfg, list(reversed(_HASH_SECTIONS)))
+    assert h1 == h2
+    assert len(h1) == 64 and all(c in string.hexdigits for c in h1)
+
+
+@settings(max_examples=50, deadline=None)
+@given(name_a=_NAME, name_b=_NAME)
+def test_hash_is_sensitive_to_changes(name_a, name_b):
+    cfg_a = build_minimal_config(domain_name=name_a)
+    cfg_b = build_minimal_config(domain_name=name_b)
+    same = compute_config_hash(cfg_a, ["domain"]) == compute_config_hash(cfg_b, ["domain"])
+    assert same == (name_a == name_b)
+
+
+def test_flatten_prefers_canonical_key_over_legacy_alias():
+    """NUM_PROCESSES is the canonical flat key; the legacy MPI_PROCESSES is not emitted."""
+    cfg = build_minimal_config(NUM_PROCESSES=8)
+    flat = flatten_nested_config(cfg)
+    assert flat.get("NUM_PROCESSES") == 8
+    assert "MPI_PROCESSES" not in flat

--- a/tests/unit/core/test_mixins.py
+++ b/tests/unit/core/test_mixins.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Tests for core mixin composition (review item 17).
+
+Covers ConfigMixin._get_config_value resolution order, ProjectContextMixin path
+derivation, LoggingMixin/TimingMixin, and the ConfigurableMixin composition — the
+shared base behind most managers, previously untested except ShapefileAccessMixin.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from symfluence.core.config.models import SymfluenceConfig
+from symfluence.core.mixins.config import ConfigMixin
+from symfluence.core.mixins.configurable import ConfigurableMixin
+from symfluence.core.mixins.project import resolve_data_subdir
+
+
+class _Configurable(ConfigurableMixin):
+    """Minimal concrete composition of all core mixins."""
+
+
+def _minimal() -> SymfluenceConfig:
+    return SymfluenceConfig.from_minimal(
+        domain_name="test_basin", model="SUMMA",
+        EXPERIMENT_TIME_START="2020-01-01 00:00", EXPERIMENT_TIME_END="2020-12-31 23:00",
+    )
+
+
+# ---- ConfigMixin._get_config_value resolution order ---------------------
+
+
+def test_typed_accessor_returns_value():
+    obj = ConfigMixin()
+    obj.config = _minimal()
+    assert obj._get_config_value(lambda: obj.config.domain.name) == "test_basin"
+
+
+def test_override_dict_takes_precedence():
+    obj = ConfigMixin()
+    obj.config = _minimal()
+    obj._config_dict_override = {"DOMAIN_NAME": "overridden"}
+    # Even though the typed accessor would return 'test_basin', the override wins.
+    assert obj._get_config_value(
+        lambda: obj.config.domain.name, dict_key="DOMAIN_NAME"
+    ) == "overridden"
+
+
+def test_dict_fallback_when_typed_accessor_fails():
+    obj = ConfigMixin()
+    obj.config = {"MY_KEY": "from_dict"}  # plain-dict config
+    value = obj._get_config_value(
+        lambda: obj.config.some.typed.path,  # raises AttributeError on a dict
+        dict_key="MY_KEY",
+    )
+    assert value == "from_dict"
+
+
+def test_default_when_nothing_resolves():
+    obj = ConfigMixin()
+    obj.config = _minimal()
+    assert obj._get_config_value(lambda: None, default="fallback") == "fallback"
+
+
+# ---- ProjectContextMixin path derivation --------------------------------
+
+
+def test_project_dir_derivation():
+    obj = _Configurable()
+    obj.data_dir = Path("/tmp/symfluence-data")  # nosec B108 - test path, not written
+    obj.domain_name = "bow"
+    assert obj.project_dir == Path("/tmp/symfluence-data/domain_bow")  # nosec B108
+    assert obj.project_forcing_dir == obj.project_dir / "data" / "forcing"
+
+
+def test_resolve_data_subdir_prefers_new_then_legacy(tmp_path):
+    project = tmp_path / "domain_x"
+    # Neither exists -> returns the new-style path.
+    assert resolve_data_subdir(project, "shapefiles") == project / "data" / "shapefiles"
+    # Legacy layout present -> returns it.
+    (project / "shapefiles").mkdir(parents=True)
+    assert resolve_data_subdir(project, "shapefiles") == project / "shapefiles"
+    # New layout present -> preferred over legacy.
+    (project / "data" / "shapefiles").mkdir(parents=True)
+    assert resolve_data_subdir(project, "shapefiles") == project / "data" / "shapefiles"
+
+
+# ---- LoggingMixin / TimingMixin -----------------------------------------
+
+
+def test_logger_is_lazily_created_and_settable():
+    obj = _Configurable()
+    assert isinstance(obj.logger, logging.Logger)
+    custom = logging.getLogger("custom.test.logger")
+    obj.logger = custom
+    assert obj.logger is custom
+
+
+def test_time_limit_context_manager_runs():
+    obj = _Configurable()
+    ran = False
+    with obj.time_limit("unit-test-task"):
+        ran = True
+    assert ran
+
+
+# ---- ConfigurableMixin composition --------------------------------------
+
+
+def test_composition_exposes_all_mixin_behaviors():
+    obj = _Configurable()
+    obj.config = _minimal()
+    # ConfigMixin, ProjectContextMixin, LoggingMixin, FileUtilsMixin, TimingMixin
+    for attr in ("config", "data_dir", "project_dir", "logger", "ensure_dir", "time_limit"):
+        assert hasattr(obj, attr), f"composed object missing {attr}"
+
+
+def test_resolve_config_value_is_deprecated_alias():
+    obj = _Configurable()
+    obj.config = _minimal()
+    with pytest.warns(DeprecationWarning):
+        value = obj._resolve_config_value(lambda: obj.config.domain.name)
+    assert value == "test_basin"

--- a/tests/unit/core/test_system_facade.py
+++ b/tests/unit/core/test_system_facade.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Tests for the top-level SYMFLUENCE system facade (review item 17).
+
+Scoped to construction wiring and delegation to the workflow orchestrator (the
+managers, logging, provenance, and orchestrator are mocked so no real workflow,
+filesystem, or subprocess work runs). Deep step-execution behaviour is integration
+territory and out of scope here.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from symfluence.core import system
+from symfluence.core.config.models import SymfluenceConfig
+from symfluence.core.system import SYMFLUENCE
+
+
+@pytest.fixture
+def facade():
+    cfg = SymfluenceConfig.from_minimal(
+        domain_name="test_basin", model="SUMMA",
+        EXPERIMENT_TIME_START="2020-01-01 00:00", EXPERIMENT_TIME_END="2020-12-31 23:00",
+    )
+    with patch.object(system, "LoggingManager"), \
+         patch.object(system, "LazyManagerDict"), \
+         patch.object(system, "WorkflowOrchestrator"), \
+         patch.object(system, "capture_provenance", return_value=None), \
+         patch.object(system, "finalize_provenance"):
+        sym = SYMFLUENCE(cfg)
+        yield sym  # keep patches active for the test body
+
+
+def test_construction_wires_components(facade):
+    assert isinstance(facade.typed_config, SymfluenceConfig)
+    assert isinstance(facade.config, dict)  # flattened backward-compat view
+    assert facade.workflow_orchestrator is not None
+    assert facade.managers is not None
+    assert facade.provenance is None  # capture_provenance patched to None
+
+
+def test_run_workflow_delegates_to_orchestrator(facade):
+    facade.workflow_orchestrator.get_workflow_status.return_value = {
+        "step_details": [], "total_steps": 0, "completed_steps": 0,
+    }
+    facade.run_workflow(force_run=True)
+    facade.workflow_orchestrator.run_workflow.assert_called_once_with(force_run=True)
+
+
+def test_run_workflow_reraises_on_failure(facade):
+    facade.workflow_orchestrator.run_workflow.side_effect = RuntimeError("boom")
+    with pytest.raises(RuntimeError, match="boom"):
+        facade.run_workflow(force_run=True)
+    # the run-summary is still written in the finally block
+    facade.logging_manager.create_run_summary.assert_called_once()
+
+
+def test_run_individual_steps_delegates(facade):
+    facade.workflow_orchestrator.run_individual_steps.return_value = [
+        {"success": True, "cli": "setup", "fn": "setup_project"},
+    ]
+    facade.run_individual_steps(["setup_project"])
+    facade.workflow_orchestrator.run_individual_steps.assert_called_once_with(
+        ["setup_project"], False
+    )
+
+
+def test_get_workflow_status_delegates(facade):
+    sentinel = {"total_steps": 3, "completed_steps": 1, "step_details": []}
+    facade.workflow_orchestrator.get_workflow_status.return_value = sentinel
+    assert facade.get_workflow_status() == sentinel

--- a/tests/unit/data/test_data_manager.py
+++ b/tests/unit/data/test_data_manager.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Tests for the DataManager facade (review item 17).
+
+Scoped to construction + the delegation contract: the acquire_* methods forward to
+the AcquisitionService. Real acquisition (network/I/O) is out of scope here. The
+three services are patched so no downloads or heavy I/O occur.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from symfluence.core.config.models import SymfluenceConfig
+from symfluence.data import data_manager as dm_mod
+from symfluence.data.data_manager import DataManager
+
+
+@pytest.fixture
+def data_manager():
+    cfg = SymfluenceConfig.from_minimal(
+        domain_name="test_basin", model="SUMMA",
+        EXPERIMENT_TIME_START="2020-01-01 00:00", EXPERIMENT_TIME_END="2020-12-31 23:00",
+    )
+    logger = logging.getLogger("test.data_manager")
+    # Patch the services so construction wires mocks instead of real acquisition.
+    # _get_service logs service_class.__name__, so the class mocks need one.
+    with patch.object(dm_mod, "AcquisitionService", MagicMock(__name__="AcquisitionService")), \
+         patch.object(dm_mod, "EMEarthIntegrator", MagicMock(__name__="EMEarthIntegrator")), \
+         patch.object(dm_mod, "VariableHandler", MagicMock(__name__="VariableHandler")):
+        dm = DataManager(cfg, logger, reporting_manager=None)
+    return dm
+
+
+def test_construction_wires_services(data_manager):
+    assert data_manager.acquisition_service is not None
+    assert data_manager.em_earth_integrator is not None
+    assert data_manager.variable_handler is not None
+
+
+def test_acquire_attributes_delegates(data_manager):
+    data_manager.acquire_attributes()
+    data_manager.acquisition_service.acquire_attributes.assert_called_once()
+
+
+def test_acquire_forcings_delegates(data_manager):
+    data_manager.acquire_forcings()
+    data_manager.acquisition_service.acquire_forcings.assert_called_once()
+
+
+def test_acquire_observations_delegates(data_manager):
+    data_manager.acquire_observations()
+    data_manager.acquisition_service.acquire_observations.assert_called_once()
+
+
+def test_get_status_returns_dict(data_manager):
+    status = data_manager.get_status()
+    assert isinstance(status, dict)

--- a/tests/unit/optimization/test_optimization_registry.py
+++ b/tests/unit/optimization/test_optimization_registry.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Tests for optimization-registry wiring (review item 17).
+
+The generic Registry and the R facade are covered elsewhere; this covers the
+optimization-specific behaviour: auto-discovery of model optimizers / parameter
+managers, the calibration-target composite-key helper, and the objectives facade.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from symfluence.core.registries import R
+
+
+@pytest.fixture
+def temp_register():
+    """Register entries into the shared R registries and remove them afterwards."""
+    registered = []
+
+    def _add(registry, key, value):
+        registry.add(key, value)
+        registered.append((registry, key))
+        return value
+
+    yield _add
+    for registry, key in registered:
+        try:
+            registry.remove(key)
+        except Exception:  # noqa: BLE001 - best-effort cleanup
+            pass
+
+
+# ---- auto-discovery ------------------------------------------------------
+
+
+def test_model_optimizers_are_autodiscovered_on_import():
+    import symfluence.optimization.model_optimizers  # noqa: F401 - triggers discovery
+
+    assert {"SUMMA", "FUSE", "NGEN", "HYPE", "MESH"} <= set(R.optimizers.keys())
+
+
+def test_parameter_managers_are_autodiscovered_on_import():
+    import symfluence.optimization.parameter_managers  # noqa: F401 - triggers discovery
+
+    assert {"SUMMA", "FUSE", "HYPE", "MESH"} <= set(R.parameter_managers.keys())
+
+
+# ---- registration round-trip --------------------------------------------
+
+
+def test_optimizer_registration_roundtrip_is_case_insensitive(temp_register):
+    class FakeOptimizer:
+        pass
+
+    temp_register(R.optimizers, "FAKEMODEL", FakeOptimizer)
+    assert R.optimizers.get("fakemodel") is FakeOptimizer  # normalized to upper
+    assert "FAKEMODEL" in R.optimizers
+    assert R.optimizers["FAKEMODEL"] is FakeOptimizer
+
+
+def test_unknown_optimizer_get_returns_none():
+    assert R.optimizers.get("NOT_A_REAL_MODEL_XYZ") is None
+
+
+# ---- calibration-target composite key -----------------------------------
+
+
+def test_calibration_target_composite_key(temp_register):
+    class FakeTarget:
+        pass
+
+    temp_register(R.calibration_targets, "FAKEMODEL_STREAMFLOW", FakeTarget)
+    assert R.get_calibration_target("fakemodel", "streamflow") is FakeTarget  # case-insensitive
+    assert R.get_calibration_target("FAKEMODEL", "snow") is None  # unregistered target type
+
+
+# ---- objectives facade ---------------------------------------------------
+
+
+def test_objective_registry_get_and_list(temp_register):
+    from symfluence.optimization.objectives.registry import ObjectiveRegistry
+
+    class FakeObjective:
+        def __init__(self, config, logger):
+            self.config = config
+            self.logger = logger
+
+    temp_register(R.objectives, "FAKEOBJ", FakeObjective)
+    instance = ObjectiveRegistry.get_objective("FAKEOBJ", {}, None)
+    assert isinstance(instance, FakeObjective)
+    assert ObjectiveRegistry.get_objective("DEFINITELY_UNKNOWN", {}, None) is None
+    assert "FAKEOBJ" in ObjectiveRegistry.list_objectives()
+
+
+def test_objective_register_decorator_is_deprecated():
+    from symfluence.optimization.objectives.registry import ObjectiveRegistry
+
+    try:
+        with pytest.warns(DeprecationWarning):
+            @ObjectiveRegistry.register("TMPOBJ")
+            class _TmpObjective:
+                def __init__(self, config, logger):
+                    pass
+
+        assert R.objectives.get("TMPOBJ") is _TmpObjective
+    finally:
+        try:
+            R.objectives.remove("TMPOBJ")
+        except Exception:  # noqa: BLE001
+            pass


### PR DESCRIPTION
## Highest-priority missing core/ tests (review item 17)

RTI review §11.2 item 17. Adds focused unit tests for the six `core/`-area gaps the
review flagged as "most likely to regress unnoticed" (43 tests, one commit per area).
Tests-only — no `src/` changes.

| Area | File | What it covers |
|------|------|----------------|
| Config coercion | `tests/unit/config/test_coercion.py` | `ensure_config` / `coerce_config` — passthrough, valid-dict coercion, `TypeError`, strict vs fallback-with-`DeprecationWarning`, `SYMFLUENCE_STRICT_CONFIG` env |
| Config properties | `tests/unit/config/test_config_properties.py` | Hypothesis: flat↔nested round-trip, `compute_config_hash` determinism/order-independence/sensitivity, canonical-key preference |
| Mixin composition | `tests/unit/core/test_mixins.py` | `_get_config_value` resolution order, `ProjectContextMixin` paths + `resolve_data_subdir`, `LoggingMixin`/`TimingMixin`, `ConfigurableMixin` composition + deprecated `_resolve_config_value` |
| Optimization registry | `tests/unit/optimization/test_optimization_registry.py` | Auto-discovery on import, registration round-trip (with cleanup so the shared `R` isn't polluted), calibration-target composite key, objectives facade |
| Data manager | `tests/unit/data/test_data_manager.py` | `DataManager` construction + `acquire_*` delegation to `AcquisitionService` (services mocked) |
| System facade | `tests/unit/core/test_system_facade.py` | `SYMFLUENCE` construction + delegation to a mocked `WorkflowOrchestrator` (`run_workflow` incl. re-raise, `run_individual_steps`, `get_workflow_status`) |

A shared `tests/unit/config/conftest.py` provides `minimal_config` / `minimal_flat_config`
fixtures via the documented `SymfluenceConfig.from_minimal` factory. The optimization-registry
tests use a fixture that removes anything they add to the global `R`.

### Verification
- New tests: **43 passed**. Full unit suite: **5992 passed / 41 skipped / 0 failed** (no
  cross-test registry pollution). `ruff` clean. `hypothesis` is already in the `[test]` extra.
- Areas 5–6 are deliberately scoped to construction + delegation; deep acquisition/workflow
  behaviour is integration-level and out of scope for this unit-test item.

---
Repo and code assistance from [Claude](https://claude.ai) (Anthropic).
