### PR TITLE
ci: fast unit-test + coverage gate (CI rethink, phase A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI - Lint Only
+name: CI
 
 on:
   push:
@@ -55,3 +55,55 @@ jobs:
           pip install mypy pandas-stubs types-PyYAML types-requests types-psutil
           # Run mypy on source directory
           mypy src/symfluence
+
+  # Fast unit-test gate (ubuntu/3.11). The full OS matrix lives in
+  # cross-platform.yml (develop/nightly/release); this keeps PRs quick while
+  # still gating on tests + coverage.
+  unit-tests:
+    name: Unit Tests (ubuntu, Python 3.11)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost
+          sudo rm -rf /usr/local/lib/android /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force || true
+          sudo apt-get clean
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gdal-bin libgdal-dev cdo
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if command -v gdal-config >/dev/null 2>&1; then
+            GDAL_VERSION=$(gdal-config --version)
+            pip install "gdal>=${GDAL_VERSION},<${GDAL_VERSION%.*}.$((${GDAL_VERSION##*.}+1))"
+          fi
+          # CPU-only torch to save space/time
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          # Package + test extras (pytest, pytest-xdist, hypothesis, jax/llm) from pyproject
+          pip install -e ".[test]"
+
+      - name: Run unit tests with coverage
+        run: |
+          pytest -v --tb=short -m "unit" -n auto \
+            --cov --cov-report=term-missing --cov-fail-under=15 tests/unit/
+
+      - name: Package import smoke test
+        run: |
+          python -c "import symfluence; from symfluence.core.registries import R; \
+            assert R.runners.get('SUMMA') is not None, 'SUMMA not registered via entry points'; \
+            print('import + entry-point registration OK')"


### PR DESCRIPTION
## CI rethink — Phase A: a fast unit-test gate

First of a phased CI rethink (item 16 + "we can do better"). `ci.yml` previously ran
lint/type/guards but **no tests** — the test signal came only from the heavy
`cross-platform` / `install-validate` matrices (which each re-run unit/integration/e2e on
every PR, three times over).

This adds an **ubuntu/3.11 unit-test job** to `ci.yml`:
`pytest -m unit -n auto --cov --cov-fail-under=15 tests/unit/`, plus a package-import +
entry-point-registration smoke. Renames the workflow `CI` (was "Lint Only").

### Where this is going (next phases, separate PRs)
- **Phase B:** move `cross-platform.yml` + `install-validate*.yml` off `pull_request` →
  `push: develop` + nightly + release. Kills the per-PR triplication.
- **Phase C:** consolidate the two install-validate workflows into one **method × OS** matrix
  and add the missing install methods (pipx/uv/uv-tool/conda/npm) — **review item 16**.

### Action needed
Once green, please set branch protection to **require the `CI` workflow** as the merge gate
(I can't change repo settings). After Phase B the heavy matrices won't run on PRs, so `CI`
becomes the gate.

---
Repo and code assistance from [Claude](https://claude.ai) (Anthropic).
