### PR TITLE
ci: tier heavy matrices off PRs → develop/nightly (CI rethink, phase B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI - Lint Only
+name: CI
 
 on:
   push:
@@ -55,3 +55,55 @@ jobs:
           pip install mypy pandas-stubs types-PyYAML types-requests types-psutil
           # Run mypy on source directory
           mypy src/symfluence
+
+  # Fast unit-test gate (ubuntu/3.11). The full OS matrix lives in
+  # cross-platform.yml (develop/nightly/release); this keeps PRs quick while
+  # still gating on tests + coverage.
+  unit-tests:
+    name: Unit Tests (ubuntu, Python 3.11)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost
+          sudo rm -rf /usr/local/lib/android /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force || true
+          sudo apt-get clean
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gdal-bin libgdal-dev cdo
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if command -v gdal-config >/dev/null 2>&1; then
+            GDAL_VERSION=$(gdal-config --version)
+            pip install "gdal>=${GDAL_VERSION},<${GDAL_VERSION%.*}.$((${GDAL_VERSION##*.}+1))"
+          fi
+          # CPU-only torch to save space/time
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          # Package + test extras (pytest, pytest-xdist, hypothesis, jax/llm) from pyproject
+          pip install -e ".[test]"
+
+      - name: Run unit tests with coverage
+        run: |
+          pytest -v --tb=short -m "unit" -n auto \
+            --cov --cov-report=term-missing --cov-fail-under=15 tests/unit/
+
+      - name: Package import smoke test
+        run: |
+          python -c "import symfluence; from symfluence.core.registries import R; \
+            assert R.runners.get('SUMMA') is not None, 'SUMMA not registered via entry points'; \
+            print('import + entry-point registration OK')"

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -1,10 +1,12 @@
 name: Cross-Platform Testing
 
 on:
+  # Tiered: the full OS matrix runs after merge to develop/main, nightly, and on
+  # demand — NOT on every PR (the fast unit gate lives in ci.yml).
   push:
     branches: [ main, develop ]
-  pull_request:
-    branches: [ main, develop ]
+  schedule:
+    - cron: '0 3 * * *'  # nightly full cross-platform matrix
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/install-validate-parallel.yml
+++ b/.github/workflows/install-validate-parallel.yml
@@ -1,9 +1,9 @@
 name: SYMFLUENCE - Parallel Install & Validate
 
 on:
+  # Tiered: install validation runs after merge to develop/main, weekly, and on
+  # demand — NOT on every PR (the fast unit gate lives in ci.yml).
   push:
-    branches: [ main, develop ]
-  pull_request:
     branches: [ main, develop ]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/install-validate.yml
+++ b/.github/workflows/install-validate.yml
@@ -1,10 +1,10 @@
 name: SYMFLUENCE - Full Install & Validate
 
 on:
+  # Tiered: install validation runs after merge to develop/main, weekly, and on
+  # demand — NOT on every PR (the fast unit gate lives in ci.yml).
   push:
     branches: [ main, develop ]  # Run on main and develop pushes
-  pull_request:
-    branches: [ main, develop ]  # Run on PRs to main/develop
   workflow_dispatch:
     inputs:
       test_level:


### PR DESCRIPTION
## CI rethink — Phase B: tier the heavy matrices off PRs

`cross-platform.yml`, `install-validate.yml`, and `install-validate-parallel.yml` each ran the
full OS / unit / integration / e2e matrices on **every PR** (three overlapping copies of the
same tests, all at once). This drops their `pull_request` trigger so they run on:
- **push to `main`/`develop`** (i.e. post-merge), and
- **schedule** (cross-platform gains a nightly cron; install-validate stay weekly), and
- **`workflow_dispatch`** (on demand).

After this, **PRs run only the fast `CI` gate** (`ci.yml`, from #146) + docs + CLA. Full
cross-platform and install validation run after merge and nightly — much faster/cheaper PRs,
same coverage before anything ships.

**Stacked on #146** so PR test coverage is never reduced without the unit gate in place — merge
#146 first. (Phase C will then consolidate the two install-validate workflows into one
method×OS matrix and add the missing install methods — item 16.)

> ⚠️ After #146 + this merge, ensure branch protection requires the **`CI`** check (the heavy
> matrices no longer run on PRs, so `CI` is the gate).

---
Repo and code assistance from [Claude](https://claude.ai) (Anthropic).
