### PR TITLE
fix: InMemoryModelWorker picks km² column and divides by 1e6

### DIFF
--- a/src/symfluence/optimization/workers/inmemory_worker.py
+++ b/src/symfluence/optimization/workers/inmemory_worker.py
@@ -440,11 +440,20 @@ class InMemoryModelWorker(BaseWorker):
                 shp_files = list(catchment_dir.rglob(pattern))
                 if shp_files:
                     gdf = gpd.read_file(shp_files[0])
-                    area_cols = [c for c in gdf.columns if 'area' in c.lower()]
-                    if area_cols:
-                        total_area_m2 = gdf[area_cols[0]].sum()
+                    # Prefer canonical m² columns. LamaH-Ice shapefiles ship an
+                    # `area_calc` column already in km², which the legacy
+                    # first-match logic blindly divided by 1e6, producing a
+                    # 1,000,000× too-small area and KGE = 1 − √2 across every
+                    # j-stack run.
+                    preferred = ['GRU_area', 'HRU_area', 'AREA_M2', 'area_m2']
+                    chosen = next((c for c in preferred if c in gdf.columns), None)
+                    if chosen is None:
+                        area_cols = [c for c in gdf.columns if 'area' in c.lower()]
+                        chosen = area_cols[0] if area_cols else None
+                    if chosen:
+                        total_area_m2 = gdf[chosen].sum()
                         self._catchment_area_km2 = float(total_area_m2) / 1e6
-                        self.logger.info(f"Catchment area from shapefile: {self._catchment_area_km2:.2f} km²")
+                        self.logger.info(f"Catchment area from shapefile column '{chosen}': {self._catchment_area_km2:.2f} km²")
                         return self._catchment_area_km2
         except (FileNotFoundError, ValueError, AttributeError) as e:
             self.logger.debug(f"Could not read catchment area from shapefile: {e}")


### PR DESCRIPTION
## Summary

`InMemoryModelWorker.get_catchment_area()` picks the first column matching `'area'` case-insensitively. For LamaH-Ice catchment shapefiles that's `area_calc` (231.638 km², already in km²) — dividing by 1e6 produces `0.000232` km², 1,000,000× too small.

Downstream, the observation-side unit conversion `cms × 86400 / (area_km² × 1e6 × 0.001)` multiplies obs by 1e6, collapsing KGE's α and β terms to ~1e-6. **Every j-stack model run on Iceland (~60 basins × 5 models) converged to KGE = 1 − √2 ≈ −0.414** — the constant-prediction floor — regardless of model, parameters, or DDS budget.

## Fix

Prefer canonical m² columns in priority order:
- `GRU_area`, `HRU_area`, `AREA_M2`, `area_m2`

Fall back to the previous first-match behavior only when none of those names exist, so non-LamaH datasets keep working.

## Evidence

LamaH-Ice domain 22:

| Metric | Before | After |
|---|---|---|
| Catchment area | 0.000232 km² | **231.66 km²** |
| HBV best KGE | −0.4310 | **+0.7649** |
| HBV β | 1.04e-6 | ~1.0 |

For reference: FUSE direct-fuse driver on the same basin gets KGE 0.806 — HBV at 0.76 is in the right ballpark.

## Scope

- `InMemoryModelWorker` is the base for jStack workers (HBV, HECHMS, TOPMODEL, SACSMA, XINANJIANG via `jhbv`/`jhechms`/`jtopmodel`/`jsacsma`/`jxaj`).
- **Not affected:** GR4J (`GRWorker → BaseWorker`), FUSE (different worker), direct-fuse calibration scripts.

## Test plan

- [x] Manual: re-smoke domain 22 HBV from clean — KGE went from −0.43 to +0.76 in 5000 DDS evals.
- [ ] Follow-up: add a unit test (suggested `tests/unit/optimization/test_inmemory_worker.py`) that mocks a shapefile containing both `area_calc` (km²) and `GRU_area` (m²) and asserts `GRU_area` wins.

Assisted-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>