### PR TITLE
ci(install): genuinely validate pipx/uv-tool installs (import inside their venvs)

### DIFF
--- a/.github/workflows/install-methods.yml
+++ b/.github/workflows/install-methods.yml
@@ -11,7 +11,6 @@ name: Install Methods
 on:
   push:
     branches: [ main, develop ]
-  pull_request:  # TEMP: validate stronger pipx/uv-tool smoke on #149; remove before merge
   schedule:
     - cron: '0 4 * * 0'  # weekly (Sundays)
   workflow_dispatch:

--- a/.github/workflows/install-methods.yml
+++ b/.github/workflows/install-methods.yml
@@ -11,6 +11,7 @@ name: Install Methods
 on:
   push:
     branches: [ main, develop ]
+  pull_request:  # TEMP: validate stronger pipx/uv-tool smoke on #149; remove before merge
   schedule:
     - cron: '0 4 * * 0'  # weekly (Sundays)
   workflow_dispatch:
@@ -144,9 +145,21 @@ jobs:
         run: |
           set -x
           case "${{ matrix.method }}" in
-            pipx|uv-tool|npm)
-              # App-install methods expose the `symfluence` CLI on PATH but do not
-              # add an importable module to the ambient Python — CLI smoke only.
+            pipx)
+              # App-install: the module isn't on the ambient Python, so import is
+              # verified inside pipx's isolated venv (where the package + deps live).
+              symfluence --version
+              PIPX_VENVS="$(pipx environment --value PIPX_LOCAL_VENVS)"
+              "${PIPX_VENVS}/symfluence/bin/python" -c "import symfluence; print('pipx venv import OK:', symfluence.__file__)"
+              ;;
+            uv-tool)
+              symfluence --version
+              UV_TOOLS="$(uv tool dir)"
+              "${UV_TOOLS}/symfluence/bin/python" -c "import symfluence; print('uv-tool venv import OK:', symfluence.__file__)"
+              ;;
+            npm)
+              # npm ships a prebuilt CLI/binary distribution, not an importable
+              # Python module — CLI smoke only.
               symfluence --version
               ;;
             uv-pip)


### PR DESCRIPTION
## What

The install-method matrix (#149) smoke-tested `pipx`/`uv-tool` with `symfluence --version` only. That proves the CLI entry-point *script* exists, but **not** that the package actually imports inside the tool's isolated venv — so a broken-but-launchable install would pass.

This strengthens the smoke for both app-install methods to run `import symfluence` using the **venv's own Python**, discovered via:
- pipx: `pipx environment --value PIPX_LOCAL_VENVS` → `<venvs>/symfluence/bin/python`
- uv-tool: `uv tool dir` → `<dir>/symfluence/bin/python`

`npm` stays CLI-only by design — it ships a prebuilt binary, not an importable Python module.

## Why this is the right fix

pipx/uv-tool are *application* installers: they create an isolated venv and expose only the CLI on PATH, so `import symfluence` against the **ambient** Python correctly fails. The earlier matrix runs failed for exactly that reason; the honest fix is to verify the import where the package actually lives (its managed venv), not to drop the import check.

## Validation

Temporarily re-adds the `pull_request` trigger so the matrix runs on this PR. Once pipx/uv-tool are confirmed green with the stronger smoke, the temp trigger is removed before merge (same validate-then-strip pattern as #149).

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).