### PR TITLE
fix(models): alias CLM-ParFlow->CLMPARFLOW; surface meshflow exceptions

### DIFF
--- a/src/symfluence/core/_bootstrap.py
+++ b/src/symfluence/core/_bootstrap.py
@@ -88,10 +88,11 @@ def _bootstrap_bmi_adapters(R: type) -> None:  # noqa: N803
 def _bootstrap_model_aliases(R: type) -> None:  # noqa: N803
     """Alias hyphenated model names to their canonical registry keys.
 
-    Some models ship as standalone pip plugins that register their components
-    under a hyphen-free canonical name (e.g. ``jhechms`` registers ``HECHMS``,
-    ``jsacsma`` registers ``SACSMA``).  A config using the conventional
-    hyphenated spelling (``HYDROLOGICAL_MODEL: HEC-HMS``) would otherwise fail
+    Some models register their components under a hyphen-free canonical name
+    (e.g. ``jhechms`` registers ``HECHMS``, ``jsacsma`` registers ``SACSMA``,
+    and the coupled land-surface/subsurface runner registers ``CLMPARFLOW``).
+    A config using the conventional hyphenated spelling
+    (``HYDROLOGICAL_MODEL: HEC-HMS`` or ``CLM-ParFlow``) would otherwise fail
     to resolve a runner.  Aliases are resolved lazily at lookup time, so they
     may be declared here before the plugin entry points register the canonical
     keys.
@@ -107,6 +108,7 @@ def _bootstrap_model_aliases(R: type) -> None:  # noqa: N803
     model_aliases = {
         "HEC-HMS": "HECHMS",
         "SAC-SMA": "SACSMA",
+        "CLM-PARFLOW": "CLMPARFLOW",
     }
     component_registries = (
         R.runners,

--- a/src/symfluence/models/mesh/preprocessing/meshflow_manager.py
+++ b/src/symfluence/models/mesh/preprocessing/meshflow_manager.py
@@ -231,10 +231,14 @@ class MESHFlowManager:
             self.logger.info("Meshflow preprocessing completed successfully")
 
         except Exception as e:  # noqa: BLE001 — wrap-and-raise to domain error
-            self.logger.error(f"Meshflow preprocessing failed: {e}")
-            self.logger.debug(traceback.format_exc())
+            # Include the exception type — meshflow can raise exceptions whose
+            # str() is empty, which would otherwise produce an opaque
+            # "Meshflow preprocessing failed: " with no cause.
+            detail = f"{type(e).__name__}: {e}" if str(e) else type(e).__name__
+            self.logger.error(f"Meshflow preprocessing failed: {detail}")
+            self.logger.error(traceback.format_exc())
             from symfluence.core.exceptions import ModelExecutionError
-            raise ModelExecutionError(f"Meshflow preprocessing failed: {e}") from e
+            raise ModelExecutionError(f"Meshflow preprocessing failed: {detail}") from e
 
     def _check_required_files(self) -> None:
         """Check that required input files exist."""

--- a/tests/unit/core/test_model_aliases.py
+++ b/tests/unit/core/test_model_aliases.py
@@ -42,6 +42,14 @@ def test_sacsma_hyphen_alias_resolves_runner():
     assert R.runners.get("SAC-SMA") is canonical
 
 
+def test_clmparflow_hyphen_alias_resolves_runner_and_optimizer():
+    """`CLM-ParFlow` (-> CLM-PARFLOW) resolves to the canonical CLMPARFLOW."""
+    canonical = R.runners.get("CLMPARFLOW")
+    assert canonical is not None, "CLMPARFLOW runner should be registered"
+    assert R.runners.get("CLM-PARFLOW") is canonical
+    assert R.optimizers.get("CLM-PARFLOW") is R.optimizers.get("CLMPARFLOW")
+
+
 def test_aliases_do_not_shadow_real_registrations():
     """An alias is never added for a name that is already a real runner entry.
 


### PR DESCRIPTION
Follow-up to #154 (merged), found by **reproducing the model-ensemble run locally** against the prepared `Bow_at_Banff_lumped_era5` domain for the four "environment" models (CRHM, CLM-ParFlow, MESH, FUSE).

## Fixes

- **CLM-ParFlow — hyphen alias.** Running `config_clm_parflow.yaml` (`hydrological_model: CLM-ParFlow`) failed with "Unknown hydrological model or no runner registered: CLM-ParFlow". The runner/optimizer/worker register as `CLMPARFLOW`, but `CLM-ParFlow` normalizes to `CLM-PARFLOW` — the *same hyphen-alias class as HEC-HMS*. Added `CLM-PARFLOW → CLMPARFLOW` to the model-name alias map (+regression test). Earlier triage guessed "missing optional dependency"; running it locally proved it's the naming mismatch.

- **MESH — surface meshflow exceptions.** meshflow can raise exceptions whose `str()` is empty, producing an opaque `Meshflow preprocessing failed: ` with no cause. Now include the exception type and log the traceback at error level. (Local run then surfaced `LookupError` from `cdo readXArray` in meshflow's CDO forcing prep — an external meshflow/CDO toolchain issue.)

## Local verification outcomes (informing the reply to the reporter)

- **CRHM** runs cleanly here (preprocess → run → 8-iter calibration, KGE computed) — **no segfault**, confirming the reporter's `return code -11` is binary/compute-node-specific. Latin-1 postprocessing fix exercised.
- **FUSE** binary runs (return code 0, **no `NC_UNLIMITED`**) and **creates its `zDecisions` file** during preprocessing — confirming both reported FUSE issues are environment-specific to the reporter's HPC build (the missing-zDecisions was downstream of the run failing).

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).