### PR TITLE
fix(observations): share nested-catchment resolver across all handlers

### DIFF
--- a/src/symfluence/data/observation/base.py
+++ b/src/symfluence/data/observation/base.py
@@ -281,6 +281,108 @@ class BaseObservationHandler(ABC, ConfigurableMixin, CoordinateUtilsMixin):
         self.logger.info(f"{obs_type} processing complete: {output_file}")
         return output_file
 
+    def _resolve_catchment_shapefile(self, required: bool = False) -> Optional[Path]:
+        """Locate the catchment/basin polygon for spatial masking or averaging.
+
+        Domain discretization writes the catchment under an experiment-scoped
+        nested layout
+        (``shapefiles/catchment/{definition_method}/{experiment_id}/
+        {domain}_HRUs_{discretization}.shp``) and may upper-case the
+        discretization suffix (GRUs -> GRUS), so a flat
+        ``{domain}_catchment.shp`` lookup never matches. Resolution order:
+
+        1. Explicit ``CATCHMENT_PATH`` / ``CATCHMENT_SHP_NAME`` (config.paths).
+        2. Canonical nested catchment layout (definition_method/experiment_id),
+           then the legacy flat ``shapefiles/catchment`` directory.
+        3. Any ``{domain}_HRUs_*.shp`` anywhere under ``shapefiles/catchment``.
+        4. The ``shapefiles/river_basins`` outline.
+
+        Args:
+            required: When True, raise FileNotFoundError if nothing is found;
+                otherwise return None.
+
+        Returns:
+            Path to the resolved shapefile, or None when not found and not
+            required.
+        """
+        # 1. Explicit user-provided path/name takes precedence. These keys live
+        #    on config.paths (NOT config.domain — a common source of silent
+        #    fall-through to defaults).
+        catchment_path_cfg = self._get_config_value(
+            lambda: self.config.paths.catchment_path, default='default', dict_key='CATCHMENT_PATH'
+        )
+        catchment_name_cfg = self._get_config_value(
+            lambda: self.config.paths.catchment_name, default='default', dict_key='CATCHMENT_SHP_NAME'
+        )
+        if catchment_path_cfg and catchment_path_cfg != 'default':
+            base_dir = Path(catchment_path_cfg)
+            if catchment_name_cfg and catchment_name_cfg != 'default':
+                explicit = base_dir / catchment_name_cfg
+                if explicit.exists():
+                    return explicit
+            found = sorted(base_dir.rglob("*.shp"))
+            if found:
+                return found[0]
+
+        catchment_dir = self.project_shapefiles_dir / "catchment"
+
+        # 2. Canonical nested layout, then legacy flat directory.
+        nested_dir = catchment_dir / self.domain_definition_method / self.experiment_id
+        for candidate_dir in (nested_dir, catchment_dir):
+            if not candidate_dir.exists():
+                continue
+            matches = (
+                sorted(candidate_dir.glob(f"{self.domain_name}_HRUs_*.shp"))
+                or sorted(candidate_dir.glob(f"{self.domain_name}*.shp"))
+            )
+            if not matches and candidate_dir == nested_dir:
+                # The experiment subdir is catchment-specific; any .shp there is ours.
+                matches = sorted(candidate_dir.glob("*.shp"))
+            if matches:
+                return matches[0]
+
+        # 3. Deep search anywhere under catchment/ (handles casing/name drift).
+        if catchment_dir.exists():
+            deep = sorted(catchment_dir.rglob(f"{self.domain_name}_HRUs_*.shp"))
+            if deep:
+                return deep[0]
+
+        # 4. River basins outline as a last resort.
+        river_basins_dir = self.project_shapefiles_dir / "river_basins"
+        if river_basins_dir.exists():
+            rb_matches = (
+                sorted(river_basins_dir.glob(f"{self.domain_name}_riverBasins_*.shp"))
+                or sorted(river_basins_dir.glob("*.shp"))
+            )
+            if rb_matches:
+                return rb_matches[0]
+
+        if required:
+            raise FileNotFoundError(
+                f"Catchment/basin shapefile not found. Searched '{catchment_dir}' "
+                f"(incl. {self.domain_definition_method}/{self.experiment_id}) and "
+                f"river_basins. Run define_domain + discretize_domain first, or set "
+                f"CATCHMENT_PATH/CATCHMENT_SHP_NAME explicitly."
+            )
+        return None
+
+    def _load_catchment_gdf(self, required: bool = False):
+        """Load the resolved catchment/basin shapefile as a GeoDataFrame.
+
+        Returns None (with a warning) when the shapefile cannot be resolved and
+        ``required`` is False; raises FileNotFoundError when ``required``.
+        """
+        basin_shp = self._resolve_catchment_shapefile(required=required)
+        if basin_shp is None:
+            self.logger.warning(
+                "Catchment shapefile not found; spatial masking unavailable. "
+                "Run define_domain + discretize_domain, or set CATCHMENT_PATH."
+            )
+            return None
+        import geopandas as gpd  # lazy: heavy dependency
+        self.logger.debug(f"Using catchment shapefile: {basin_shp}")
+        return gpd.read_file(basin_shp)
+
     # =========================================================================
     # Utility Methods - Data Loading
     # =========================================================================

--- a/src/symfluence/data/observation/handlers/canopy_height.py
+++ b/src/symfluence/data/observation/handlers/canopy_height.py
@@ -295,30 +295,13 @@ class CanopyHeightHandler(BaseObservationHandler):
         return output_file
 
     def _load_catchment_shapefile(self) -> Optional[gpd.GeoDataFrame]:
-        """Load catchment shapefile for spatial masking."""
-        catchment_path_cfg = self._get_config_value(lambda: self.config.domain.catchment_path, default='default')
-        if catchment_path_cfg == 'default' or not catchment_path_cfg:
-            catchment_path = self.project_dir / "shapefiles" / "catchment"
-        else:
-            catchment_path = Path(catchment_path_cfg)
+        """Load the catchment shapefile for spatial masking.
 
-        catchment_name = self._get_config_value(lambda: self.config.domain.catchment_shp_name, default=f"{self.domain_name}_catchment.shp")
-
-        basin_shp = catchment_path / catchment_name
-        if not basin_shp.exists():
-            for pattern in [f"{self.domain_name}*.shp", "*.shp"]:
-                matches = list(catchment_path.glob(pattern))
-                if matches:
-                    basin_shp = matches[0]
-                    break
-
-        if basin_shp.exists():
-            gdf = gpd.read_file(basin_shp)
-            self.logger.debug(f"Loaded catchment shapefile: {basin_shp}")
-            return gdf
-
-        self.logger.warning("Catchment shapefile not found, using bounding box")
-        return None
+        Delegates to the shared resolver, which handles the nested
+        discretization layout and river_basins fallback. Returns None when
+        no basin is found (callers fall back to the bounding box).
+        """
+        return self._load_catchment_gdf()
 
     def _extract_basin_statistics(
         self,

--- a/src/symfluence/data/observation/handlers/daymet.py
+++ b/src/symfluence/data/observation/handlers/daymet.py
@@ -151,28 +151,13 @@ class DaymetHandler(BaseObservationHandler):
         return output_file
 
     def _load_catchment_shapefile(self) -> Optional[gpd.GeoDataFrame]:
-        """Load catchment shapefile for spatial masking."""
-        catchment_path_cfg = self._get_config_value(lambda: self.config.domain.catchment_path, default='default')
-        if catchment_path_cfg == 'default' or not catchment_path_cfg:
-            catchment_path = self.project_dir / "shapefiles" / "catchment"
-        else:
-            catchment_path = Path(catchment_path_cfg)
+        """Load the catchment shapefile for spatial masking.
 
-        catchment_name = self._get_config_value(lambda: self.config.domain.catchment_shp_name, default=f"{self.domain_name}_catchment.shp")
-
-        basin_shp = catchment_path / catchment_name
-        if not basin_shp.exists():
-            for pattern in [f"{self.domain_name}*.shp", "*.shp"]:
-                matches = list(catchment_path.glob(pattern))
-                if matches:
-                    basin_shp = matches[0]
-                    break
-
-        if basin_shp.exists():
-            return gpd.read_file(basin_shp)
-
-        self.logger.warning("Catchment shapefile not found, using bounding box")
-        return None
+        Delegates to the shared resolver, which handles the nested
+        discretization layout and river_basins fallback. Returns None when
+        no basin is found (callers fall back to the bounding box).
+        """
+        return self._load_catchment_gdf()
 
     def _process_netcdf(
         self,

--- a/src/symfluence/data/observation/handlers/era5_land.py
+++ b/src/symfluence/data/observation/handlers/era5_land.py
@@ -168,35 +168,13 @@ class ERA5LandHandler(BaseObservationHandler):
         return output_file
 
     def _load_catchment_shapefile(self) -> Optional[gpd.GeoDataFrame]:
-        """Load catchment shapefile for spatial masking."""
-        catchment_path_cfg = self._get_config_value(lambda: self.config.domain.catchment_path, default='default')
-        if catchment_path_cfg == 'default' or not catchment_path_cfg:
-            catchment_path = self.project_dir / "shapefiles" / "catchment"
-        else:
-            catchment_path = Path(catchment_path_cfg)
+        """Load the catchment shapefile for spatial masking.
 
-        catchment_name = self._get_config_value(lambda: self.config.domain.catchment_shp_name, default=f"{self.domain_name}_catchment.shp")
-        if catchment_name == 'default' or not catchment_name:
-            catchment_name = f"{self.domain_name}_HRUs_GRUs.shp"
-
-        basin_shp = catchment_path / catchment_name
-        if not basin_shp.exists():
-            # Try alternate patterns
-            alt_patterns = [
-                f"{self.domain_name}*.shp",
-                "*.shp"
-            ]
-            for pattern in alt_patterns:
-                matches = list(catchment_path.glob(pattern))
-                if matches:
-                    basin_shp = matches[0]
-                    break
-
-        if basin_shp.exists():
-            return gpd.read_file(basin_shp)
-
-        self.logger.warning(f"Catchment shapefile not found: {basin_shp}")
-        return None
+        Delegates to the shared resolver, which handles the nested
+        discretization layout and river_basins fallback. Returns None when
+        no basin is found (callers fall back to the bounding box).
+        """
+        return self._load_catchment_gdf()
 
     def _process_file(
         self,

--- a/src/symfluence/data/observation/handlers/grace.py
+++ b/src/symfluence/data/observation/handlers/grace.py
@@ -72,79 +72,13 @@ class GRACEHandler(BaseObservationHandler):
 
         return grace_dir
 
-    def _resolve_basin_shapefile(self) -> Path:
-        """Locate the basin polygon used for GRACE spatial averaging.
-
-        Discretization writes the catchment under a nested, experiment-scoped
-        layout (``shapefiles/catchment/{definition_method}/{experiment_id}/
-        {domain}_HRUs_{discretization}.shp``) — and may upper-case the
-        discretization suffix (GRUs -> GRUS) — so a flat
-        ``{domain}_catchment.shp`` lookup never matches. Honour an explicit
-        ``CATCHMENT_PATH`` / ``CATCHMENT_SHP_NAME`` first, then fall back to the
-        canonical nested catchment layout, and finally the river_basins
-        outline. Any single-polygon basin works for TWS averaging.
-        """
-        # 1. Explicit user-provided path/name takes precedence.
-        catchment_path_cfg = self._get_config_value(
-            lambda: self.config.paths.catchment_path, default='default', dict_key='CATCHMENT_PATH'
-        )
-        catchment_name_cfg = self._get_config_value(
-            lambda: self.config.paths.catchment_name, default='default', dict_key='CATCHMENT_SHP_NAME'
-        )
-        if catchment_path_cfg and catchment_path_cfg != 'default':
-            base = Path(catchment_path_cfg)
-            if catchment_name_cfg and catchment_name_cfg != 'default':
-                explicit = base / catchment_name_cfg
-                if explicit.exists():
-                    return explicit
-            # Path given but no (or missing) name: search it.
-            found = sorted(base.rglob("*.shp"))
-            if found:
-                self.logger.info(f"Using basin shapefile from CATCHMENT_PATH: {found[0]}")
-                return found[0]
-
-        catchment_dir = self.project_shapefiles_dir / "catchment"
-
-        # 2. Canonical nested catchment layout (definition_method/experiment_id).
-        nested_dir = catchment_dir / self.domain_definition_method / self.experiment_id
-        for candidate_dir in (nested_dir, catchment_dir):
-            if not candidate_dir.exists():
-                continue
-            # Prefer the discretized HRU shapefile; fall back to any .shp.
-            hru_matches = sorted(candidate_dir.glob(f"{self.domain_name}_HRUs_*.shp"))
-            if not hru_matches and candidate_dir is nested_dir:
-                hru_matches = sorted(candidate_dir.glob("*.shp"))
-            if hru_matches:
-                self.logger.info(f"Found catchment shapefile for GRACE averaging: {hru_matches[0]}")
-                return hru_matches[0]
-
-        # 3. Deep search anywhere under catchment/ (handles casing/name drift).
-        deep = sorted(catchment_dir.rglob(f"{self.domain_name}_HRUs_*.shp")) if catchment_dir.exists() else []
-        if deep:
-            self.logger.info(f"Found catchment shapefile in subdirectory: {deep[0]}")
-            return deep[0]
-
-        # 4. River basins outline as a last resort.
-        river_basins_dir = self.project_shapefiles_dir / "river_basins"
-        if river_basins_dir.exists():
-            rb_matches = sorted(river_basins_dir.glob(f"{self.domain_name}_riverBasins_*.shp")) \
-                or sorted(river_basins_dir.glob("*.shp"))
-            if rb_matches:
-                self.logger.info(f"Using river_basins outline for GRACE averaging: {rb_matches[0]}")
-                return rb_matches[0]
-
-        raise FileNotFoundError(
-            f"Basin shapefile not found for GRACE. Searched catchment dir "
-            f"'{catchment_dir}' (incl. {self.domain_definition_method}/{self.experiment_id}) "
-            f"and river_basins. Run define_domain + discretize_domain first, or set "
-            f"CATCHMENT_PATH/CATCHMENT_SHP_NAME explicitly."
-        )
-
     def process(self, input_path: Path) -> Path:
         """Process GRACE data for the current domain."""
         self.logger.info(f"Processing GRACE TWS for domain: {self.domain_name}")
 
-        basin_shp = self._resolve_basin_shapefile()
+        # GRACE TWS averaging needs a basin polygon. The shared resolver handles
+        # the nested discretization layout and river_basins fallback.
+        basin_shp = self._resolve_catchment_shapefile(required=True)
         basin_gdf = gpd.read_file(basin_shp)
         basin_area_km2 = self._calculate_area(basin_gdf)
         self.logger.info(f"Basin area: {basin_area_km2:.1f} km²")

--- a/src/symfluence/data/observation/handlers/jrc_water.py
+++ b/src/symfluence/data/observation/handlers/jrc_water.py
@@ -159,34 +159,12 @@ class JRCWaterHandler(BaseObservationHandler):
         return output_file
 
     def _get_catchment_path(self) -> Optional[Path]:
-        """Get path to catchment shapefile if available."""
-        catchment_dir = self._get_config_value(
-            lambda: self.config.domain.catchment_path,
-            default=None
-        )
-        if catchment_dir:
-            catchment_dir = Path(catchment_dir)
-        else:
-            catchment_dir = self.project_dir / "shapefiles" / "catchment"
+        """Get path to catchment shapefile if available.
 
-        if not catchment_dir.exists():
-            return None
-
-        # Find shapefile
-        shp_name = self._get_config_value(
-            lambda: self.config.domain.catchment_shp_name,
-            default=f"{self.domain_name}_catchment.shp"
-        )
-        shp_path = catchment_dir / shp_name
-        if shp_path.exists():
-            return shp_path
-
-        # Try to find any shapefile
-        shp_files = list(catchment_dir.glob("*.shp"))
-        if shp_files:
-            return shp_files[0]
-
-        return None
+        Delegates to the shared resolver, which handles the nested
+        discretization layout and river_basins fallback.
+        """
+        return self._resolve_catchment_shapefile()
 
     def _compute_basin_stats(
         self,

--- a/src/symfluence/data/observation/handlers/modis_lai.py
+++ b/src/symfluence/data/observation/handlers/modis_lai.py
@@ -283,28 +283,13 @@ class MODISLAIHandler(BaseObservationHandler):
         return df
 
     def _load_catchment_shapefile(self) -> Optional[gpd.GeoDataFrame]:
-        """Load catchment shapefile for spatial masking."""
-        catchment_path_cfg = self._get_config_value(lambda: self.config.domain.catchment_path, default='default')
-        if catchment_path_cfg == 'default' or not catchment_path_cfg:
-            catchment_path = self.project_dir / "shapefiles" / "catchment"
-        else:
-            catchment_path = Path(catchment_path_cfg)
+        """Load the catchment shapefile for spatial masking.
 
-        catchment_name = self._get_config_value(lambda: self.config.domain.catchment_shp_name, default=f"{self.domain_name}_catchment.shp")
-
-        basin_shp = catchment_path / catchment_name
-        if not basin_shp.exists():
-            for pattern in [f"{self.domain_name}*.shp", "*.shp"]:
-                matches = list(catchment_path.glob(pattern))
-                if matches:
-                    basin_shp = matches[0]
-                    break
-
-        if basin_shp.exists():
-            return gpd.read_file(basin_shp)
-
-        self.logger.warning("Catchment shapefile not found, using bounding box")
-        return None
+        Delegates to the shared resolver, which handles the nested
+        discretization layout and river_basins fallback. Returns None when
+        no basin is found (callers fall back to the bounding box).
+        """
+        return self._load_catchment_gdf()
 
     def _process_spatial_netcdf(
         self,

--- a/src/symfluence/data/observation/handlers/modis_lst.py
+++ b/src/symfluence/data/observation/handlers/modis_lst.py
@@ -161,28 +161,13 @@ class MODISLSTHandler(BaseObservationHandler):
         return output_file
 
     def _load_catchment_shapefile(self) -> Optional[gpd.GeoDataFrame]:
-        """Load catchment shapefile for spatial masking."""
-        catchment_path_cfg = self._get_config_value(lambda: self.config.domain.catchment_path, default='default')
-        if catchment_path_cfg == 'default' or not catchment_path_cfg:
-            catchment_path = self.project_dir / "shapefiles" / "catchment"
-        else:
-            catchment_path = Path(catchment_path_cfg)
+        """Load the catchment shapefile for spatial masking.
 
-        catchment_name = self._get_config_value(lambda: self.config.domain.catchment_shp_name, default=f"{self.domain_name}_catchment.shp")
-
-        basin_shp = catchment_path / catchment_name
-        if not basin_shp.exists():
-            for pattern in [f"{self.domain_name}*.shp", "*.shp"]:
-                matches = list(catchment_path.glob(pattern))
-                if matches:
-                    basin_shp = matches[0]
-                    break
-
-        if basin_shp.exists():
-            return gpd.read_file(basin_shp)
-
-        self.logger.warning("Catchment shapefile not found, using bounding box")
-        return None
+        Delegates to the shared resolver, which handles the nested
+        discretization layout and river_basins fallback. Returns None when
+        no basin is found (callers fall back to the bounding box).
+        """
+        return self._load_catchment_gdf()
 
     def _process_netcdf(
         self,

--- a/src/symfluence/data/observation/handlers/modis_snow.py
+++ b/src/symfluence/data/observation/handlers/modis_snow.py
@@ -255,16 +255,9 @@ class MODISSnowHandler(BaseObservationHandler):
 
     def _extract_with_catchment_mask(self, data: xr.DataArray, ds: xr.Dataset) -> pd.DataFrame:
         """Extract SCA using catchment shapefile as mask."""
-        catchment_path = self._get_config_value(lambda: self.config.domain.catchment_path, default=None)
-        catchment_name = self._get_config_value(lambda: self.config.domain.catchment_shp_name, default=None)
-
-        if not catchment_path or not catchment_name:
-            self.logger.warning("Catchment mask requested but CATCHMENT_PATH/CATCHMENT_SHP_NAME not set")
-            return self._extract_spatial_average(data)
-
-        shp_path = Path(catchment_path) / catchment_name
-        if not shp_path.exists():
-            self.logger.warning(f"Catchment shapefile not found: {shp_path}")
+        shp_path = self._resolve_catchment_shapefile()
+        if shp_path is None:
+            self.logger.warning("Catchment shapefile not found; using spatial average")
             return self._extract_spatial_average(data)
 
         try:

--- a/src/symfluence/data/observation/handlers/mswep.py
+++ b/src/symfluence/data/observation/handlers/mswep.py
@@ -127,29 +127,13 @@ class MSWEPHandler(BaseObservationHandler):
         return output_file
 
     def _load_catchment_shapefile(self) -> Optional[gpd.GeoDataFrame]:
-        """Load catchment shapefile for spatial masking."""
-        catchment_path_cfg = self._get_config_value(lambda: self.config.domain.catchment_path, default='default')
-        if catchment_path_cfg == 'default' or not catchment_path_cfg:
-            catchment_path = self.project_dir / "shapefiles" / "catchment"
-        else:
-            catchment_path = Path(catchment_path_cfg)
+        """Load the catchment shapefile for spatial masking.
 
-        catchment_name = self._get_config_value(lambda: self.config.domain.catchment_shp_name, default=f"{self.domain_name}_catchment.shp")
-
-        basin_shp = catchment_path / catchment_name
-        if not basin_shp.exists():
-            # Try alternate patterns
-            for pattern in [f"{self.domain_name}*.shp", "*.shp"]:
-                matches = list(catchment_path.glob(pattern))
-                if matches:
-                    basin_shp = matches[0]
-                    break
-
-        if basin_shp.exists():
-            return gpd.read_file(basin_shp)
-
-        self.logger.warning("Catchment shapefile not found, using bounding box")
-        return None
+        Delegates to the shared resolver, which handles the nested
+        discretization layout and river_basins fallback. Returns None when
+        no basin is found (callers fall back to the bounding box).
+        """
+        return self._load_catchment_gdf()
 
     def _extract_basin_precip(
         self,

--- a/src/symfluence/data/observation/handlers/sentinel1_sm.py
+++ b/src/symfluence/data/observation/handlers/sentinel1_sm.py
@@ -140,28 +140,13 @@ class Sentinel1SMHandler(BaseObservationHandler):
         return output_file
 
     def _load_catchment_shapefile(self) -> Optional[gpd.GeoDataFrame]:
-        """Load catchment shapefile for spatial masking."""
-        catchment_path_cfg = self._get_config_value(lambda: self.config.domain.catchment_path, default='default')
-        if catchment_path_cfg == 'default' or not catchment_path_cfg:
-            catchment_path = self.project_dir / "shapefiles" / "catchment"
-        else:
-            catchment_path = Path(catchment_path_cfg)
+        """Load the catchment shapefile for spatial masking.
 
-        catchment_name = self._get_config_value(lambda: self.config.domain.catchment_shp_name, default=f"{self.domain_name}_catchment.shp")
-
-        basin_shp = catchment_path / catchment_name
-        if not basin_shp.exists():
-            for pattern in [f"{self.domain_name}*.shp", "*.shp"]:
-                matches = list(catchment_path.glob(pattern))
-                if matches:
-                    basin_shp = matches[0]
-                    break
-
-        if basin_shp.exists():
-            return gpd.read_file(basin_shp)
-
-        self.logger.warning("Catchment shapefile not found, using bounding box")
-        return None
+        Delegates to the shared resolver, which handles the nested
+        discretization layout and river_basins fallback. Returns None when
+        no basin is found (callers fall back to the bounding box).
+        """
+        return self._load_catchment_gdf()
 
     def _process_netcdf(
         self,

--- a/src/symfluence/data/observation/handlers/viirs_snow.py
+++ b/src/symfluence/data/observation/handlers/viirs_snow.py
@@ -132,28 +132,13 @@ class VIIRSSnowHandler(BaseObservationHandler):
         return output_file
 
     def _load_catchment_shapefile(self) -> Optional[gpd.GeoDataFrame]:
-        """Load catchment shapefile for spatial masking."""
-        catchment_path_cfg = self._get_config_value(lambda: self.config.domain.catchment_path, default='default')
-        if catchment_path_cfg == 'default' or not catchment_path_cfg:
-            catchment_path = self.project_dir / "shapefiles" / "catchment"
-        else:
-            catchment_path = Path(catchment_path_cfg)
+        """Load the catchment shapefile for spatial masking.
 
-        catchment_name = self._get_config_value(lambda: self.config.domain.catchment_shp_name, default=f"{self.domain_name}_catchment.shp")
-
-        basin_shp = catchment_path / catchment_name
-        if not basin_shp.exists():
-            for pattern in [f"{self.domain_name}*.shp", "*.shp"]:
-                matches = list(catchment_path.glob(pattern))
-                if matches:
-                    basin_shp = matches[0]
-                    break
-
-        if basin_shp.exists():
-            return gpd.read_file(basin_shp)
-
-        self.logger.warning("Catchment shapefile not found, using bounding box")
-        return None
+        Delegates to the shared resolver, which handles the nested
+        discretization layout and river_basins fallback. Returns None when
+        no basin is found (callers fall back to the bounding box).
+        """
+        return self._load_catchment_gdf()
 
     def _process_netcdf(
         self,

--- a/tests/unit/data/observation/test_grace_basin_resolution.py
+++ b/tests/unit/data/observation/test_grace_basin_resolution.py
@@ -1,14 +1,16 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
 
-"""Tests for GRACEHandler basin-shapefile resolution.
+"""Tests for the shared observation-handler basin-shapefile resolver.
 
 Regression coverage for the case where domain discretization writes the
 catchment under the nested, experiment-scoped layout
 (``shapefiles/catchment/{definition_method}/{experiment_id}/
 {domain}_HRUs_{discretization}.shp``) rather than a flat
-``{domain}_catchment.shp``. The resolver must find the nested file, fall
-back to the river_basins outline, and honour explicit config.
+``{domain}_catchment.shp``. The resolver (``BaseObservationHandler.
+_resolve_catchment_shapefile``) must find the nested file, fall back to the
+river_basins outline, and honour explicit config — for every observation
+handler, not just GRACE.
 """
 import logging
 
@@ -59,7 +61,7 @@ def test_resolves_nested_discretized_catchment(tmp_path):
     )
     _touch_shp(nested)
 
-    assert handler._resolve_basin_shapefile() == nested
+    assert handler._resolve_catchment_shapefile(required=True) == nested
 
 
 def test_falls_back_to_river_basins(tmp_path):
@@ -68,7 +70,7 @@ def test_falls_back_to_river_basins(tmp_path):
     rb = handler.project_shapefiles_dir / "river_basins" / f"{DOMAIN}_riverBasins_lumped.shp"
     _touch_shp(rb)
 
-    assert handler._resolve_basin_shapefile() == rb
+    assert handler._resolve_catchment_shapefile(required=True) == rb
 
 
 def test_prefers_catchment_over_river_basins(tmp_path):
@@ -82,7 +84,7 @@ def test_prefers_catchment_over_river_basins(tmp_path):
     _touch_shp(nested)
     _touch_shp(handler.project_shapefiles_dir / "river_basins" / f"{DOMAIN}_riverBasins_lumped.shp")
 
-    assert handler._resolve_basin_shapefile() == nested
+    assert handler._resolve_catchment_shapefile(required=True) == nested
 
 
 def test_honours_explicit_catchment_path_and_name(tmp_path):
@@ -95,11 +97,57 @@ def test_honours_explicit_catchment_path_and_name(tmp_path):
         CATCHMENT_SHP_NAME="basin.shp",
     )
 
-    assert handler._resolve_basin_shapefile() == custom
+    assert handler._resolve_catchment_shapefile(required=True) == custom
 
 
 def test_raises_clear_error_when_nothing_found(tmp_path):
     """A helpful FileNotFoundError is raised when no basin exists."""
     handler = _handler(tmp_path)
     with pytest.raises(FileNotFoundError, match="define_domain"):
-        handler._resolve_basin_shapefile()
+        handler._resolve_catchment_shapefile(required=True)
+
+
+def test_not_required_returns_none(tmp_path):
+    """Without required=True, a missing basin resolves to None (no raise)."""
+    handler = _handler(tmp_path)
+    assert handler._resolve_catchment_shapefile(required=False) is None
+
+
+def test_shared_resolver_works_for_non_grace_handler(tmp_path):
+    """The resolver lives on the base class, so any handler benefits."""
+    from symfluence.data.observation.handlers.era5_land import ERA5LandHandler
+
+    handler = ERA5LandHandler(_config(tmp_path), logging.getLogger("test_era5_basin"))
+    nested = (
+        handler.project_shapefiles_dir
+        / "catchment" / "lumped" / EXPERIMENT
+        / f"{DOMAIN}_HRUs_GRUS.shp"
+    )
+    _touch_shp(nested)
+
+    assert handler._resolve_catchment_shapefile() == nested
+
+
+def test_load_catchment_gdf_reads_resolved_shapefile(tmp_path):
+    """_load_catchment_gdf returns a GeoDataFrame for the resolved basin."""
+    import geopandas as gpd
+    from shapely.geometry import box
+
+    handler = _handler(tmp_path)
+    nested = (
+        handler.project_shapefiles_dir
+        / "catchment" / "lumped" / EXPERIMENT
+        / f"{DOMAIN}_HRUs_GRUS.shp"
+    )
+    nested.parent.mkdir(parents=True, exist_ok=True)
+    gpd.GeoDataFrame({"id": [1]}, geometry=[box(0, 0, 1, 1)], crs="EPSG:4326").to_file(nested)
+
+    gdf = handler._load_catchment_gdf()
+    assert gdf is not None
+    assert len(gdf) == 1
+
+
+def test_load_catchment_gdf_returns_none_when_missing(tmp_path):
+    """_load_catchment_gdf returns None (warning path) when no basin exists."""
+    handler = _handler(tmp_path)
+    assert handler._load_catchment_gdf() is None


### PR DESCRIPTION
## Summary

Generalises the GRACE catchment-path fix into a **single shared resolver** on `BaseObservationHandler` and routes every catchment-using observation handler through it, replacing per-handler flat-path lookups that silently failed against the real on-disk layout.

### The bug
Each handler independently built a flat `shapefiles/catchment/{domain}_catchment.shp` path and read the catchment location from `config.domain.catchment_path` / `config.domain.catchment_shp_name` — but **those keys live on `config.paths`**, so explicit `CATCHMENT_PATH` / `CATCHMENT_SHP_NAME` was silently ignored. Worse, discretization actually writes the catchment under an experiment-scoped layout:

```
shapefiles/catchment/{definition_method}/{experiment_id}/{domain}_HRUs_{discretization}.shp
```

(with the suffix sometimes upper-cased, `GRUs` → `GRUS`). The flat lookup never matched, so GRACE TWS processing failed with `Basin shapefile not found` even though the shapefile existed.

### The fix
New `BaseObservationHandler._resolve_catchment_shapefile()` / `_load_catchment_gdf()` resolve in order:
1. Explicit `CATCHMENT_PATH` / `CATCHMENT_SHP_NAME` (read from the correct `config.paths` location)
2. Canonical nested layout (`{definition_method}/{experiment_id}/`), then the legacy flat dir
3. Deep search under `catchment/` for `{domain}_HRUs_*.shp` (handles experiment/casing drift)
4. `river_basins` outline fallback
5. Clear, actionable `FileNotFoundError` only when `required=True`

**Handlers routed through the shared helper:** `grace`, `era5_land`, `daymet`, `canopy_height`, `mswep`, `modis_lst`, `modis_lai`, `viirs_snow`, `sentinel1_sm`, `jrc_water`, `modis_snow`. Net **−123 lines** of duplicated logic.

## Testing
- 9 resolver unit tests (nested resolution, river_basins fallback, explicit-config precedence, required/not-required, a non-GRACE handler, real-GeoDataFrame loading).
- Full observation + acquisition suites: **2039 passed**; ruff clean.
- **Verified end-to-end against the real `Bow_at_Banff_multivar` domain**: GRACE TWS processing resolved a catchment written under a *different* experiment id (`bow_tws_uncalibrated`) than the config's `experiment_id` (`bow_exp2_tws_only`), with an upper-cased `GRUS` suffix, computed basin area 2205 km², and produced the processed TWS series.

## Scope / follow-up
This PR covers the **observation handlers** only. A codebase-wide search found ~20 *non-handler* sites with the same flat-path assumption (FUSE, MESH, RHESSys, mizuRoute, CLM, evaluation, reporting) — left for a separate, more careful PR.

---
Repo and code assistance from [Claude](https://claude.ai) (Anthropic).