### PR TITLE
fix(paths): resolve nested catchment/basin shapefiles across non-handler sites (#159)

### DIFF
--- a/src/symfluence/core/path_resolver.py
+++ b/src/symfluence/core/path_resolver.py
@@ -163,6 +163,173 @@ def resolve_file_path(
     return file_path
 
 
+def find_basin_shapefile(
+    shapefiles_dir: Path,
+    domain_name: str,
+    definition_method: str,
+    experiment_id: str,
+    *,
+    explicit_path: Optional[str] = None,
+    explicit_name: Optional[str] = None,
+    include_river_basins: bool = True,
+    required: bool = False,
+    logger: Optional[logging.Logger] = None,
+) -> Optional[Path]:
+    """Locate an EXISTING catchment/basin polygon shapefile on disk.
+
+    Discretization writes the catchment under an experiment-scoped nested layout
+    (``catchment/{definition_method}/{experiment_id}/{domain}_HRUs_{disc}.shp``)
+    and may upper-case the discretization suffix (GRUs -> GRUS), so a flat
+    ``catchment/{domain}_catchment.shp`` lookup never matches. This finder is a
+    READ-side complement to :meth:`PathResolverMixin._get_catchment_file_path`
+    (which builds the canonical WRITE path). Resolution order:
+
+    1. ``explicit_path`` (+ ``explicit_name``) when provided and non-'default'.
+    2. The canonical nested layout, then the legacy flat ``catchment`` directory.
+    3. A deep search under ``catchment/`` for ``{domain}_HRUs_*.shp`` (handles
+       experiment-id and casing drift).
+    4. The ``river_basins`` outline (any single-polygon basin works for masking
+       or area), unless ``include_river_basins`` is False.
+
+    Args:
+        shapefiles_dir: The domain's ``shapefiles`` directory.
+        domain_name: Domain name (filename prefix).
+        definition_method: e.g. ``lumped`` / ``semidistributed`` (nesting level 1).
+        experiment_id: Experiment id (nesting level 2).
+        explicit_path: Optional CATCHMENT_PATH override (dir or 'default').
+        explicit_name: Optional CATCHMENT_SHP_NAME override (file or 'default').
+        include_river_basins: Allow falling back to the river_basins outline.
+        required: Raise FileNotFoundError when nothing is found.
+        logger: Optional logger for a debug breadcrumb.
+
+    Returns:
+        The resolved Path, or None when not found and not ``required``.
+    """
+    def _log(found: Path) -> Path:
+        if logger is not None:
+            logger.debug(f"Resolved basin shapefile: {found}")
+        return found
+
+    # 1. Explicit user-provided path/name.
+    if explicit_path and explicit_path != 'default':
+        base_dir = Path(explicit_path)
+        if explicit_name and explicit_name != 'default':
+            explicit = base_dir / explicit_name
+            if explicit.exists():
+                return _log(explicit)
+        found = sorted(base_dir.rglob("*.shp")) if base_dir.exists() else []
+        if found:
+            return _log(found[0])
+
+    catchment_dir = shapefiles_dir / "catchment"
+
+    # 2. Canonical nested layout, then legacy flat directory.
+    nested_dir = catchment_dir / definition_method / experiment_id
+    for candidate_dir in (nested_dir, catchment_dir):
+        if not candidate_dir.exists():
+            continue
+        matches = (
+            sorted(candidate_dir.glob(f"{domain_name}_HRUs_*.shp"))
+            or sorted(candidate_dir.glob(f"{domain_name}*.shp"))
+        )
+        if not matches and candidate_dir == nested_dir:
+            matches = sorted(candidate_dir.glob("*.shp"))
+        if matches:
+            return _log(matches[0])
+
+    # 3. Deep search anywhere under catchment/ (experiment/casing drift).
+    if catchment_dir.exists():
+        deep = sorted(catchment_dir.rglob(f"{domain_name}_HRUs_*.shp"))
+        if deep:
+            return _log(deep[0])
+
+    # 4. River basins outline as a last resort.
+    if include_river_basins:
+        river_basins_dir = shapefiles_dir / "river_basins"
+        if river_basins_dir.exists():
+            rb_matches = (
+                sorted(river_basins_dir.glob(f"{domain_name}_riverBasins_*.shp"))
+                or sorted(river_basins_dir.glob("*.shp"))
+            )
+            if rb_matches:
+                return _log(rb_matches[0])
+
+    if required:
+        raise FileNotFoundError(
+            f"Catchment/basin shapefile not found. Searched '{catchment_dir}' "
+            f"(incl. {definition_method}/{experiment_id})"
+            f"{' and river_basins' if include_river_basins else ''}. Run "
+            f"define_domain + discretize_domain first, or set "
+            f"CATCHMENT_PATH/CATCHMENT_SHP_NAME."
+        )
+    return None
+
+
+def find_catchment_subfile(
+    shapefiles_dir: Path,
+    definition_method: str,
+    experiment_id: str,
+    filename: str,
+    *,
+    logger: Optional[logging.Logger] = None,
+) -> Optional[Path]:
+    """Find a specifically-named file under the nested catchment layout.
+
+    For artifacts written with a fixed name (e.g.
+    ``{domain}_catchment_delineated.shp``) that discretization places under
+    ``catchment/{definition_method}/{experiment_id}/``. Checks the nested path,
+    then the legacy flat ``catchment`` directory, then deep-searches. Returns
+    None when not found.
+    """
+    catchment_dir = shapefiles_dir / "catchment"
+    for candidate in (
+        catchment_dir / definition_method / experiment_id / filename,
+        catchment_dir / filename,
+    ):
+        if candidate.exists():
+            if logger is not None:
+                logger.debug(f"Resolved catchment file: {candidate}")
+            return candidate
+    if catchment_dir.exists():
+        deep = sorted(catchment_dir.rglob(filename))
+        if deep:
+            if logger is not None:
+                logger.debug(f"Resolved catchment file (deep search): {deep[0]}")
+            return deep[0]
+    return None
+
+
+def find_river_basins_shapefile(
+    shapefiles_dir: Path,
+    domain_name: str,
+    *,
+    required: bool = False,
+    logger: Optional[logging.Logger] = None,
+) -> Optional[Path]:
+    """Locate the EXISTING river-basins (domain outline) shapefile.
+
+    Domain definition writes ``river_basins/{domain}_riverBasins_{method}.shp``
+    (flat, method-suffixed — not experiment-nested). Returns None when not found
+    unless ``required``.
+    """
+    river_basins_dir = shapefiles_dir / "river_basins"
+    if river_basins_dir.exists():
+        matches = (
+            sorted(river_basins_dir.glob(f"{domain_name}_riverBasins_*.shp"))
+            or sorted(river_basins_dir.glob("*.shp"))
+        )
+        if matches:
+            if logger is not None:
+                logger.debug(f"Resolved river_basins shapefile: {matches[0]}")
+            return matches[0]
+    if required:
+        raise FileNotFoundError(
+            f"River-basins shapefile not found under '{river_basins_dir}'. "
+            f"Run define_domain first."
+        )
+    return None
+
+
 from .mixins import ConfigurableMixin
 
 
@@ -332,6 +499,37 @@ class PathResolverMixin(ConfigurableMixin):
             self.domain_definition_method / self.experiment_id / catchment_name
         )
         return new_path
+
+    def _find_basin_shapefile(
+        self,
+        required: bool = False,
+        include_river_basins: bool = True,
+    ) -> Optional[Path]:
+        """Locate an EXISTING catchment/basin shapefile for reading.
+
+        Read-side complement to :meth:`_get_catchment_file_path` (which builds
+        the canonical write path). Honours explicit CATCHMENT_PATH /
+        CATCHMENT_SHP_NAME, searches the nested discretization layout, and falls
+        back to the river_basins outline. Returns None when not found unless
+        ``required``. See :func:`find_basin_shapefile`.
+        """
+        explicit_path = self._get_config_value(
+            lambda: self.config.paths.catchment_path, default='default', dict_key='CATCHMENT_PATH'
+        )
+        explicit_name = self._get_config_value(
+            lambda: self.config.paths.catchment_name, default='default', dict_key='CATCHMENT_SHP_NAME'
+        )
+        return find_basin_shapefile(
+            self.project_dir / "shapefiles",
+            self.domain_name,
+            self.domain_definition_method,
+            self.experiment_id,
+            explicit_path=explicit_path,
+            explicit_name=explicit_name,
+            include_river_basins=include_river_basins,
+            required=required,
+            logger=getattr(self, 'logger', None),
+        )
 
     def _get_method_suffix(self) -> str:
         """

--- a/src/symfluence/core/system.py
+++ b/src/symfluence/core/system.py
@@ -28,6 +28,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 from symfluence.core.config.models import SymfluenceConfig
 from symfluence.core.exceptions import SYMFLUENCEError
 from symfluence.core.mixins.project import resolve_data_subdir
+from symfluence.core.path_resolver import find_basin_shapefile, find_river_basins_shapefile
 from symfluence.core.provenance import capture_provenance
 from symfluence.core.provenance import finalize as finalize_provenance
 from symfluence.project.logging_manager import LoggingManager
@@ -56,10 +57,21 @@ class _DiagnosticSpec:
     """Callable(config, project_dir) → kwargs dict for the plotter, or None to skip."""
 
 
+def _domain_ctx(config: SymfluenceConfig) -> tuple:
+    """Extract (domain_name, definition_method, experiment_id) for shapefile lookup."""
+    domain = getattr(config, 'domain', None)
+    return (
+        getattr(domain, 'name', None),
+        getattr(domain, 'definition_method', 'lumped'),
+        getattr(domain, 'experiment_id', 'run_1'),
+    )
+
+
 def _load_domain(config: SymfluenceConfig, project_dir: Path) -> Optional[Dict[str, Any]]:
     import geopandas as gpd
-    basin_path = project_dir / "shapefiles" / "river_basins" / "river_basins.shp"
-    if not basin_path.exists():
+    name, _method, _exp = _domain_ctx(config)
+    basin_path = find_river_basins_shapefile(project_dir / "shapefiles", name)
+    if basin_path is None:
         return None
     dem_path = resolve_data_subdir(project_dir, 'attributes') / "dem" / "dem.tif"
     return dict(
@@ -70,8 +82,9 @@ def _load_domain(config: SymfluenceConfig, project_dir: Path) -> Optional[Dict[s
 
 def _load_discretization(config: SymfluenceConfig, project_dir: Path) -> Optional[Dict[str, Any]]:
     import geopandas as gpd
-    hru_path = project_dir / "shapefiles" / "catchment" / "catchment.shp"
-    if not hru_path.exists():
+    name, method, exp = _domain_ctx(config)
+    hru_path = find_basin_shapefile(project_dir / "shapefiles", name, method, exp)
+    if hru_path is None:
         return None
     return dict(
         hru_gdf=gpd.read_file(hru_path),
@@ -98,10 +111,11 @@ def _load_forcing_raw(config: SymfluenceConfig, project_dir: Path) -> Optional[D
     nc_files = list(forcing_dir.glob("*.nc"))
     if not nc_files:
         return None
-    domain_shp = project_dir / "shapefiles" / "river_basins" / "river_basins.shp"
+    name, _method, _exp = _domain_ctx(config)
+    domain_shp = find_river_basins_shapefile(project_dir / "shapefiles", name)
     return dict(
         forcing_nc=nc_files[0],
-        domain_shp=domain_shp if domain_shp.exists() else None,
+        domain_shp=domain_shp,
     )
 
 
@@ -114,11 +128,12 @@ def _load_forcing_remapped(config: SymfluenceConfig, project_dir: Path) -> Optio
     remapped_files = list(remapped_dir.glob("*.nc"))
     if not raw_files or not remapped_files:
         return None
-    hru_shp = project_dir / "shapefiles" / "catchment" / "catchment.shp"
+    name, method, exp = _domain_ctx(config)
+    hru_shp = find_basin_shapefile(project_dir / "shapefiles", name, method, exp)
     return dict(
         raw_nc=raw_files[0],
         remapped_nc=remapped_files[0],
-        hru_shp=hru_shp if hru_shp.exists() else None,
+        hru_shp=hru_shp,
     )
 
 

--- a/src/symfluence/data/acquisition/observed_processor.py
+++ b/src/symfluence/data/acquisition/observed_processor.py
@@ -18,6 +18,7 @@ from symfluence.core.constants import UnitConversion
 from symfluence.core.exceptions import DataAcquisitionError
 from symfluence.core.mixins import ConfigMixin
 from symfluence.core.mixins.project import resolve_data_subdir
+from symfluence.core.path_resolver import find_basin_shapefile
 
 
 class ObservedDataProcessor(ConfigMixin):
@@ -743,24 +744,22 @@ class ObservedDataProcessor(ConfigMixin):
             if discharge_unit == 'mm/d':
                 # Get the basin area from the shapefile
                 try:
-                    # Determine the shapefile path
-                    subbasins_name = self._get_config_value(lambda: self.config.paths.river_basins_name, dict_key='RIVER_BASINS_NAME')
-                    if subbasins_name == 'default':
-                        subbasins_name = f"{self._get_config_value(lambda: self.config.domain.name, dict_key='DOMAIN_NAME')}_riverBasins.shp"
-
+                    # Determine the shapefile path. Honour an explicit override,
+                    # else use the shared resolver (handles the nested catchment
+                    # layout and river_basins fallback).
                     shapefile_path_str = self._get_config_value(lambda: None, default=None, dict_key='RIVER_BASIN_SHP_PATH')
                     if shapefile_path_str:
                         shapefile_path = Path(shapefile_path_str)
                     else:
-                        # Try default locations
-                        shapefile_path = self.project_dir / "shapefiles/river_basins" / subbasins_name
-                        if not shapefile_path.exists():
-                            alt_shapefile_path = self.project_dir / "shapefiles/catchment" / f"{self._get_config_value(lambda: self.config.domain.name, dict_key='DOMAIN_NAME')}_catchment.shp"
-                            if alt_shapefile_path.exists():
-                                shapefile_path = alt_shapefile_path
-                                self.logger.info(f"Using alternative shapefile: {shapefile_path}")
-                            else:
-                                raise FileNotFoundError(f"Cannot find shapefile at {shapefile_path} or {alt_shapefile_path}")
+                        domain_name = self._get_config_value(lambda: self.config.domain.name, dict_key='DOMAIN_NAME')
+                        shapefile_path = find_basin_shapefile(
+                            self.project_dir / "shapefiles",
+                            domain_name,
+                            self.domain_definition_method,
+                            self.experiment_id,
+                            required=True,
+                            logger=self.logger,
+                        )
 
                     # Read the shapefile
                     import geopandas as gpd

--- a/src/symfluence/data/data_manager.py
+++ b/src/symfluence/data/data_manager.py
@@ -16,6 +16,7 @@ import pandas as pd
 
 from symfluence.core.base_manager import BaseManager
 from symfluence.core.exceptions import DataAcquisitionError, symfluence_error_handler
+from symfluence.core.path_resolver import find_basin_shapefile
 from symfluence.core.registries import R
 from symfluence.data.acquisition.acquisition_service import AcquisitionService
 from symfluence.data.acquisition.observed_processor import ObservedDataProcessor
@@ -622,21 +623,20 @@ class DataManager(BaseManager):
             if explicit_path.exists():
                 return explicit_path
 
-        # Search for HRU shapefiles with common patterns
-        patterns = [
-            f"{domain_name}_HRUs_*.shp",
-            f"{domain_name}_catchment*.shp",
-            "*HRU*.shp",
-            "*catchment*.shp",
-            "*.shp"  # Fallback to any shapefile
-        ]
-
-        for pattern in patterns:
-            matches = list(catchment_dir.glob(pattern))
-            if matches:
-                return matches[0]
-
-        return None
+        # Search the nested discretization layout (and legacy flat dir) via the
+        # shared finder.
+        return find_basin_shapefile(
+            self.project_dir / 'shapefiles',
+            domain_name,
+            self._get_config_value(
+                lambda: self.config.domain.definition_method, default='lumped',
+                dict_key='DOMAIN_DEFINITION_METHOD'),
+            self._get_config_value(
+                lambda: self.config.domain.experiment_id, default='run_1',
+                dict_key='EXPERIMENT_ID'),
+            include_river_basins=False,
+            logger=self.logger,
+        )
 
     def _find_forcing_shapefile(self) -> Optional[Path]:
         """

--- a/src/symfluence/evaluation/evaluators/streamflow.py
+++ b/src/symfluence/evaluation/evaluators/streamflow.py
@@ -20,6 +20,7 @@ import pandas as pd
 import xarray as xr
 
 from symfluence.core.constants import UnitConverter
+from symfluence.core.path_resolver import find_basin_shapefile
 from symfluence.data.observation.paths import first_existing_path, streamflow_observation_candidates
 from symfluence.evaluation.output_file_locator import OutputFileLocator
 from symfluence.evaluation.registry import EvaluationRegistry
@@ -754,10 +755,17 @@ class StreamflowEvaluator(ModelEvaluator):
         # Priority 3: Try catchment shapefile
         try:
             import geopandas as gpd
-            catchment_path = self.project_dir / "shapefiles" / "catchment"
-            catchment_files = list(catchment_path.glob("*.shp"))
-            if catchment_files:
-                gdf = gpd.read_file(catchment_files[0])
+            # Resolve the nested discretized catchment (river_basins already
+            # handled in priority 2).
+            catchment_shp = find_basin_shapefile(
+                self.project_dir / "shapefiles",
+                self.domain_name,
+                self.domain_definition_method,
+                self.experiment_id,
+                include_river_basins=False,
+            )
+            if catchment_shp is not None:
+                gdf = gpd.read_file(catchment_shp)
                 area_col = self._get_config_value(
                     lambda: self.config.geospatial.catchment_area_column,
                     default='HRU_area',

--- a/src/symfluence/evaluation/utilities/streamflow_metrics.py
+++ b/src/symfluence/evaluation/utilities/streamflow_metrics.py
@@ -17,6 +17,7 @@ import pandas as pd
 
 from symfluence.core.constants import ModelDefaults, UnitConversion
 from symfluence.core.mixins.project import resolve_data_subdir
+from symfluence.core.path_resolver import find_basin_shapefile
 from symfluence.evaluation.metrics import kge, kge_prime, mae, nse, rmse
 
 logger = logging.getLogger(__name__)
@@ -148,75 +149,23 @@ class StreamflowMetrics:
         """Get catchment area from shapefile/geopackage."""
         import geopandas as gpd
 
-        # Resolve catchment path
-        catchment_path = config.get('CATCHMENT_PATH', 'default')
-        if catchment_path == 'default' or not catchment_path:
-            catchment_path = project_dir / 'shapefiles' / 'catchment'
-        else:
-            catchment_path = Path(catchment_path)
-
-        # Resolve catchment filename
-        discretization = config.get('SUB_GRID_DISCRETIZATION', 'elevation')
-        catchment_name = config.get('CATCHMENT_SHP_NAME', 'default')
-        if catchment_name == 'default' or not catchment_name:
-            catchment_name = f"{domain_name}_HRUs_{discretization}.shp"
-
-        # Build list of paths to search (in priority order)
-        domain_method = config.get('DOMAIN_DEFINITION_METHOD', 'lumped')
-        experiment_id = config.get('EXPERIMENT_ID', 'run_1')
-
-        # Also search for GRUs variant (common naming convention)
-        grus_name = f"{domain_name}_HRUs_GRUs.shp"
-
-        # Build search paths with multiple fallbacks
-        # Shapefiles are typically created during preprocessing and may be in a different
-        # experiment directory (commonly run_1) than the current calibration experiment
-        search_paths = [
-            catchment_path / catchment_name,  # Direct path
-            catchment_path / domain_method / experiment_id / catchment_name,  # Current experiment
-            catchment_path / domain_method / catchment_name,  # Without experiment_id
-            catchment_path / grus_name,  # GRUs variant direct
-            catchment_path / domain_method / experiment_id / grus_name,  # GRUs current experiment
-            catchment_path / domain_method / grus_name,  # GRUs without experiment_id
-        ]
-
-        # Add run_1 as fallback if current experiment_id is different
-        # (shapefiles are typically created during initial preprocessing in run_1)
-        if experiment_id != 'run_1':
-            search_paths.extend([
-                catchment_path / domain_method / 'run_1' / catchment_name,
-                catchment_path / domain_method / 'run_1' / grus_name,
-            ])
-
-        # Find the first existing file
-        catchment_file = None
-        for path in search_paths:
-            if path.exists():
-                catchment_file = path
-                logger.debug(f"Found catchment shapefile: {path}")
-                break
-
-        # Last resort: search any existing experiment directory under domain_method
-        if catchment_file is None:
-            domain_method_dir = catchment_path / domain_method
-            if domain_method_dir.exists():
-                for exp_dir in sorted(domain_method_dir.iterdir()):
-                    if exp_dir.is_dir():
-                        for name in [catchment_name, grus_name]:
-                            candidate = exp_dir / name
-                            if candidate.exists():
-                                catchment_file = candidate
-                                logger.debug(
-                                    f"Found catchment shapefile in fallback search: {candidate}"
-                                )
-                                break
-                    if catchment_file:
-                        break
+        # Resolve via the shared finder: handles the nested experiment-scoped
+        # layout, the GRUs/GRUS casing drift, cross-experiment shapefiles
+        # (preprocessing often writes under run_1), and explicit
+        # CATCHMENT_PATH / CATCHMENT_SHP_NAME overrides.
+        catchment_file = find_basin_shapefile(
+            project_dir / 'shapefiles',
+            domain_name,
+            config.get('DOMAIN_DEFINITION_METHOD', 'lumped'),
+            config.get('EXPERIMENT_ID', 'run_1'),
+            explicit_path=config.get('CATCHMENT_PATH', 'default'),
+            explicit_name=config.get('CATCHMENT_SHP_NAME', 'default'),
+            logger=logger,
+        )
 
         if catchment_file is None:
             logger.warning(
                 f"Catchment shapefile not found for {domain_name}. "
-                f"Searched paths include: {catchment_path / domain_method}. "
                 f"Using default area {default_area} km2. "
                 f"This may cause incorrect unit conversions during calibration!"
             )

--- a/src/symfluence/models/clm/domain_generator.py
+++ b/src/symfluence/models/clm/domain_generator.py
@@ -52,19 +52,10 @@ class CLMDomainGenerator:
         if shapefile_path and shapefile_path != 'default':
             shapefile = Path(shapefile_path)
         else:
-            shapefile = (
-                self.pp.project_dir / 'shapefiles' / 'catchment'
-                / f'{self.pp.domain_name}_catchment.shp'
-            )
+            # Shared resolver: nested layout, casing drift, river_basins fallback.
+            shapefile = self.pp._find_basin_shapefile()
 
-        if not shapefile.exists():
-            for pattern in ['**/*catchment*.shp', '**/*.shp']:
-                shps = list(self.pp.project_dir.glob(pattern))
-                if shps:
-                    shapefile = shps[0]
-                    break
-
-        if shapefile.exists():
+        if shapefile is not None and shapefile.exists():
             import geopandas as gpd
             gdf = gpd.read_file(shapefile)
             if gdf.crs and gdf.crs.to_epsg() != 4326:

--- a/src/symfluence/models/execution/spatial_orchestrator.py
+++ b/src/symfluence/models/execution/spatial_orchestrator.py
@@ -41,6 +41,7 @@ import numpy as np
 import xarray as xr
 
 from symfluence.core.exceptions import GeospatialError, ModelExecutionError
+from symfluence.core.path_resolver import find_basin_shapefile
 from symfluence.models.spatial_modes import SpatialMode
 
 
@@ -727,15 +728,20 @@ class SpatialOrchestrator(ABC):
         import geopandas as gpd
 
         if shapefile_path is None:
-            catchment_name = self._get_config_value(
-                lambda: None, default='default', dict_key='CATCHMENT_SHP_NAME')
-            if catchment_name == 'default':
-                discretization = self._get_config_value(
-                    lambda: self.config.domain.discretization, default='catchment')
-                catchment_name = f"{self.domain_name}_HRUs_{discretization}.shp"
-            shapefile_path = self.project_dir / 'shapefiles' / 'catchment' / catchment_name
+            shapefile_path = find_basin_shapefile(
+                self.project_dir / 'shapefiles',
+                self.domain_name,
+                self._get_config_value(
+                    lambda: self.config.domain.definition_method, default='lumped',
+                    dict_key='DOMAIN_DEFINITION_METHOD'),
+                self._get_config_value(
+                    lambda: self.config.domain.experiment_id, default='run_1',
+                    dict_key='EXPERIMENT_ID'),
+                include_river_basins=False,
+                logger=self.logger,
+            )
 
-        if not shapefile_path.exists():
+        if shapefile_path is None or not shapefile_path.exists():
             self.logger.warning(f"Shapefile not found: {shapefile_path}")
             return 1
 

--- a/src/symfluence/models/fuse/forcing_processor.py
+++ b/src/symfluence/models/fuse/forcing_processor.py
@@ -19,6 +19,7 @@ import numpy as np
 import xarray as xr
 
 from symfluence.core.exceptions import FileOperationError, ModelExecutionError
+from symfluence.core.path_resolver import find_catchment_subfile
 from symfluence.data.utils.variable_utils import VariableHandler
 
 from ..spatial_modes import SpatialMode
@@ -483,10 +484,17 @@ class FuseForcingProcessor(BaseForcingProcessor):
 
     def _load_subcatchment_data(self) -> np.ndarray:
         """Load subcatchment information for semi-distributed mode"""
-        # Check if delineated catchments exist (for distributed routing)
-        delineated_path = self.project_dir / 'shapefiles' / 'catchment' / f"{self.domain_name}_catchment_delineated.shp"
+        # Check if delineated catchments exist (for distributed routing).
+        # Discretization writes this under the nested experiment layout.
+        delineated_path = find_catchment_subfile(
+            self.project_dir / 'shapefiles',
+            self.domain_definition_method,
+            self.experiment_id,
+            f"{self.domain_name}_catchment_delineated.shp",
+            logger=self.logger,
+        )
 
-        if delineated_path.exists():
+        if delineated_path is not None:
             self.logger.info("Using delineated subcatchments")
             subcatchments = gpd.read_file(delineated_path)
             return subcatchments['GRU_ID'].values.astype(int)

--- a/src/symfluence/models/fuse/subcatchment_processor.py
+++ b/src/symfluence/models/fuse/subcatchment_processor.py
@@ -27,6 +27,7 @@ import xarray as xr
 from symfluence.core.exceptions import ModelExecutionError
 from symfluence.core.mixins.config import ConfigMixin
 from symfluence.core.mixins.project import resolve_data_subdir
+from symfluence.core.path_resolver import find_basin_shapefile, find_catchment_subfile
 from symfluence.data.utils.netcdf_utils import create_netcdf_encoding
 
 if TYPE_CHECKING:
@@ -107,28 +108,37 @@ class SubcatchmentProcessor(ConfigMixin):
         Returns:
             np.ndarray: Array of integer subcatchment IDs (GRU_ID values).
         """
-        # Check if delineated catchments exist (for distributed routing)
-        delineated_path = self.project_dir / 'shapefiles' / 'catchment' / f"{self.domain_name}_catchment_delineated.shp"
+        # Check if delineated catchments exist (for distributed routing).
+        # Discretization writes this under the nested experiment layout.
+        delineated_path = find_catchment_subfile(
+            self.project_dir / 'shapefiles',
+            self.domain_definition_method,
+            self.experiment_id,
+            f"{self.domain_name}_catchment_delineated.shp",
+            logger=self.logger,
+        )
 
-        if delineated_path.exists():
+        if delineated_path is not None:
             self.logger.info("Using delineated subcatchments")
             subcatchments = gpd.read_file(delineated_path)
             return subcatchments['GRU_ID'].values.astype(int)
         else:
-            # Use regular HRUs
-            catchment_path = self._get_catchment_path()
-            discretization = self._get_config_value(
-                lambda: self.config.domain.discretization,
-                default='GRUs',
-                dict_key='SUB_GRID_DISCRETIZATION'
-            )
-
-            if catchment_name_col == 'default':
-                catchment_name = f"{self.domain_name}_HRUs_{discretization}.shp"
+            # Use regular HRUs. Honour an explicit catchment_name_col, else
+            # resolve via the shared finder (nested layout + casing drift).
+            if catchment_name_col != 'default':
+                catchment_file = self._get_catchment_path() / catchment_name_col
             else:
-                catchment_name = catchment_name_col
+                catchment_file = find_basin_shapefile(
+                    self.project_dir / 'shapefiles',
+                    self.domain_name,
+                    self.domain_definition_method,
+                    self.experiment_id,
+                    include_river_basins=False,
+                    required=True,
+                    logger=self.logger,
+                )
 
-            catchment = gpd.read_file(catchment_path / catchment_name)
+            catchment = gpd.read_file(catchment_file)
             if 'GRU_ID' in catchment.columns:
                 return catchment['GRU_ID'].values.astype(int)
             else:

--- a/src/symfluence/models/mesh/preprocessor.py
+++ b/src/symfluence/models/mesh/preprocessor.py
@@ -562,6 +562,16 @@ class MESHPreProcessor(BaseModelPreProcessor):  # type: ignore[misc]
                 hru_shapefile = candidate
                 break
 
+        # Cross-experiment / casing drift: the elevation-band shapefile may have
+        # been written under a different experiment_id. Deep-search before giving
+        # up (kept elevation-specific so we never grab a GRUs/landclass variant).
+        if hru_shapefile is None:
+            catchment_root = self.project_dir / 'shapefiles' / 'catchment'
+            if catchment_root.exists():
+                deep = sorted(catchment_root.rglob(f'{self.domain_name}_HRUs_elevation*.shp'))
+                if deep:
+                    hru_shapefile = deep[0]
+
         if hru_shapefile is None:
             self.logger.warning(
                 f"Could not find elevation band HRU shapefile. Tried: {hru_shp_candidates}"

--- a/src/symfluence/models/mizuroute/remap_generator.py
+++ b/src/symfluence/models/mizuroute/remap_generator.py
@@ -22,6 +22,11 @@ import pandas as pd
 import xarray as xr
 
 from symfluence.core.exceptions import ModelExecutionError
+from symfluence.core.path_resolver import (
+    find_basin_shapefile,
+    find_catchment_subfile,
+    find_river_basins_shapefile,
+)
 
 if TYPE_CHECKING:
     from symfluence.models.mizuroute.preprocessor import MizuRoutePreProcessor
@@ -75,8 +80,18 @@ class MizuRouteRemapGenerator:
             weights = self.pp.subcatchment_weights
             gru_ids = self.pp.subcatchment_gru_ids
         else:
-            # Fallback: load from delineated catchments shapefile
-            catchment_path = self.pp.project_dir / 'shapefiles' / 'catchment' / f"{self.pp.domain_name}_catchment_delineated.shp"
+            # Fallback: load from delineated catchments shapefile (nested layout)
+            catchment_path = find_catchment_subfile(
+                self.pp.project_dir / 'shapefiles',
+                self.pp.domain_definition_method,
+                self.pp.experiment_id,
+                f"{self.pp.domain_name}_catchment_delineated.shp",
+                logger=self.pp.logger,
+            )
+            if catchment_path is None:
+                raise ModelExecutionError(
+                    f"Delineated catchment shapefile not found for {self.pp.domain_name}"
+                )
             shp_catchments = gpd.read_file(catchment_path)
             weights = shp_catchments['avg_subbas'].values
         remap_name = self.pp.mizu_remap_file
@@ -235,19 +250,16 @@ class MizuRouteRemapGenerator:
             self.create_area_weighted_remap_file()  # Changed from create_equal_weight_remap_file
             return
 
-        hm_catchment_path = Path(self.pp._get_config_value(
+        hm_path_cfg = self.pp._get_config_value(
             lambda: self.pp.config.paths.catchment_path, default='default'
-        ))
-        hm_catchment_name = self.pp._get_config_value(
+        )
+        hm_name_cfg = self.pp._get_config_value(
             lambda: self.pp.config.paths.catchment_name, default='default'
         )
-        if hm_catchment_name == 'default':
-            hm_catchment_name = f"{self.pp.domain_name}_HRUs_{self.pp.sub_grid_discretization}.shp"
-
-        rm_catchment_path = Path(self.pp._get_config_value(
+        rm_path_cfg = self.pp._get_config_value(
             lambda: self.pp.config.paths.river_basins_path, default='default'
-        ))
-        rm_catchment_name = self.pp._get_config_value(
+        )
+        rm_name_cfg = self.pp._get_config_value(
             lambda: self.pp.config.paths.river_basins_name, default='default'
         )
 
@@ -270,19 +282,26 @@ class MizuRouteRemapGenerator:
             remap_name = "remap_file.nc"
             self.pp.logger.warning(f"SETTINGS_MIZU_REMAP not found in config, using default: {remap_name}")
 
-        if hm_catchment_path == 'default':
-            hm_catchment_path = self.pp.project_dir / 'shapefiles/catchment'
+        # Resolve the hydrologic-model catchment (HRUs) and routing-model basins
+        # via the shared finders (nested layout + casing drift), honouring any
+        # explicit CATCHMENT_PATH / RIVER_BASINS_PATH overrides.
+        shapefiles_dir = self.pp.project_dir / 'shapefiles'
+        hm_shapefile = find_basin_shapefile(
+            shapefiles_dir, self.pp.domain_name,
+            self.pp.domain_definition_method, self.pp.experiment_id,
+            explicit_path=hm_path_cfg, explicit_name=hm_name_cfg,
+            include_river_basins=False, required=True, logger=self.pp.logger,
+        )
+        if rm_path_cfg and rm_path_cfg != 'default' and rm_name_cfg and rm_name_cfg != 'default':
+            rm_shapefile = Path(rm_path_cfg) / rm_name_cfg
         else:
-            hm_catchment_path = Path(hm_catchment_path)
-
-        if rm_catchment_path == 'default':
-            rm_catchment_path = self.pp.project_dir / 'shapefiles/catchment'
-        else:
-            rm_catchment_path = Path(rm_catchment_path)
+            rm_shapefile = find_river_basins_shapefile(
+                shapefiles_dir, self.pp.domain_name, required=True, logger=self.pp.logger,
+            )
 
         # Load shapefiles
-        hm_shape = gpd.read_file(hm_catchment_path / hm_catchment_name)
-        rm_shape = gpd.read_file(rm_catchment_path / rm_catchment_name)
+        hm_shape = gpd.read_file(hm_shapefile)
+        rm_shape = gpd.read_file(rm_shapefile)
 
         # Create intersection
         esmr_obj = _create_easymore_instance()

--- a/src/symfluence/models/mizuroute/topology_generator.py
+++ b/src/symfluence/models/mizuroute/topology_generator.py
@@ -20,6 +20,7 @@ import netCDF4 as nc4
 import numpy as np
 
 from symfluence.core.exceptions import FileOperationError
+from symfluence.core.path_resolver import find_catchment_subfile
 
 if TYPE_CHECKING:
     from symfluence.models.mizuroute.preprocessor import MizuRoutePreProcessor
@@ -129,10 +130,18 @@ class MizuRouteTopologyGenerator:
             # Enable remapping: map single lumped SUMMA GRU to 25 routing HRUs with area weights
             self.pp.needs_remap_lumped_distributed = True
 
-            # Load the delineated catchments shapefile
-            catchment_path = self.pp.project_dir / 'shapefiles' / 'catchment' / f"{self.pp.domain_name}_catchment_delineated.shp"
-            if not catchment_path.exists():
-                raise FileOperationError(f"Delineated catchment shapefile not found: {catchment_path}")
+            # Load the delineated catchments shapefile (nested experiment layout)
+            catchment_path = find_catchment_subfile(
+                self.pp.project_dir / 'shapefiles',
+                self.pp.domain_definition_method,
+                self.pp.experiment_id,
+                f"{self.pp.domain_name}_catchment_delineated.shp",
+                logger=self.pp.logger,
+            )
+            if catchment_path is None:
+                raise FileOperationError(
+                    f"Delineated catchment shapefile not found for {self.pp.domain_name}"
+                )
 
             shp_catchments = gpd.read_file(catchment_path)
             self.pp.logger.info(f"Loaded {len(shp_catchments)} delineated subcatchments")

--- a/src/symfluence/models/ngen/calibration/targets.py
+++ b/src/symfluence/models/ngen/calibration/targets.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 import pandas as pd
 
+from symfluence.core.path_resolver import find_basin_shapefile
 from symfluence.evaluation.evaluators import StreamflowEvaluator
 
 
@@ -423,13 +424,16 @@ class NgenStreamflowTarget(StreamflowEvaluator):
         if cfg_area:
             return float(cfg_area)
 
-        domain_dir = self.project_dir
-        shp_dir = domain_dir / "shapefiles" / "catchment"
-        if not shp_dir.exists():
-            return 100.0
-
-        candidates = sorted(shp_dir.glob("*HRUs_GRUs.shp")) + sorted(shp_dir.glob("*.shp"))
-        shp_path = next((p for p in candidates if p.exists()), None)
+        # Shared finder handles the nested layout and GRUs/GRUS casing drift
+        # (the old glob "*HRUs_GRUs.shp" was case-sensitive and non-recursive).
+        shp_path = find_basin_shapefile(
+            self.project_dir / "shapefiles",
+            self.domain_name,
+            self.domain_definition_method,
+            self.experiment_id,
+            include_river_basins=False,
+            logger=self.logger,
+        )
         if not shp_path:
             return 100.0
 

--- a/src/symfluence/models/rhessys/flow_table_generator.py
+++ b/src/symfluence/models/rhessys/flow_table_generator.py
@@ -73,22 +73,12 @@ class RHESSysFlowTableGenerator:
             flow_file: Output path for the flow table file.
         """
         try:
-            catchment_path = self.pp.get_catchment_path()
-
-            # Search alternate experiment dirs if not found
-            if not catchment_path.exists():
-                catchment_dir = self.pp.project_dir / 'shapefiles' / 'catchment'
-                if catchment_dir.exists():
-                    for shp_file in catchment_dir.rglob('*.shp'):
-                        if self.pp.domain_name in shp_file.name:
-                            catchment_path = shp_file
-                            logger.info(f"Found catchment shapefile in alternate location: {shp_file}")
-                            break
-
-            if not catchment_path.exists():
+            # Shared resolver: nested layout, casing drift, river_basins fallback.
+            catchment_path = self.pp._find_basin_shapefile(include_river_basins=False)
+            if catchment_path is None:
                 raise FileNotFoundError(
-                    f"Catchment shapefile not found for flow table generation. "
-                    f"Searched: {self.pp.project_dir / 'shapefiles' / 'catchment'}"
+                    f"Catchment shapefile not found for flow table generation "
+                    f"({self.pp.domain_name}). Run geospatial preprocessing first."
                 )
 
             gdf = gpd.read_file(catchment_path)

--- a/src/symfluence/models/rhessys/worldfile_generator.py
+++ b/src/symfluence/models/rhessys/worldfile_generator.py
@@ -89,24 +89,13 @@ class RHESSysWorldfileGenerator:
 
         # Get domain properties from shapefile
         try:
-            catchment_path = self.pp.get_catchment_path()
-
-            # If catchment path doesn't exist, search other experiment dirs
-            if not catchment_path.exists():
-                catchment_dir = self.pp.project_dir / 'shapefiles' / 'catchment'
-                if catchment_dir.exists():
-                    for shp_file in catchment_dir.rglob('*.shp'):
-                        if self.pp.domain_name in shp_file.name:
-                            catchment_path = shp_file
-                            logger.info(f"Found catchment shapefile in alternate location: {shp_file}")
-                            break
-
-            if not catchment_path.exists():
+            # Shared resolver: nested layout, casing drift, river_basins fallback.
+            catchment_path = self.pp._find_basin_shapefile(include_river_basins=False)
+            if catchment_path is None:
                 raise FileNotFoundError(
-                    f"Catchment shapefile not found at {catchment_path} or any alternate location. "
-                    f"Searched: {self.pp.project_dir / 'shapefiles' / 'catchment'}. "
+                    f"Catchment shapefile not found for {self.pp.domain_name}. "
                     f"Cannot determine basin area - this would cause incorrect unit conversions. "
-                    f"Run geospatial preprocessing first or verify shapefile paths."
+                    f"Run geospatial preprocessing first or set CATCHMENT_PATH."
                 )
 
             gdf = gpd.read_file(catchment_path)

--- a/src/symfluence/models/summa/plotter.py
+++ b/src/symfluence/models/summa/plotter.py
@@ -12,9 +12,9 @@ from typing import Dict, Optional
 
 import numpy as np
 
+from symfluence.core.path_resolver import find_basin_shapefile
 from symfluence.core.registries import R
 from symfluence.reporting.core.base_plotter import BasePlotter
-from symfluence.reporting.core.shapefile_helper import resolve_default_name
 
 
 @R.plotters.add('SUMMA')
@@ -53,13 +53,12 @@ class SUMMAPlotter(BasePlotter):
             plot_dir = self._ensure_output_dir('summa_outputs', experiment_id)
             ds = xr.open_dataset(summa_file)
 
-            hru_name = resolve_default_name(
-                self.config,
-                'CATCHMENT_SHP_NAME',
-                '{domain}_HRUs_{discretization}.shp'
+            hru_shp = find_basin_shapefile(
+                self.project_dir / 'shapefiles', self.domain_name,
+                self.domain_definition_method, self.experiment_id,
+                include_river_basins=False,
             )
-            hru_path = self.project_dir / 'shapefiles' / 'catchment' / hru_name
-            hru_gdf = gpd.read_file(hru_path) if hru_path.exists() else None
+            hru_gdf = gpd.read_file(hru_shp) if hru_shp is not None else None
 
             skip_vars = {'hru', 'time', 'gru', 'dateId', 'latitude', 'longitude', 'hruId', 'gruId'}
 

--- a/src/symfluence/reporting/plotters/model_results_plotter.py
+++ b/src/symfluence/reporting/plotters/model_results_plotter.py
@@ -15,6 +15,7 @@ import numpy as np
 import pandas as pd
 
 from symfluence.core.constants import ConfigKeys
+from symfluence.core.path_resolver import find_basin_shapefile
 from symfluence.reporting.core.base_plotter import BasePlotter
 from symfluence.reporting.core.shapefile_helper import resolve_default_name
 
@@ -136,13 +137,12 @@ class ModelResultsPlotter(BasePlotter):
         plot_dir = self._ensure_output_dir('summa_outputs', experiment_id)
         ds = xr.open_dataset(summa_file)
 
-        hru_name = resolve_default_name(
-            self.config,
-            'CATCHMENT_SHP_NAME',
-            '{domain}_HRUs_{discretization}.shp'
+        hru_shp = find_basin_shapefile(
+            self.project_dir / 'shapefiles', self.domain_name,
+            self.domain_definition_method, self.experiment_id,
+            include_river_basins=False,
         )
-        hru_path = self.project_dir / 'shapefiles' / 'catchment' / hru_name
-        hru_gdf = gpd.read_file(hru_path) if hru_path.exists() else None
+        hru_gdf = gpd.read_file(hru_shp) if hru_shp is not None else None
 
         skip_vars = {'hru', 'time', 'gru', 'dateId', 'latitude', 'longitude', 'hruId', 'gruId'}
 

--- a/tests/unit/core/test_path_resolver_basin.py
+++ b/tests/unit/core/test_path_resolver_basin.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Tests for the shared basin/catchment shapefile finders in path_resolver.
+
+These back the codebase-wide fix for the flat-path assumption: discretization
+writes the catchment under ``catchment/{definition_method}/{experiment_id}/
+{domain}_HRUs_{disc}.shp`` (suffix sometimes upper-cased, GRUs -> GRUS), and
+the river-basins outline flat under ``river_basins/{domain}_riverBasins_*.shp``.
+"""
+import pytest
+
+from symfluence.core.path_resolver import (
+    find_basin_shapefile,
+    find_catchment_subfile,
+    find_river_basins_shapefile,
+)
+
+pytestmark = [pytest.mark.unit]
+
+DOMAIN = "Bow_at_Banff"
+
+
+def _touch(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("")
+    return path
+
+
+# --------------------------------------------------------------------------
+# find_basin_shapefile
+# --------------------------------------------------------------------------
+
+def test_basin_resolves_nested_with_casing_and_cross_experiment(tmp_path):
+    shp = tmp_path / "shapefiles"
+    # Catchment written under a DIFFERENT experiment id, with upper-cased GRUS.
+    target = _touch(shp / "catchment" / "lumped" / "exp_other" / f"{DOMAIN}_HRUs_GRUS.shp")
+    # Config points at a different experiment id; deep search must still find it.
+    assert find_basin_shapefile(shp, DOMAIN, "lumped", "exp_config") == target
+
+
+def test_basin_prefers_correct_experiment_dir(tmp_path):
+    shp = tmp_path / "shapefiles"
+    correct = _touch(shp / "catchment" / "lumped" / "exp_a" / f"{DOMAIN}_HRUs_GRUs.shp")
+    _touch(shp / "catchment" / "lumped" / "exp_b" / f"{DOMAIN}_HRUs_GRUs.shp")
+    assert find_basin_shapefile(shp, DOMAIN, "lumped", "exp_a") == correct
+
+
+def test_basin_falls_back_to_river_basins(tmp_path):
+    shp = tmp_path / "shapefiles"
+    rb = _touch(shp / "river_basins" / f"{DOMAIN}_riverBasins_lumped.shp")
+    assert find_basin_shapefile(shp, DOMAIN, "lumped", "exp") == rb
+
+
+def test_basin_river_basins_disabled_returns_none(tmp_path):
+    shp = tmp_path / "shapefiles"
+    _touch(shp / "river_basins" / f"{DOMAIN}_riverBasins_lumped.shp")
+    assert find_basin_shapefile(shp, DOMAIN, "lumped", "exp", include_river_basins=False) is None
+
+
+def test_basin_prefers_catchment_over_river_basins(tmp_path):
+    shp = tmp_path / "shapefiles"
+    catchment = _touch(shp / "catchment" / "lumped" / "exp" / f"{DOMAIN}_HRUs_GRUs.shp")
+    _touch(shp / "river_basins" / f"{DOMAIN}_riverBasins_lumped.shp")
+    assert find_basin_shapefile(shp, DOMAIN, "lumped", "exp") == catchment
+
+
+def test_basin_honours_explicit_path_and_name(tmp_path):
+    shp = tmp_path / "shapefiles"
+    custom = _touch(tmp_path / "custom" / "basin.shp")
+    assert find_basin_shapefile(
+        shp, DOMAIN, "lumped", "exp",
+        explicit_path=str(tmp_path / "custom"), explicit_name="basin.shp",
+    ) == custom
+
+
+def test_basin_not_found_returns_none(tmp_path):
+    assert find_basin_shapefile(tmp_path / "shapefiles", DOMAIN, "lumped", "exp") is None
+
+
+def test_basin_required_raises(tmp_path):
+    with pytest.raises(FileNotFoundError, match="define_domain"):
+        find_basin_shapefile(tmp_path / "shapefiles", DOMAIN, "lumped", "exp", required=True)
+
+
+# --------------------------------------------------------------------------
+# find_catchment_subfile (specifically-named artifacts, e.g. delineated)
+# --------------------------------------------------------------------------
+
+def test_subfile_nested(tmp_path):
+    shp = tmp_path / "shapefiles"
+    name = f"{DOMAIN}_catchment_delineated.shp"
+    target = _touch(shp / "catchment" / "lumped" / "exp" / name)
+    assert find_catchment_subfile(shp, "lumped", "exp", name) == target
+
+
+def test_subfile_deep_search_other_experiment(tmp_path):
+    shp = tmp_path / "shapefiles"
+    name = f"{DOMAIN}_catchment_delineated.shp"
+    target = _touch(shp / "catchment" / "lumped" / "exp_other" / name)
+    # Configured experiment differs; deep search finds it.
+    assert find_catchment_subfile(shp, "lumped", "exp_config", name) == target
+
+
+def test_subfile_legacy_flat(tmp_path):
+    shp = tmp_path / "shapefiles"
+    name = f"{DOMAIN}_catchment_delineated.shp"
+    target = _touch(shp / "catchment" / name)
+    assert find_catchment_subfile(shp, "lumped", "exp", name) == target
+
+
+def test_subfile_not_found(tmp_path):
+    assert find_catchment_subfile(tmp_path / "shapefiles", "lumped", "exp", "x.shp") is None
+
+
+# --------------------------------------------------------------------------
+# find_river_basins_shapefile
+# --------------------------------------------------------------------------
+
+def test_river_basins_found(tmp_path):
+    shp = tmp_path / "shapefiles"
+    rb = _touch(shp / "river_basins" / f"{DOMAIN}_riverBasins_lumped.shp")
+    assert find_river_basins_shapefile(shp, DOMAIN) == rb
+
+
+def test_river_basins_not_found_none(tmp_path):
+    assert find_river_basins_shapefile(tmp_path / "shapefiles", DOMAIN) is None
+
+
+def test_river_basins_required_raises(tmp_path):
+    with pytest.raises(FileNotFoundError, match="define_domain"):
+        find_river_basins_shapefile(tmp_path / "shapefiles", DOMAIN, required=True)


### PR DESCRIPTION
Closes #159 (non-handler sites). Companion to #158 (observation handlers).

## Summary

Generalises the catchment-path fix beyond observation handlers. Many model preprocessors, evaluation utilities, core diagnostics, and plotters assumed a **flat** `shapefiles/catchment/{domain}_catchment.shp`, read `config.domain.catchment_path` (those keys live on `config.paths`), or used a **case-sensitive / non-recursive** glob — so they failed once a domain was discretized into the nested, experiment-scoped layout `shapefiles/catchment/{method}/{experiment}/{domain}_HRUs_{disc}.shp` (suffix sometimes upper-cased `GRUs`→`GRUS`).

### Shared resolvers (new, in `core/path_resolver.py`)
- `find_basin_shapefile()` — explicit config → nested layout → deep search (cross-experiment + casing drift) → `river_basins` outline fallback.
- `find_catchment_subfile()` — a specifically-named artifact (e.g. `{domain}_catchment_delineated.shp`) under the nested layout.
- `find_river_basins_shapefile()` — the flat, method-suffixed domain outline.
- `PathResolverMixin._find_basin_shapefile()` — thin wrapper for mixin classes.

### Sites routed through them (~20)
| Severity | Sites |
|---|---|
| HIGH | `core/system.py` (4 diagnostic loaders), `data/acquisition/observed_processor.py`, `evaluation/evaluators/streamflow.py` |
| MEDIUM | `evaluation/utilities/streamflow_metrics.py` (GRUs→GRUS casing), `models/mesh/preprocessor.py`, `models/fuse/{forcing,subcatchment}_processor.py`, `models/mizuroute/{remap,topology}_generator.py` (delineated read), `models/ngen/calibration/targets.py` (case-sensitive glob), `models/execution/spatial_orchestrator.py`, `data/data_manager.py` |
| LOW | `models/rhessys/{worldfile,flow_table}_generator.py`, `models/clm/domain_generator.py`, `models/summa/plotter.py`, `reporting/plotters/model_results_plotter.py` |

`coastal_delineator` was a **false positive** (river_basins is flat + method-suffixed by design) and is left unchanged. `base_topology_generator` already had a nested rglob fallback and is unchanged.

## Testing
- 15 new resolver unit tests (`tests/unit/core/test_path_resolver_basin.py`): nested resolution, GRUs/GRUS casing drift, cross-experiment, river_basins fallback, explicit-config precedence, `required` raising, the delineated-subfile finder.
- Full unit suite green (one unrelated pre-existing droute registration flake that passes in isolation; not touched by this PR).
- ruff + mypy + the generic-raise adapter guard all pass.

## Net
557 insertions / 221 deletions — consolidates a lot of duplicated, buggy path logic into three shared finders.

---
Repo and code assistance from [Claude](https://claude.ai) (Anthropic).