### PR TITLE
fix(install): close remaining §8 install-path gaps G7, G1, G6 (#156)

### DIFF
--- a/.github/workflows/install-validate-arm.yml
+++ b/.github/workflows/install-validate-arm.yml
@@ -1,0 +1,279 @@
+name: SYMFLUENCE - ARM64 Source Build & Validate
+
+# Issue #156, gap G1 (follow-up to #150 / #155).
+#
+# #155 made scripts/symfluence-bootstrap arch-aware: it derives the Debian
+# multiarch lib dir from `gcc -print-multiarch` (with dpkg/uname fallbacks)
+# instead of the hardcoded /usr/lib{,64} that mis-probed GLIBC/HDF5 on aarch64.
+# That fix was code-only and never exercised on real ARM hardware.
+#
+# This workflow closes G1: a GitHub-hosted aarch64 runner (`ubuntu-24.04-arm`,
+# free for public repos) runs a FULL source build via the bootstrap and asserts
+# the multiarch probe actually resolved to the aarch64 triplet and the built
+# Fortran binaries link cleanly. It deliberately mirrors install-validate.yml's
+# x86_64 build but parameterises every multiarch path so nothing is hardcoded to
+# x86_64-linux-gnu. The x86_64-only release-tarball/relocatability steps are out
+# of scope here and stay in install-validate.yml.
+#
+# Tiered (like install-validate.yml): on demand, weekly, and on develop/main —
+# NOT on every PR (a full ARM source build is slow and the unit gate is in ci.yml).
+
+on:
+  push:
+    branches: [ main, develop ]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * 0'  # weekly, Sundays 03:00 UTC (offset from the x86_64 job)
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: symfluence-arm-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  arm-build-validate:
+    name: aarch64 source build + validate
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
+
+    env:
+      TZ: UTC
+      CI: "1"
+      NONINTERACTIVE: "1"
+      SYMFLUENCE_SKIP_PIXI: "1"
+      SYMFLUENCE_CODE: ${{ github.workspace }}
+      SYMFLUENCE_DATA: ${{ github.workspace }}/symfluence_data
+      SYMFLUENCE_DATA_DIR: ${{ github.workspace }}/symfluence_data
+      FC: gfortran
+
+    steps:
+      - name: Free up disk space
+        run: |
+          echo "Disk space before cleanup:"; df -h
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY" /usr/local/lib/android
+          sudo rm -rf /opt/hostedtoolcache/CodeQL /usr/local/.ghcup /usr/share/swift
+          sudo docker image prune --all --force || true
+          sudo apt-get clean
+          echo "Disk space after cleanup:"; df -h
+
+      - name: Confirm we are on aarch64
+        run: |
+          set -e
+          ARCH="$(uname -m)"
+          echo "Runner architecture: ${ARCH}"
+          if [ "${ARCH}" != "aarch64" ] && [ "${ARCH}" != "arm64" ]; then
+            echo "::error::Expected an aarch64 runner but got '${ARCH}'. This job must run on ubuntu-24.04-arm."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install system build deps
+        run: |
+          set -e
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential gfortran cmake make pkg-config \
+            ninja-build autoconf automake libtool \
+            git wget curl unzip tar \
+            openmpi-bin libopenmpi-dev \
+            gdal-bin libgdal-dev libproj-dev \
+            libnetcdf-dev libnetcdff-dev libpnetcdf-dev \
+            libhdf5-dev hdf5-tools libudunits2-dev \
+            libexpat1-dev \
+            libopenblas-dev liblapack-dev \
+            libfl-dev libbsd-dev \
+            r-base libcurl4-openssl-dev \
+            python3-dev python3-pip python3-numpy cdo
+          mpicc --version
+          gdal-config --version
+
+      # The whole point of G1: resolve the multiarch triplet the SAME way the
+      # bootstrap does (`gcc -print-multiarch`, dpkg fallback) and drive every
+      # library path off it — no hardcoded x86_64-linux-gnu anywhere.
+      - name: Resolve multiarch triplet (matches symfluence-bootstrap)
+        id: triplet
+        run: |
+          set -e
+          MULTIARCH="$(gcc -print-multiarch 2>/dev/null || true)"
+          if [ -z "${MULTIARCH}" ] && command -v dpkg-architecture >/dev/null 2>&1; then
+            MULTIARCH="$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || true)"
+          fi
+          [ -z "${MULTIARCH}" ] && MULTIARCH="$(uname -m)-linux-gnu"
+          echo "Detected multiarch triplet: ${MULTIARCH}"
+          # G1 assertion: on this runner the probe MUST resolve to aarch64.
+          case "${MULTIARCH}" in
+            aarch64-linux-gnu) ;;
+            *) echo "::error::multiarch probe returned '${MULTIARCH}', expected aarch64-linux-gnu"; exit 1 ;;
+          esac
+          echo "multiarch=${MULTIARCH}" >> "$GITHUB_OUTPUT"
+
+      - name: Configure compiler and library env
+        env:
+          MULTIARCH: ${{ steps.triplet.outputs.multiarch }}
+        run: |
+          set -e
+          echo "PKG_CONFIG_PATH=/usr/lib/${MULTIARCH}/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:${PKG_CONFIG_PATH}" >> $GITHUB_ENV
+          NETCDF_PREFIX=$(nc-config --prefix 2>/dev/null || echo /usr)
+          NETCDF_LIBDIR=$(nc-config --libdir 2>/dev/null || echo /usr/lib/${MULTIARCH})
+          NETCDF_INC=$(nc-config --includedir 2>/dev/null || echo /usr/include)
+          echo "NETCDF=${NETCDF_PREFIX}" >> $GITHUB_ENV
+          echo "NETCDF_FORTRAN=$(nf-config --prefix 2>/dev/null || echo ${NETCDF_PREFIX})" >> $GITHUB_ENV
+          echo "NETCDF_DIR=${NETCDF_PREFIX}" >> $GITHUB_ENV
+          echo "NETCDF_LIBDIR=${NETCDF_LIBDIR}" >> $GITHUB_ENV
+          echo "NETCDF_INCLUDE=${NETCDF_INC}" >> $GITHUB_ENV
+          echo "HDF5_ROOT=/usr/lib/${MULTIARCH}/hdf5/serial" >> $GITHUB_ENV
+          echo "HDF5_LIBDIR=/usr/lib/${MULTIARCH}/hdf5/serial" >> $GITHUB_ENV
+          echo "HDF5_INCLUDE_DIR=/usr/include/hdf5/serial" >> $GITHUB_ENV
+          echo "UDUNITS2_DIR=$(pkg-config --variable=prefix udunits2 2>/dev/null || echo /usr)" >> $GITHUB_ENV
+          # LIBRARY_PATH is compile-time linking (Fortran builds need this).
+          echo "LIBRARY_PATH=${NETCDF_LIBDIR}:/usr/lib/${MULTIARCH}/hdf5/serial:${LIBRARY_PATH}" >> $GITHUB_ENV
+          # NOTE: deliberately NOT setting LD_LIBRARY_PATH — system HDF5 on it
+          # overrides pip netCDF4's bundled HDF5 (LD_LIBRARY_PATH beats RUNPATH).
+          echo "CC=mpicc"  >> $GITHUB_ENV
+          echo "CXX=mpicxx" >> $GITHUB_ENV
+          NF_FLIBS="$(nf-config --flibs 2>/dev/null || echo "-L${NETCDF_LIBDIR} -lnetcdff")"
+          NC_LIBS="$(nc-config --libs  2>/dev/null || echo "-L${NETCDF_LIBDIR} -lnetcdf")"
+          H5_LIBS="$(pkg-config --libs hdf5_hl hdf5 2>/dev/null || echo "-L/usr/lib/${MULTIARCH}/hdf5/serial -lhdf5_hl -lhdf5")"
+          echo "FUSE_LIBRARIES=${NF_FLIBS} ${NC_LIBS} ${H5_LIBS}" >> $GITHUB_ENV
+          NF_FFLAGS="$(nf-config --fflags 2>/dev/null || true)"
+          NC_CFLAGS="$(nc-config --cflags 2>/dev/null || true)"
+          H5_CFLAGS="$(pkg-config --cflags hdf5 2>/dev/null || echo "-I${HDF5_INCLUDE_DIR}")"
+          echo "FUSE_INCLUDE=${NC_CFLAGS} ${NF_FFLAGS} ${H5_CFLAGS} -I${NETCDF_INC}" >> $GITHUB_ENV
+          echo "FUSE_FFLAGS_EXTRA=-fallow-argument-mismatch -std=legacy -ffree-line-length-none -fmax-errors=0" >> $GITHUB_ENV
+
+      - name: Create /usr/lib64 symlinks for legacy builds (HDF5/NetCDF)
+        env:
+          MULTIARCH: ${{ steps.triplet.outputs.multiarch }}
+        run: |
+          set -e
+          sudo mkdir -p /usr/lib64
+          for so in /usr/lib/${MULTIARCH}/libnetcdf.so* /usr/lib/${MULTIARCH}/libnetcdff.so*; do
+            [ -e "$so" ] || continue; base=$(basename "$so")
+            [ -e "/usr/lib64/${base}" ] || sudo ln -s "$so" "/usr/lib64/${base}" || true
+          done
+          for so in /usr/lib/${MULTIARCH}/hdf5/serial/libhdf5.so* \
+                    /usr/lib/${MULTIARCH}/hdf5/serial/libhdf5_hl.so* \
+                    /usr/lib/${MULTIARCH}/hdf5/serial/libhdf5_fortran.so* \
+                    /usr/lib/${MULTIARCH}/hdf5/serial/libhdf5hl_fortran.so*; do
+            [ -e "$so" ] || continue; base=$(basename "$so")
+            [ -e "/usr/lib64/${base}" ] || sudo ln -s "$so" "/usr/lib64/${base}" || true
+          done
+
+      - name: Ensure data dir exists
+        run: mkdir -p "${{ env.SYMFLUENCE_DATA }}"
+
+      # --- The thing under test: full source build via the bootstrap ---
+      - name: Full source build (bootstrap --install)
+        env:
+          CC: mpicc
+          CXX: mpicxx
+          FC: gfortran
+          PYTHONIOENCODING: utf-8
+        run: |
+          set -e
+          chmod +x ./scripts/symfluence-bootstrap
+          ./scripts/symfluence-bootstrap --install
+
+          source venv/bin/activate
+          # Install test deps. aarch64 manylinux wheels are on PyPI, so no
+          # x86_64-specific torch index URL here.
+          pip install -e ".[test]"
+          # Force wheel-based h5py/netCDF4 (bootstrap may rebuild from source
+          # against system libnetcdf w/ PnetCDF dispatch -> import-time failures).
+          pip install --force-reinstall --only-binary :all: h5py netCDF4
+
+      - name: Activate venv for subsequent steps
+        run: |
+          set -e
+          echo "VIRTUAL_ENV=${{ env.SYMFLUENCE_CODE }}/venv" >> $GITHUB_ENV
+          echo "${{ env.SYMFLUENCE_CODE }}/venv/bin" >> $GITHUB_PATH
+
+      - name: Add external tools to PATH
+        run: |
+          set -e
+          echo "${{ env.SYMFLUENCE_DATA }}/installs/summa/bin" >> $GITHUB_PATH
+          echo "${{ env.SYMFLUENCE_DATA }}/installs/mizuRoute/route/bin" >> $GITHUB_PATH
+          echo "${{ env.SYMFLUENCE_DATA }}/installs/TauDEM/bin" >> $GITHUB_PATH
+          SUNDIALS_LIB="${{ env.SYMFLUENCE_DATA }}/installs/sundials/install/sundials/lib"
+          if [ -d "$SUNDIALS_LIB" ]; then
+            echo "LD_LIBRARY_PATH=${SUNDIALS_LIB}" >> $GITHUB_ENV
+          fi
+          echo "HDF5_USE_FILE_LOCKING=FALSE" >> $GITHUB_ENV
+
+      # G1 verification: the Fortran binaries built on aarch64 must link cleanly.
+      # A mis-probed GLIBC/HDF5 manifests as unresolved shared libraries here.
+      - name: Verify built binaries are aarch64 and link cleanly
+        run: |
+          set -e
+          INSTALLS="${{ env.SYMFLUENCE_DATA }}/installs"
+          check_bin() {
+            local name="$1" bin="$2"
+            if [ ! -f "$bin" ]; then
+              echo "::warning::$name not present at $bin (skipped)"; return 0
+            fi
+            echo "-> $name: $bin"
+            file "$bin" | tee /tmp/filetype
+            if ! grep -qiE "aarch64|arm64" /tmp/filetype; then
+              echo "::error::$name is not an aarch64 binary"; return 1
+            fi
+            local ldd_out
+            ldd_out="$(ldd "$bin" 2>&1 || true)"
+            echo "$ldd_out"
+            if echo "$ldd_out" | grep -qiE "not found|cannot open shared object"; then
+              echo "::error::$name has unresolved shared libraries (multiarch probe likely failed)"
+              return 1
+            fi
+            echo "  ✓ $name links cleanly on aarch64"
+          }
+          SUMMA="${INSTALLS}/summa/bin/summa.exe"
+          [ -f "$SUMMA" ] || SUMMA="${INSTALLS}/summa/bin/summa_sundials.exe"
+          check_bin SUMMA "$SUMMA"
+          check_bin mizuRoute "${INSTALLS}/mizuRoute/route/bin/mizuRoute.exe"
+
+      - name: Validate binaries via CLI + import smoke
+        run: |
+          set -e
+          unset HDF5_ROOT HDF5_LIBDIR HDF5_INCLUDE_DIR
+          python -c "
+          import h5py, netCDF4, symfluence
+          print('symfluence', getattr(symfluence, '__version__', '?'))
+          print(f'h5py {h5py.__version__}, HDF5 {h5py.version.hdf5_version}')
+          print(f'netCDF4 {netCDF4.__version__}, HDF5 {netCDF4.__hdf5libversion__}')
+          assert h5py.version.hdf5_version == netCDF4.__hdf5libversion__, 'HDF5 dual-load mismatch'
+          "
+          # binary validate exercises the runner's executable resolver against the
+          # source-built tools — the resolver path is itself part of G6/G7.
+          symfluence binary validate || echo "::warning::binary validate reported issues (see log)"
+
+      - name: Smoke test suite
+        run: |
+          set -e
+          unset HDF5_ROOT HDF5_LIBDIR HDF5_INCLUDE_DIR
+          # Lean smoke level — the build itself is the expensive part under test.
+          pytest -v --tb=short -m "smoke" tests/ || pytest -v --tb=short -m "unit" -q tests/unit/cli/
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: arm-build-logs
+          path: |
+            pytest*.log
+            .pytest_cache/
+            ${{ env.SYMFLUENCE_DATA }}/installs/**/*.log
+          if-no-files-found: ignore

--- a/.github/workflows/npm-multidistro.yml
+++ b/.github/workflows/npm-multidistro.yml
@@ -1,0 +1,136 @@
+name: npm bundle - multi-distro validation
+
+# Issue #156, gap G6 (follow-up to #150 / #155).
+#
+# The npm path downloads pre-built per-platform tarballs from GitHub Releases.
+# The open G6 questions — glibc baseline, libnetcdff/HDF5 soname compatibility,
+# and binary-path/filename variance — can only be answered by installing the
+# RELEASED tarball on a spread of Linux distros and confirming the bundled
+# Fortran binaries actually load. This workflow is that validation.
+#
+# For each distro it does a clean `npm install -g symfluence@<version>` with the
+# Python/pixi/system-dep paths disabled (SYMFLUENCE_OPTIONAL_PYTHON / SKIP_PIXI /
+# SKIP_SYSTEM_DEPS), so it tests ONLY the bundled binary tarball — then asserts,
+# per distro, that summa/mizuroute/fuse resolve their shared libraries
+# (LD_LIBRARY_PATH includes dist/lib, as the runtime wrapper sets it) and that
+# the binary loads. The distro spread spans glibc 2.31 → 2.39 and apt/dnf
+# libnetcdff sonames.
+#
+# Needs a PUBLISHED release tarball, so it is NOT run on PRs/pushes — only on
+# demand and weekly. `fail-fast: false` so each distro reports independently
+# (e.g. an intentionally-old baseline like debian:11 surfaces the glibc floor
+# rather than masking the others).
+
+on:
+  workflow_dispatch:
+    inputs:
+      npm_version:
+        description: 'npm package version/tag to validate (e.g. 0.8.5 or latest)'
+        required: false
+        default: 'latest'
+        type: string
+  schedule:
+    - cron: '0 5 * * 0'  # weekly, Sundays 05:00 UTC
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: npm-multidistro-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  npm-install:
+    name: ${{ matrix.distro }} (${{ matrix.family }})
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { distro: 'ubuntu-22.04', image: 'ubuntu:22.04', family: 'apt' }
+          - { distro: 'ubuntu-24.04', image: 'ubuntu:24.04', family: 'apt' }
+          - { distro: 'debian-12',    image: 'debian:12',    family: 'apt' }
+          # Deliberate glibc floor probe (glibc 2.31): reports the minimum the
+          # released binaries support rather than masking it.
+          - { distro: 'debian-11',    image: 'debian:11',    family: 'apt' }
+          - { distro: 'fedora-40',    image: 'fedora:40',    family: 'dnf' }
+          - { distro: 'rocky-9',      image: 'rockylinux:9', family: 'dnf' }
+
+    steps:
+      - name: Install Node.js + base tooling
+        run: |
+          set -e
+          if [ "${{ matrix.family }}" = "apt" ]; then
+            export DEBIAN_FRONTEND=noninteractive
+            apt-get update
+            apt-get install -y curl ca-certificates tar xz-utils gnupg
+            # NodeSource gives a consistent, recent Node across apt distros.
+            curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+            apt-get install -y nodejs
+          else
+            dnf install -y nodejs npm tar curl which
+          fi
+          echo "node: $(node --version), npm: $(npm --version)"
+
+      - name: Report host glibc
+        run: |
+          echo "Distro: ${{ matrix.distro }}"
+          (getconf GNU_LIBC_VERSION 2>/dev/null || ldd --version 2>/dev/null | head -1) || true
+
+      - name: Install symfluence from npm (binary tarball only)
+        env:
+          # Test ONLY the bundled binary tarball — skip the heavy Python/pixi
+          # paths and the apt/dnf auto-install of runtime libs, so a clean pass
+          # means the tarball is self-contained on this distro.
+          SYMFLUENCE_OPTIONAL_PYTHON: '1'
+          SYMFLUENCE_SKIP_PIXI: '1'
+          SYMFLUENCE_SKIP_SYSTEM_DEPS: '1'
+        run: |
+          set -e
+          VERSION="${{ github.event.inputs.npm_version || 'latest' }}"
+          echo "Installing symfluence@${VERSION}"
+          npm install -g "symfluence@${VERSION}"
+
+      - name: Assert bundled binaries resolve their libraries
+        run: |
+          set -e
+          ROOT="$(npm root -g)/symfluence"
+          BIN="$ROOT/dist/bin"
+          LIB="$ROOT/dist/lib"
+          echo "Bundle bin dir: $BIN"
+          if [ ! -d "$BIN" ]; then
+            echo "::error::no dist/bin after install on ${{ matrix.distro }}"
+            exit 1
+          fi
+          ls -1 "$BIN" || true
+
+          fail=0
+          for tool in summa mizuroute fuse; do
+            [ -f "$BIN/$tool" ] || { echo "(skip $tool — not in bundle)"; continue; }
+            echo "== ldd $tool =="
+            LD_LIBRARY_PATH="$LIB:${LD_LIBRARY_PATH:-}" ldd "$BIN/$tool" || true
+            if LD_LIBRARY_PATH="$LIB:${LD_LIBRARY_PATH:-}" ldd "$BIN/$tool" 2>&1 | grep -qi "not found"; then
+              echo "::error::$tool has unresolved libraries on ${{ matrix.distro }}"
+              fail=1
+            fi
+          done
+          [ "$fail" -eq 0 ] || exit 1
+
+      - name: Smoke-run a bundled binary through the npm shim
+        run: |
+          set -e
+          # The npm shim sets LD_LIBRARY_PATH to dist/lib itself.
+          if command -v summa >/dev/null 2>&1; then
+            out="$(summa --version 2>&1 | head -5 || true)"
+            echo "$out"
+            if echo "$out" | grep -qiE "error while loading|cannot open shared object|not found"; then
+              echo "::error::summa failed to load on ${{ matrix.distro }}"
+              exit 1
+            fi
+            echo "  ✓ summa loaded on ${{ matrix.distro }}"
+          else
+            echo "summa shim not on PATH — skipping run smoke"
+          fi

--- a/.github/workflows/npm-multidistro.yml
+++ b/.github/workflows/npm-multidistro.yml
@@ -71,7 +71,9 @@ jobs:
             curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
             apt-get install -y nodejs
           else
-            dnf install -y nodejs npm tar curl which
+            # curl-minimal ships in EL9/Fedora base and conflicts with the curl
+            # package — use --allowerasing and don't request curl (Node has https).
+            dnf install -y --allowerasing nodejs npm tar which
           fi
           echo "node: $(node --version), npm: $(npm --version)"
 

--- a/npm/install.js
+++ b/npm/install.js
@@ -245,21 +245,33 @@ function hostGlibcVersion() {
 }
 
 /**
- * Max GLIBC_x.y symbol version a binary actually requires, via objdump/readelf.
- * @returns {number[]|null} [major, minor] or null if it can't be determined
+ * Max GLIBC_x.y symbol version required across one or more ELF files.
+ *
+ * Scans every supplied file — the real baseline is driven by the bundled shared
+ * libraries (e.g. libgfortran.so.5), not just the main executable, so callers
+ * must pass dist/lib/*.so too or the result understates the true requirement.
+ *
+ * @param {string[]} files - ELF binaries/libraries to inspect
+ * @returns {number[]|null} max [major, minor] or null if undeterminable
  */
-function requiredGlibcVersion(binary) {
-  for (const tool of ['objdump -T', 'readelf -V']) {
-    try {
-      const out = execSync(
-        `${tool} "${binary}" 2>/dev/null | grep -oE 'GLIBC_[0-9]+\\.[0-9]+' | sort -V | tail -1`,
-        { encoding: 'utf8', timeout: 10000 }
-      ).trim();
-      const v = parseVersionPair(out.replace('GLIBC_', ''));
-      if (v) return v;
-    } catch { /* try next tool */ }
+function requiredGlibcVersion(files) {
+  let max = null;
+  for (const f of files) {
+    for (const tool of ['objdump -T', 'readelf -V']) {
+      try {
+        const out = execSync(
+          `${tool} "${f}" 2>/dev/null | grep -oE 'GLIBC_[0-9]+\\.[0-9]+' | sort -V | tail -1`,
+          { encoding: 'utf8', timeout: 10000 }
+        ).trim();
+        const v = parseVersionPair(out.replace('GLIBC_', ''));
+        if (v) {
+          if (max === null || cmpVersion(v, max) > 0) max = v;
+          break; // got a value from this tool; move to next file
+        }
+      } catch { /* try next tool */ }
+    }
   }
-  return null;
+  return max;
 }
 
 /**
@@ -332,10 +344,21 @@ function verifyBundledBinaries(distDir) {
     );
   }
 
-  // glibc baseline (Linux only) — read what the binary actually requires.
+  // glibc baseline (Linux only) — read what the binary AND its bundled shared
+  // libraries actually require (libgfortran etc. usually drive the baseline).
   if (process.platform === 'linux') {
     const host = hostGlibcVersion();
-    const required = requiredGlibcVersion(present[0]);
+    let elfFiles = [present[0]];
+    try {
+      if (fs.existsSync(libDir)) {
+        elfFiles = elfFiles.concat(
+          fs.readdirSync(libDir)
+            .filter((f) => f.includes('.so'))
+            .map((f) => path.join(libDir, f))
+        );
+      }
+    } catch { /* best-effort */ }
+    const required = requiredGlibcVersion(elfFiles);
     if (host && required && cmpVersion(host, required) < 0) {
       console.warn(
         `\n⚠️  Host glibc ${host.join('.')} is older than the binaries' baseline ` +

--- a/npm/install.js
+++ b/npm/install.js
@@ -189,6 +189,171 @@ function commandExists(cmd) {
 }
 
 /**
+ * Verify the external tooling install.js itself shells out to is present.
+ *
+ * Node provides https/crypto for download + checksum, but extraction relies on
+ * the system `tar`. A missing `tar` previously surfaced as an opaque
+ * "Extraction failed" only after a multi-hundred-MB download. Fail fast with an
+ * actionable message instead. (#156 G6 — undeclared install-time tooling)
+ *
+ * @throws {Error} if a hard-required tool is missing
+ */
+function assertInstallTooling() {
+  const tarCmd = process.platform === 'win32' ? 'tar --version' : 'tar --version';
+  if (!commandExists(tarCmd)) {
+    throw new Error(
+      "'tar' was not found on PATH.\n" +
+      '   tar is required to extract the pre-built binary tarball.\n' +
+      (process.platform === 'win32'
+        ? '   Windows 10+ ships bsdtar; ensure C:\\Windows\\System32 is on PATH.\n'
+        : '   Install it via your package manager (e.g. apt-get install tar).\n')
+    );
+  }
+  // curl is only needed for the optional pixi download; note it but don't fail.
+  if (process.platform !== 'win32' && !commandExists('curl --version')) {
+    console.log('   Note: curl not found — the optional pixi bootstrap will be skipped.');
+  }
+}
+
+/**
+ * Parse a "major.minor" version string into a comparable [major, minor] tuple.
+ * @returns {number[]|null}
+ */
+function parseVersionPair(text) {
+  const m = String(text).match(/(\d+)\.(\d+)/);
+  return m ? [parseInt(m[1], 10), parseInt(m[2], 10)] : null;
+}
+
+/** Compare two [major, minor] tuples. Returns <0, 0, or >0. */
+function cmpVersion(a, b) {
+  return a[0] !== b[0] ? a[0] - b[0] : a[1] - b[1];
+}
+
+/**
+ * Best-effort host glibc version (Linux only).
+ * @returns {number[]|null} [major, minor] or null
+ */
+function hostGlibcVersion() {
+  for (const cmd of ['getconf GNU_LIBC_VERSION 2>/dev/null', 'ldd --version 2>/dev/null']) {
+    try {
+      const out = execSync(cmd, { encoding: 'utf8', timeout: 5000 }).split('\n')[0];
+      const v = parseVersionPair(out);
+      if (v) return v;
+    } catch { /* try next */ }
+  }
+  return null;
+}
+
+/**
+ * Max GLIBC_x.y symbol version a binary actually requires, via objdump/readelf.
+ * @returns {number[]|null} [major, minor] or null if it can't be determined
+ */
+function requiredGlibcVersion(binary) {
+  for (const tool of ['objdump -T', 'readelf -V']) {
+    try {
+      const out = execSync(
+        `${tool} "${binary}" 2>/dev/null | grep -oE 'GLIBC_[0-9]+\\.[0-9]+' | sort -V | tail -1`,
+        { encoding: 'utf8', timeout: 10000 }
+      ).trim();
+      const v = parseVersionPair(out.replace('GLIBC_', ''));
+      if (v) return v;
+    } catch { /* try next tool */ }
+  }
+  return null;
+}
+
+/**
+ * Shared libraries a binary cannot resolve, honouring the bundled dist/lib
+ * (which the runtime wrapper also prepends to LD_LIBRARY_PATH). Linux only.
+ * @returns {string[]} unresolved "lib... => not found" lines
+ */
+function unresolvedLibraries(binary, distLibDir) {
+  if (process.platform !== 'linux') return [];
+  const env = {
+    ...process.env,
+    LD_LIBRARY_PATH: `${distLibDir}${path.delimiter}${process.env.LD_LIBRARY_PATH || ''}`,
+  };
+  let out = '';
+  try {
+    out = execSync(`ldd "${binary}" 2>&1`, { encoding: 'utf8', timeout: 15000, env });
+  } catch (err) {
+    out = (err.stdout || '').toString() + (err.stderr || '').toString();
+  }
+  return out
+    .split('\n')
+    .filter((line) => /not found/i.test(line))
+    .map((line) => line.trim());
+}
+
+/**
+ * Post-extract sanity check of the bundled native binaries.
+ *
+ * Surfaces the two distro-portability failure modes G6 calls out — a libnetcdff
+ * (or HDF5) soname the host doesn't provide, and a host glibc older than the
+ * binaries were built against — at install time with actionable guidance,
+ * instead of as an opaque loader error on first model run. Non-fatal: the npm
+ * shim's built-in commands still work, and pixi/system-dep install may yet
+ * provide the missing libraries.
+ */
+function verifyBundledBinaries(distDir) {
+  if (process.platform === 'win32') return; // libs bundled in the tarball
+
+  const binDir = path.join(distDir, 'bin');
+  const libDir = path.join(distDir, 'lib');
+  if (!fs.existsSync(binDir)) return;
+
+  // Prefer the Fortran models that link libnetcdff/HDF5 — they exercise the
+  // soname-variance path. Fall back to whatever is present.
+  const preferred = ['summa', 'mizuroute', 'fuse'];
+  const present = preferred
+    .map((n) => path.join(binDir, n))
+    .filter((p) => fs.existsSync(p));
+  if (present.length === 0) return;
+
+  console.log('\n🔎 Verifying bundled binaries link cleanly on this host...');
+
+  const missing = new Set();
+  for (const bin of present) {
+    for (const line of unresolvedLibraries(bin, libDir)) {
+      // keep just the soname (e.g. "libnetcdff.so.7")
+      missing.add(line.split('=>')[0].trim() || line);
+    }
+  }
+
+  if (missing.size > 0) {
+    console.warn('\n⚠️  Some bundled binaries are missing shared libraries on this system:');
+    for (const lib of missing) console.warn(`     - ${lib}`);
+    console.warn(
+      '\n   This is usually a libnetcdff/HDF5 soname that differs across distros.\n' +
+      '   Fixes (any one):\n' +
+      '     • Install the matching dev packages (e.g. apt-get install libnetcdff-dev libhdf5-dev),\n' +
+      '     • or use the pixi-managed environment (do NOT set SYMFLUENCE_SKIP_PIXI=1),\n' +
+      '     • or build from source: symfluence binary install\n'
+    );
+  }
+
+  // glibc baseline (Linux only) — read what the binary actually requires.
+  if (process.platform === 'linux') {
+    const host = hostGlibcVersion();
+    const required = requiredGlibcVersion(present[0]);
+    if (host && required && cmpVersion(host, required) < 0) {
+      console.warn(
+        `\n⚠️  Host glibc ${host.join('.')} is older than the binaries' baseline ` +
+        `(glibc ${required.join('.')}).\n` +
+        '   The pre-built Linux binaries will fail to load. Use a newer distro,\n' +
+        '   the pixi environment, or build from source: symfluence binary install\n'
+      );
+    } else if (host && required) {
+      console.log(`   glibc ${host.join('.')} ≥ required ${required.join('.')} ✓`);
+    }
+  }
+
+  if (missing.size === 0) {
+    console.log('   ✅ Bundled binaries resolve their libraries.');
+  }
+}
+
+/**
  * Runtime C/Fortran libraries required by SYMFLUENCE models (SUMMA, FUSE, etc.)
  * Each entry lists one or more detection commands and per-package-manager names.
  */
@@ -616,6 +781,14 @@ async function install() {
   console.log(`📍 Platform: ${getPlatformName()} (${platform})`);
   console.log(`📦 Version: ${PACKAGE_VERSION}\n`);
 
+  // Fail fast on missing install-time tooling before a large download.
+  try {
+    assertInstallTooling();
+  } catch (err) {
+    console.error('❌', err.message);
+    process.exit(1);
+  }
+
   const url = getDownloadUrl(platform);
   const checksumUrl = `${url}.sha256`;
 
@@ -644,6 +817,9 @@ async function install() {
 
     // Cleanup tarball
     fs.unlinkSync(tarballPath);
+
+    // Surface distro-portability issues (soname / glibc) now, not at first run.
+    verifyBundledBinaries(distDir);
 
     // Try pixi-managed Python environment (preferred — single libhdf5)
     const pixiOk = tryPixiBootstrap(distDir);
@@ -708,3 +884,15 @@ async function install() {
 if (require.main === module) {
   install();
 }
+
+// Exported for testing / reuse (e.g. the multi-distro CI matrix). Requiring
+// this module does not run install() — that only happens when run directly.
+module.exports = {
+  assertInstallTooling,
+  parseVersionPair,
+  cmpVersion,
+  hostGlibcVersion,
+  requiredGlibcVersion,
+  unresolvedLibraries,
+  verifyBundledBinaries,
+};

--- a/src/symfluence/cli/commands/binary_commands.py
+++ b/src/symfluence/cli/commands/binary_commands.py
@@ -345,15 +345,21 @@ class BinaryCommands(BaseCommand):
         service = BinaryService()
 
         # --- 1. npm-installed binaries ---
+        # The npm bundle stages binaries under canonical names (the tool key,
+        # e.g. `summa`) rather than the source-install filename (default_exe,
+        # `summa_sundials.exe`), so try the canonical name first. (#156 G6)
         npm_bin_dir = service.detect_npm_binaries()
         if npm_bin_dir is not None:
             tools_defs = get_external_tools_definitions()
             tool_def = tools_defs.get(tool_name)
+            exe_candidates = [tool_name]
             if tool_def is not None:
-                exe_name = tool_def.get("default_exe", tool_name)
+                exe_candidates.append(tool_def.get("default_exe", tool_name))
+            for exe_name in dict.fromkeys(c for c in exe_candidates if c):
                 candidate = npm_bin_dir / exe_name
                 if candidate.is_file():
                     binary_path = candidate
+                    break
 
         # --- 2. Source installs ($SYMFLUENCE_DATA_DIR/<suffix>/<exe>) ---
         if binary_path is None:

--- a/src/symfluence/cli/services/base.py
+++ b/src/symfluence/cli/services/base.py
@@ -117,12 +117,33 @@ class BaseService:
         if config_val and config_val != "default":
             return Path(config_val), "config SYMFLUENCE_DATA_DIR"
 
-        # 3. Reuse an existing workspace found at or above the current directory.
+        # 3-5. No explicit value — infer (shared with config-template repair).
+        return self._infer_data_dir_fallback()
+
+    def _infer_data_dir_fallback(self) -> tuple[Path, str]:
+        """
+        Infer a data directory when no explicit env/config value applies.
+
+        Shared by :meth:`_resolve_data_dir` (``binary install`` et al.) and
+        :meth:`_ensure_valid_config_paths` (config-template repair) so the
+        cwd-aware inference is identical in both. Order:
+
+        1. An existing, writable ``SYMFLUENCE_data`` workspace near cwd.
+        2. Sibling ``SYMFLUENCE_data`` next to a *real* repo checkout, when the
+           location is writable (developer default).
+        3. ``<cwd>/SYMFLUENCE_data`` for ad-hoc installs.
+        4. The computed default, even if not writable, as a last resort so
+           callers have a concrete path to report against.
+
+        Returns:
+            A ``(path, reason)`` tuple.
+        """
+        # 1. Reuse an existing workspace found at or above the current directory.
         existing = self._find_existing_data_dir()
         if existing is not None and self._is_writable_dir(existing):
             return existing, "existing workspace near the current directory"
 
-        # 4. Repo-sibling default — only when running from a real checkout and
+        # 2. Repo-sibling default — only when running from a real checkout and
         #    the location is actually writable.
         from symfluence.core.config.factories import _resolve_default_data_dir
         if self._running_from_repo():
@@ -130,7 +151,7 @@ class BaseService:
             if self._is_writable_dir(sibling):
                 return sibling, "sibling of the SYMFLUENCE repository"
 
-        # 5. Ad-hoc install (no env, no config, no repo) — infer from cwd.
+        # 3. Ad-hoc install (no env, no config, no repo) — infer from cwd.
         cwd = Path.cwd()
         if cwd.name == ".ipynb_checkpoints":
             cwd = cwd.parent
@@ -138,22 +159,40 @@ class BaseService:
         if self._is_writable_dir(cwd_data):
             return cwd_data, "current working directory (ad-hoc install)"
 
-        # Last resort: the computed default, even if not writable, so callers
-        # have a concrete path to report against.
+        # 4. Last resort.
         return Path(_resolve_default_data_dir()), "default data directory"
 
     @staticmethod
-    def _find_existing_data_dir(max_levels: int = 6) -> Optional[Path]:
+    def _looks_like_workspace(path: Path) -> bool:
         """
-        Look for an existing ``SYMFLUENCE_data`` directory at or above cwd.
+        Whether ``path`` looks like a populated SYMFLUENCE_data workspace.
 
-        Walks up at most ``max_levels`` directories so an ad-hoc install run from
-        inside (or just below) a workspace reuses it instead of creating a new
-        store. Matches either a directory literally named ``SYMFLUENCE_data`` or
-        one containing a ``SYMFLUENCE_data`` child.
+        Requiring a marker (``installs``/``.symfluence``/a ``domain_*`` dir)
+        before reusing a directory avoids adopting an unrelated directory that
+        merely happens to be named ``SYMFLUENCE_data``.
+        """
+        if not path.is_dir():
+            return False
+        if (path / "installs").is_dir() or (path / ".symfluence").is_dir():
+            return True
+        try:
+            return any(path.glob("domain_*"))
+        except OSError:
+            return False
+
+    @classmethod
+    def _find_existing_data_dir(cls, max_levels: int = 3) -> Optional[Path]:
+        """
+        Look for an existing SYMFLUENCE_data *workspace* at or above cwd.
+
+        Walks up at most ``max_levels`` directories and returns a ``SYMFLUENCE_data``
+        directory (the directory itself, or a child) only when it looks like a
+        real workspace (:meth:`_looks_like_workspace`). The bounded depth +
+        marker requirement keep an ad-hoc install from adopting a coincidentally
+        named or far-away directory.
 
         Returns:
-            The existing data directory, or ``None`` if none is found nearby.
+            The existing workspace directory, or ``None`` if none is found nearby.
         """
         start = Path.cwd()
         if start.name == ".ipynb_checkpoints":
@@ -161,10 +200,10 @@ class BaseService:
         for depth, directory in enumerate([start, *start.parents]):
             if depth > max_levels:
                 break
-            if directory.name == "SYMFLUENCE_data" and directory.is_dir():
+            if directory.name == "SYMFLUENCE_data" and cls._looks_like_workspace(directory):
                 return directory
             candidate = directory / "SYMFLUENCE_data"
-            if candidate.is_dir():
+            if cls._looks_like_workspace(candidate):
                 return candidate
         return None
 
@@ -263,10 +302,7 @@ class BaseService:
                 "Detected invalid or inaccessible paths in config template:"
             )
 
-            from symfluence.core.config.factories import (
-                _resolve_default_code_dir,
-                _resolve_default_data_dir,
-            )
+            from symfluence.core.config.factories import _resolve_default_code_dir
 
             if not code_dir_valid:
                 new_code_dir = _resolve_default_code_dir()
@@ -274,9 +310,9 @@ class BaseService:
                 self._console.success(f"SYMFLUENCE_CODE_DIR set to: {new_code_dir}")
 
             if not data_dir_valid:
-                new_data_dir = Path(_resolve_default_data_dir(
-                    config.get("SYMFLUENCE_CODE_DIR")
-                ))
+                # Same cwd-aware inference as `binary install`, so the two paths
+                # cannot disagree on where the data dir lives.
+                new_data_dir, _reason = self._infer_data_dir_fallback()
                 config["SYMFLUENCE_DATA_DIR"] = str(new_data_dir)
                 try:
                     new_data_dir.mkdir(parents=True, exist_ok=True)

--- a/src/symfluence/cli/services/base.py
+++ b/src/symfluence/cli/services/base.py
@@ -71,10 +71,8 @@ class BaseService:
         """
         Get SYMFLUENCE data directory from environment or config.
 
-        Priority:
-        1. SYMFLUENCE_DATA_DIR environment variable
-        2. Config value (if not 'default')
-        3. Sibling SYMFLUENCE_data directory next to the repo root
+        Thin wrapper over :meth:`_resolve_data_dir` that discards the
+        human-readable reason. See that method for the full resolution order.
 
         Args:
             config: Configuration dictionary.
@@ -82,19 +80,130 @@ class BaseService:
         Returns:
             Path to data directory.
         """
-        # Check environment variables
+        return self._resolve_data_dir(config)[0]
+
+    def _resolve_data_dir(self, config: Dict[str, Any]) -> tuple[Path, str]:
+        """
+        Resolve the SYMFLUENCE data directory and explain how it was chosen.
+
+        Priority:
+        1. SYMFLUENCE_DATA_DIR / SYMFLUENCE_DATA environment variable (explicit).
+        2. Config value (if not the 'default' sentinel).
+        3. An existing ``SYMFLUENCE_data`` workspace at or above the current
+           working directory (so ad-hoc installs land in a workspace the user
+           is already sitting in).
+        4. Sibling ``SYMFLUENCE_data`` next to a *real* repo checkout, when one
+           is detected and the location is writable (developer default).
+        5. ``<cwd>/SYMFLUENCE_data`` for ad-hoc installs (no repo, no env/config),
+           or when the repo-sibling default is not writable.
+
+        Every candidate after the explicit env/config values is validated for
+        writability; non-writable candidates are skipped with a fallback.
+
+        Args:
+            config: Configuration dictionary.
+
+        Returns:
+            A ``(path, reason)`` tuple. ``reason`` is a short phrase suitable for
+            surfacing to the user (e.g. in the installer's location banner).
+        """
+        # 1. Explicit environment variable — honour verbatim (even if awkward).
         data_dir = os.getenv("SYMFLUENCE_DATA_DIR") or os.getenv("SYMFLUENCE_DATA")
         if data_dir:
-            return Path(data_dir)
+            return Path(data_dir), "SYMFLUENCE_DATA_DIR environment variable"
 
-        # Check config value (skip 'default' sentinel)
+        # 2. Explicit config value (skip 'default' sentinel).
         config_val = config.get("SYMFLUENCE_DATA_DIR")
         if config_val and config_val != "default":
-            return Path(config_val)
+            return Path(config_val), "config SYMFLUENCE_DATA_DIR"
 
-        # Resolve from repo root: sibling SYMFLUENCE_data directory
+        # 3. Reuse an existing workspace found at or above the current directory.
+        existing = self._find_existing_data_dir()
+        if existing is not None and self._is_writable_dir(existing):
+            return existing, "existing workspace near the current directory"
+
+        # 4. Repo-sibling default — only when running from a real checkout and
+        #    the location is actually writable.
         from symfluence.core.config.factories import _resolve_default_data_dir
-        return Path(_resolve_default_data_dir())
+        if self._running_from_repo():
+            sibling = Path(_resolve_default_data_dir())
+            if self._is_writable_dir(sibling):
+                return sibling, "sibling of the SYMFLUENCE repository"
+
+        # 5. Ad-hoc install (no env, no config, no repo) — infer from cwd.
+        cwd = Path.cwd()
+        if cwd.name == ".ipynb_checkpoints":
+            cwd = cwd.parent
+        cwd_data = cwd / "SYMFLUENCE_data"
+        if self._is_writable_dir(cwd_data):
+            return cwd_data, "current working directory (ad-hoc install)"
+
+        # Last resort: the computed default, even if not writable, so callers
+        # have a concrete path to report against.
+        return Path(_resolve_default_data_dir()), "default data directory"
+
+    @staticmethod
+    def _find_existing_data_dir(max_levels: int = 6) -> Optional[Path]:
+        """
+        Look for an existing ``SYMFLUENCE_data`` directory at or above cwd.
+
+        Walks up at most ``max_levels`` directories so an ad-hoc install run from
+        inside (or just below) a workspace reuses it instead of creating a new
+        store. Matches either a directory literally named ``SYMFLUENCE_data`` or
+        one containing a ``SYMFLUENCE_data`` child.
+
+        Returns:
+            The existing data directory, or ``None`` if none is found nearby.
+        """
+        start = Path.cwd()
+        if start.name == ".ipynb_checkpoints":
+            start = start.parent
+        for depth, directory in enumerate([start, *start.parents]):
+            if depth > max_levels:
+                break
+            if directory.name == "SYMFLUENCE_data" and directory.is_dir():
+                return directory
+            candidate = directory / "SYMFLUENCE_data"
+            if candidate.is_dir():
+                return candidate
+        return None
+
+    @staticmethod
+    def _running_from_repo() -> bool:
+        """
+        Detect whether SYMFLUENCE is running from a real source checkout.
+
+        Returns True when the installed package sits inside a directory tree that
+        contains a ``pyproject.toml`` or ``.git`` (a developer checkout), and
+        False for an installed/site-packages ("ad-hoc") install.
+        """
+        try:
+            import symfluence
+
+            candidate = Path(symfluence.__file__).parent
+            for _ in range(5):
+                candidate = candidate.parent
+                if (candidate / "pyproject.toml").exists() or (candidate / ".git").exists():
+                    return True
+        except (ImportError, AttributeError, OSError, TypeError):
+            pass
+        return False
+
+    @staticmethod
+    def _is_writable_dir(path: Path) -> bool:
+        """
+        Check whether ``path`` is (or could be) created as a writable directory.
+
+        Walks up to the nearest existing ancestor and tests write access there,
+        so a not-yet-created target is judged by whether it *could* be made.
+        """
+        probe = path
+        while not probe.exists():
+            parent = probe.parent
+            if parent == probe:  # reached filesystem root without an existing dir
+                return False
+            probe = parent
+        return os.access(probe, os.W_OK)
 
     def _ensure_valid_config_paths(
         self, config: Dict[str, Any], config_path: Path

--- a/src/symfluence/cli/services/system_diagnostics.py
+++ b/src/symfluence/cli/services/system_diagnostics.py
@@ -9,7 +9,6 @@ Provides system health checks, toolchain information, and library detection.
 
 import json
 import shutil
-import subprocess
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -223,28 +222,15 @@ class SystemDiagnostics(BaseService):
         """
         Detect if SYMFLUENCE binaries are installed via npm.
 
+        Delegates to the shared :func:`symfluence.core.npm_bundle.npm_bundle_bin`
+        locator (single source of truth for the ``dist/bin`` convention).
+
         Returns:
             Path to npm-installed binaries, or None if not found.
         """
-        try:
-            result = subprocess.run(
-                ["npm", "root", "-g"],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
+        from symfluence.core.npm_bundle import npm_bundle_bin
 
-            if result.returncode == 0:
-                npm_root = Path(result.stdout.strip())
-                npm_bin_dir = npm_root / "symfluence" / "dist" / "bin"
-
-                if npm_bin_dir.exists() and npm_bin_dir.is_dir():
-                    return npm_bin_dir
-
-        except (subprocess.TimeoutExpired, subprocess.SubprocessError, FileNotFoundError, OSError, ValueError):
-            pass
-
-        return None
+        return npm_bundle_bin()
 
     def _check_binary_status(
         self, symfluence_data: str, npm_bin_dir: Optional[Path]

--- a/src/symfluence/cli/services/tool_installer.py
+++ b/src/symfluence/cli/services/tool_installer.py
@@ -469,9 +469,11 @@ class ToolInstaller(BaseService):
         }
 
         config = self._load_config(symfluence_instance)
-        install_base_dir = self._get_data_dir(config) / "installs"
+        data_dir, data_dir_reason = self._resolve_data_dir(config)
+        install_base_dir = data_dir / "installs"
 
         self._console.info(f"Installation directory: {install_base_dir}")
+        self._console.indent(f"(location: {data_dir_reason})")
 
         if not dry_run:
             install_base_dir.mkdir(parents=True, exist_ok=True)

--- a/src/symfluence/core/npm_bundle.py
+++ b/src/symfluence/core/npm_bundle.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""
+Locate binaries shipped via the npm package (``npm install -g symfluence``).
+
+The npm bundle stages pre-built tools in a flat ``dist/bin`` (and shared
+libraries in ``dist/lib``) under the global npm root. Several places need to
+find that directory — the CLI diagnostics, the binary pass-through command, the
+model runners' executable resolver, and the ngen preprocessor's BMI-lib lookup.
+This module is the single source of truth for that location so the
+``$(npm root -g)/symfluence/dist/...`` convention is not re-encoded per call
+site.
+
+Resolution honours the ``SYMFLUENCE_NPM_DIST_BIN`` environment override (an
+explicit path to the bundle's ``bin`` dir), which is also how tests point at a
+fixture bundle without a real npm install.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+_NPM_DIST_BIN_ENV = "SYMFLUENCE_NPM_DIST_BIN"
+
+
+def _npm_global_dist() -> Optional[Path]:
+    """Return ``$(npm root -g)/symfluence/dist`` if it exists, else ``None``."""
+    try:
+        result = subprocess.run(
+            ["npm", "root", "-g"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError, OSError, ValueError):
+        return None
+
+    if result.returncode != 0:
+        return None
+    try:
+        dist = Path(result.stdout.strip()) / "symfluence" / "dist"
+    except (ValueError, OSError):
+        return None
+    return dist if dist.is_dir() else None
+
+
+def npm_bundle_bin() -> Optional[Path]:
+    """Return the npm bundle's ``dist/bin`` directory, or ``None``.
+
+    Honours ``SYMFLUENCE_NPM_DIST_BIN`` (explicit bin dir) before falling back to
+    ``$(npm root -g)``. The ``npm root -g`` subprocess is only spawned when the
+    override is unset.
+    """
+    override = os.getenv(_NPM_DIST_BIN_ENV)
+    if override:
+        override_path = Path(override)
+        return override_path if override_path.is_dir() else None
+
+    dist = _npm_global_dist()
+    if dist is None:
+        return None
+    bin_dir = dist / "bin"
+    return bin_dir if bin_dir.is_dir() else None
+
+
+def npm_bundle_lib() -> Optional[Path]:
+    """Return the npm bundle's ``dist/lib`` directory, or ``None``.
+
+    When ``SYMFLUENCE_NPM_DIST_BIN`` is set, ``lib`` is taken as its sibling
+    (``dist/bin`` and ``dist/lib`` always live side by side in the bundle).
+    """
+    override = os.getenv(_NPM_DIST_BIN_ENV)
+    if override:
+        lib_dir = Path(override).parent / "lib"
+        return lib_dir if lib_dir.is_dir() else None
+
+    dist = _npm_global_dist()
+    if dist is None:
+        return None
+    lib_dir = dist / "lib"
+    return lib_dir if lib_dir.is_dir() else None

--- a/src/symfluence/models/base/base_runner.py
+++ b/src/symfluence/models/base/base_runner.py
@@ -608,6 +608,17 @@ class BaseModelRunner(ABC, ModelComponentMixin, PathResolverMixin, ShapefileAcce
             # Standard behavior - combine into full path
             exe_path = install_dir / exe_name
 
+        # npm fallback: pre-built tools shipped via `npm install -g symfluence`
+        # live in a flat dist/bin under canonical names (summa, mizuroute, ...),
+        # NOT under the source-install layout (installs/summa/bin/summa_sundials.exe).
+        # When the source path is absent, look the binary up in the npm bundle so
+        # workflows run against npm-only installs instead of failing here. (#156 G6)
+        if not exe_path.exists():
+            npm_exe = self._resolve_npm_executable(exe_name, default_install_subpath)
+            if npm_exe is not None:
+                self.logger.info(f"Using npm-bundled binary: {npm_exe}")
+                exe_path = npm_exe
+
         # Optional validation
         if must_exist and not exe_path.exists():
             if candidates:
@@ -632,6 +643,93 @@ class BaseModelRunner(ABC, ModelComponentMixin, PathResolverMixin, ShapefileAcce
         self._resolved_executables.append((label, exe_path))
 
         return exe_path
+
+    @staticmethod
+    def _find_npm_bin_dir() -> Optional[Path]:
+        """Locate the npm-bundled binary directory (``dist/bin``), if present.
+
+        Resolution order:
+          1. ``SYMFLUENCE_NPM_DIST_BIN`` env override (explicit; also used in tests).
+          2. ``$(npm root -g)/symfluence/dist/bin`` for a global ``npm install``.
+
+        Returns the directory, or ``None`` when no npm bundle is available. The
+        ``npm root -g`` subprocess is only reached on the executable-not-found
+        path, so the cost is paid solely when a source install is missing.
+        """
+        import os
+
+        override = os.getenv("SYMFLUENCE_NPM_DIST_BIN")
+        if override:
+            override_path = Path(override)
+            return override_path if override_path.is_dir() else None
+
+        import subprocess  # noqa: PLC0415 — lazy, failure-path only
+
+        try:
+            result = subprocess.run(
+                ["npm", "root", "-g"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except (subprocess.SubprocessError, FileNotFoundError, OSError, ValueError):
+            return None
+
+        if result.returncode != 0:
+            return None
+        try:
+            npm_bin_dir = Path(result.stdout.strip()) / "symfluence" / "dist" / "bin"
+        except (ValueError, OSError):
+            return None
+        return npm_bin_dir if npm_bin_dir.is_dir() else None
+
+    def _resolve_npm_executable(
+        self, exe_name: Optional[str], default_install_subpath: str
+    ) -> Optional[Path]:
+        """Resolve a model executable from the npm bundle's flat ``dist/bin``.
+
+        The npm release stages binaries under canonical names (the build-registry
+        tool key, e.g. ``summa``, ``mizuroute``) rather than the source-install
+        filename (``summa_sundials.exe``). This maps the requested tool to that
+        canonical name via the build registry, then falls back to ``.exe``-stripped
+        / lowercased variants of ``exe_name``.
+
+        Returns the resolved path inside the npm bundle, or ``None``.
+        """
+        npm_bin_dir = self._find_npm_bin_dir()
+        if npm_bin_dir is None:
+            return None
+
+        candidates: List[str] = []
+
+        # Authoritative mapping: build-registry tool key == npm staged filename.
+        try:
+            from symfluence.cli.services.build_registry import BuildInstructionsRegistry
+
+            for name, info in BuildInstructionsRegistry.get_all_instructions().items():
+                if (
+                    info.get("default_path_suffix") == default_install_subpath
+                    or (exe_name and info.get("default_exe") == exe_name)
+                ):
+                    candidates.append(name)
+                    break
+        except (ImportError, AttributeError, KeyError, OSError):
+            # Registry mapping is best-effort; fall back to exe-name variants.
+            pass
+
+        # Generic fallbacks derived from the source exe name.
+        if exe_name:
+            candidates.append(exe_name)
+            if exe_name.endswith(".exe"):
+                stem = exe_name[:-4]
+                candidates.extend([stem, stem.lower()])
+            candidates.append(exe_name.lower())
+
+        for candidate in dict.fromkeys(c for c in candidates if c):
+            path = npm_bin_dir / candidate
+            if path.is_file():
+                return path
+        return None
 
     # =========================================================================
     # File Verification

--- a/src/symfluence/models/base/base_runner.py
+++ b/src/symfluence/models/base/base_runner.py
@@ -648,40 +648,14 @@ class BaseModelRunner(ABC, ModelComponentMixin, PathResolverMixin, ShapefileAcce
     def _find_npm_bin_dir() -> Optional[Path]:
         """Locate the npm-bundled binary directory (``dist/bin``), if present.
 
-        Resolution order:
-          1. ``SYMFLUENCE_NPM_DIST_BIN`` env override (explicit; also used in tests).
-          2. ``$(npm root -g)/symfluence/dist/bin`` for a global ``npm install``.
-
-        Returns the directory, or ``None`` when no npm bundle is available. The
-        ``npm root -g`` subprocess is only reached on the executable-not-found
-        path, so the cost is paid solely when a source install is missing.
+        Thin delegate to :func:`symfluence.core.npm_bundle.npm_bundle_bin` — the
+        single source of truth for the npm bundle location (honours
+        ``SYMFLUENCE_NPM_DIST_BIN`` then ``npm root -g``). The subprocess is only
+        reached on the executable-not-found path.
         """
-        import os
+        from symfluence.core.npm_bundle import npm_bundle_bin
 
-        override = os.getenv("SYMFLUENCE_NPM_DIST_BIN")
-        if override:
-            override_path = Path(override)
-            return override_path if override_path.is_dir() else None
-
-        import subprocess  # noqa: PLC0415 — lazy, failure-path only
-
-        try:
-            result = subprocess.run(
-                ["npm", "root", "-g"],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-        except (subprocess.SubprocessError, FileNotFoundError, OSError, ValueError):
-            return None
-
-        if result.returncode != 0:
-            return None
-        try:
-            npm_bin_dir = Path(result.stdout.strip()) / "symfluence" / "dist" / "bin"
-        except (ValueError, OSError):
-            return None
-        return npm_bin_dir if npm_bin_dir.is_dir() else None
+        return npm_bundle_bin()
 
     def _resolve_npm_executable(
         self, exe_name: Optional[str], default_install_subpath: str
@@ -691,8 +665,8 @@ class BaseModelRunner(ABC, ModelComponentMixin, PathResolverMixin, ShapefileAcce
         The npm release stages binaries under canonical names (the build-registry
         tool key, e.g. ``summa``, ``mizuroute``) rather than the source-install
         filename (``summa_sundials.exe``). This maps the requested tool to that
-        canonical name via the build registry, then falls back to ``.exe``-stripped
-        / lowercased variants of ``exe_name``.
+        canonical name via the build-instructions registry, then falls back to
+        ``.exe``-stripped / lowercased variants of ``exe_name``.
 
         Returns the resolved path inside the npm bundle, or ``None``.
         """
@@ -702,16 +676,28 @@ class BaseModelRunner(ABC, ModelComponentMixin, PathResolverMixin, ShapefileAcce
 
         candidates: List[str] = []
 
-        # Authoritative mapping: build-registry tool key == npm staged filename.
+        # Authoritative mapping: build-instructions tool key == npm staged
+        # filename. Read R.build_instructions (core) directly rather than the
+        # cli accessor, so the models layer does not depend on cli. Entries may
+        # be unresolved provider callables — resolve each one defensively.
         try:
-            from symfluence.cli.services.build_registry import BuildInstructionsRegistry
+            from symfluence.core.registries import R
 
-            for name, info in BuildInstructionsRegistry.get_all_instructions().items():
+            # Same failure modes a provider callable can raise as the cli accessor.
+            _resolve_errors = (ImportError, AttributeError, KeyError, OSError,
+                               TypeError, ValueError, RuntimeError)
+            for name, value in list(R.build_instructions.items()):
+                try:
+                    info = value() if callable(value) and not isinstance(value, type) else value
+                except _resolve_errors:  # one bad provider must not block resolution
+                    continue
+                if not isinstance(info, dict):
+                    continue
                 if (
                     info.get("default_path_suffix") == default_install_subpath
                     or (exe_name and info.get("default_exe") == exe_name)
                 ):
-                    candidates.append(name)
+                    candidates.append(name.lower())
                     break
         except (ImportError, AttributeError, KeyError, OSError):
             # Registry mapping is best-effort; fall back to exe-name variants.

--- a/src/symfluence/models/ngen/preprocessor.py
+++ b/src/symfluence/models/ngen/preprocessor.py
@@ -192,20 +192,14 @@ class NgenPreProcessor(BaseModelPreProcessor):  # type: ignore[misc]
             self._include_snow17 = False
 
     def _detect_npm_lib_dir(self) -> Optional[Path]:
-        """Detect the npm-installed symfluence dist/lib/ directory."""
-        import subprocess as _sp
-        try:
-            result = _sp.run(
-                ["npm", "root", "-g"],
-                capture_output=True, text=True, timeout=5,
-            )
-            if result.returncode == 0:
-                lib_dir = Path(result.stdout.strip()) / "symfluence" / "dist" / "lib"
-                if lib_dir.is_dir():
-                    return lib_dir
-        except (FileNotFoundError, OSError, _sp.TimeoutExpired, _sp.SubprocessError):
-            pass
-        return None
+        """Detect the npm-installed symfluence dist/lib/ directory.
+
+        Delegates to the shared :func:`symfluence.core.npm_bundle.npm_bundle_lib`
+        locator (single source of truth for the bundle location).
+        """
+        from symfluence.core.npm_bundle import npm_bundle_lib
+
+        return npm_bundle_lib()
 
     def _resolve_ngen_lib_paths(self) -> Dict[str, Path]:
         lib_ext = ".dylib" if sys.platform == "darwin" else ".so"

--- a/tests/unit/cli/test_base_service_data_dir.py
+++ b/tests/unit/cli/test_base_service_data_dir.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Unit tests for BaseService data-directory resolution (issue #156, gap G7).
+
+Covers the cwd-inference + writability-validation behaviour added so that
+``symfluence binary install`` lands in a deterministic, writable location for
+ad-hoc installs, while preserving the explicit env/config/repo-sibling paths.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from symfluence.cli.services.base import BaseService
+
+
+@pytest.fixture
+def service():
+    return BaseService()
+
+
+@pytest.fixture(autouse=True)
+def _clear_data_env(monkeypatch):
+    """Ensure tests start from a clean env so resolution is deterministic."""
+    monkeypatch.delenv("SYMFLUENCE_DATA_DIR", raising=False)
+    monkeypatch.delenv("SYMFLUENCE_DATA", raising=False)
+
+
+class TestResolveDataDir:
+    def test_env_var_takes_priority(self, service, monkeypatch, tmp_path):
+        monkeypatch.setenv("SYMFLUENCE_DATA_DIR", str(tmp_path / "env_data"))
+        path, reason = service._resolve_data_dir({})
+        assert path == tmp_path / "env_data"
+        assert "environment" in reason.lower()
+
+    def test_config_value_used_when_no_env(self, service, tmp_path):
+        cfg = {"SYMFLUENCE_DATA_DIR": str(tmp_path / "cfg_data")}
+        path, reason = service._resolve_data_dir(cfg)
+        assert path == tmp_path / "cfg_data"
+        assert "config" in reason.lower()
+
+    def test_default_sentinel_is_ignored(self, service, monkeypatch, tmp_path):
+        """'default' is a sentinel, not a real path — fall through to inference."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(BaseService, "_running_from_repo", staticmethod(lambda: False))
+        path, _ = service._resolve_data_dir({"SYMFLUENCE_DATA_DIR": "default"})
+        assert path == tmp_path / "SYMFLUENCE_data"
+
+    def test_existing_workspace_at_cwd_is_reused(self, service, monkeypatch, tmp_path):
+        workspace = tmp_path / "SYMFLUENCE_data"
+        workspace.mkdir()
+        monkeypatch.chdir(tmp_path)
+        path, reason = service._resolve_data_dir({})
+        assert path == workspace
+        assert "existing workspace" in reason.lower()
+
+    def test_existing_workspace_above_cwd_is_reused(self, service, monkeypatch, tmp_path):
+        workspace = tmp_path / "SYMFLUENCE_data"
+        workspace.mkdir()
+        nested = tmp_path / "project" / "sub"
+        nested.mkdir(parents=True)
+        monkeypatch.chdir(nested)
+        path, _ = service._resolve_data_dir({})
+        assert path == workspace
+
+    def test_adhoc_install_infers_cwd(self, service, monkeypatch, tmp_path):
+        """No env/config/repo/workspace -> <cwd>/SYMFLUENCE_data, not cwd.parent."""
+        project = tmp_path / "myproject"
+        project.mkdir()
+        monkeypatch.chdir(project)
+        monkeypatch.setattr(BaseService, "_running_from_repo", staticmethod(lambda: False))
+        path, reason = service._resolve_data_dir({})
+        assert path == project / "SYMFLUENCE_data"
+        assert "current working directory" in reason.lower()
+
+    def test_repo_sibling_used_when_running_from_repo(self, service, monkeypatch, tmp_path):
+        repo = tmp_path / "SYMFLUENCE"
+        repo.mkdir()
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr(BaseService, "_running_from_repo", staticmethod(lambda: True))
+        monkeypatch.setattr(
+            "symfluence.core.config.factories._resolve_default_data_dir",
+            lambda *a, **k: str(tmp_path / "SYMFLUENCE_data"),
+        )
+        path, reason = service._resolve_data_dir({})
+        assert path == tmp_path / "SYMFLUENCE_data"
+        assert "repository" in reason.lower()
+
+    def test_non_writable_repo_sibling_falls_back_to_cwd(self, service, monkeypatch, tmp_path):
+        project = tmp_path / "proj"
+        project.mkdir()
+        monkeypatch.chdir(project)
+        monkeypatch.setattr(BaseService, "_running_from_repo", staticmethod(lambda: True))
+        monkeypatch.setattr(
+            "symfluence.core.config.factories._resolve_default_data_dir",
+            lambda *a, **k: "/nonexistent-root/SYMFLUENCE_data",
+        )
+        # /nonexistent-root has no existing writable ancestor -> not writable.
+        path, reason = service._resolve_data_dir({})
+        assert path == project / "SYMFLUENCE_data"
+        assert "current working directory" in reason.lower()
+
+
+class TestHelpers:
+    def test_is_writable_dir_for_existing_dir(self, tmp_path):
+        assert BaseService._is_writable_dir(tmp_path) is True
+
+    def test_is_writable_dir_for_creatable_child(self, tmp_path):
+        assert BaseService._is_writable_dir(tmp_path / "new" / "deep") is True
+
+    def test_is_writable_dir_for_unrootable_path(self):
+        assert BaseService._is_writable_dir(Path("/this-root-should-not-exist-xyz/x")) is False
+
+    def test_find_existing_data_dir_none_when_absent(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        assert BaseService._find_existing_data_dir() is None
+
+    def test_find_existing_data_dir_respects_depth_limit(self, monkeypatch, tmp_path):
+        (tmp_path / "SYMFLUENCE_data").mkdir()
+        deep = tmp_path.joinpath(*[f"l{i}" for i in range(8)])
+        deep.mkdir(parents=True)
+        monkeypatch.chdir(deep)
+        # The workspace is more than max_levels above cwd -> not found.
+        assert BaseService._find_existing_data_dir(max_levels=3) is None
+
+    def test_get_data_dir_returns_path_only(self, service, monkeypatch, tmp_path):
+        monkeypatch.setenv("SYMFLUENCE_DATA_DIR", str(tmp_path / "d"))
+        assert service._get_data_dir({}) == tmp_path / "d"

--- a/tests/unit/cli/test_base_service_data_dir.py
+++ b/tests/unit/cli/test_base_service_data_dir.py
@@ -49,7 +49,7 @@ class TestResolveDataDir:
 
     def test_existing_workspace_at_cwd_is_reused(self, service, monkeypatch, tmp_path):
         workspace = tmp_path / "SYMFLUENCE_data"
-        workspace.mkdir()
+        (workspace / "installs").mkdir(parents=True)  # marker: real workspace
         monkeypatch.chdir(tmp_path)
         path, reason = service._resolve_data_dir({})
         assert path == workspace
@@ -57,12 +57,23 @@ class TestResolveDataDir:
 
     def test_existing_workspace_above_cwd_is_reused(self, service, monkeypatch, tmp_path):
         workspace = tmp_path / "SYMFLUENCE_data"
-        workspace.mkdir()
+        (workspace / "domain_test").mkdir(parents=True)  # marker: real workspace
         nested = tmp_path / "project" / "sub"
         nested.mkdir(parents=True)
         monkeypatch.chdir(nested)
         path, _ = service._resolve_data_dir({})
         assert path == workspace
+
+    def test_empty_named_dir_is_not_adopted(self, service, monkeypatch, tmp_path):
+        """A SYMFLUENCE_data dir with no workspace marker is NOT reused."""
+        (tmp_path / "SYMFLUENCE_data").mkdir()  # no markers
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(BaseService, "_running_from_repo", staticmethod(lambda: False))
+        path, reason = service._resolve_data_dir({})
+        # Falls through to the ad-hoc cwd path, which happens to be the same dir
+        # name — but the reason proves it was created fresh, not "adopted".
+        assert path == tmp_path / "SYMFLUENCE_data"
+        assert "current working directory" in reason.lower()
 
     def test_adhoc_install_infers_cwd(self, service, monkeypatch, tmp_path):
         """No env/config/repo/workspace -> <cwd>/SYMFLUENCE_data, not cwd.parent."""
@@ -117,12 +128,25 @@ class TestHelpers:
         assert BaseService._find_existing_data_dir() is None
 
     def test_find_existing_data_dir_respects_depth_limit(self, monkeypatch, tmp_path):
-        (tmp_path / "SYMFLUENCE_data").mkdir()
+        ws = tmp_path / "SYMFLUENCE_data"
+        (ws / "installs").mkdir(parents=True)  # a real workspace, but far away
         deep = tmp_path.joinpath(*[f"l{i}" for i in range(8)])
         deep.mkdir(parents=True)
         monkeypatch.chdir(deep)
         # The workspace is more than max_levels above cwd -> not found.
         assert BaseService._find_existing_data_dir(max_levels=3) is None
+
+    def test_looks_like_workspace_requires_marker(self, tmp_path):
+        plain = tmp_path / "SYMFLUENCE_data"
+        plain.mkdir()
+        assert BaseService._looks_like_workspace(plain) is False
+        (plain / "installs").mkdir()
+        assert BaseService._looks_like_workspace(plain) is True
+
+    def test_looks_like_workspace_accepts_domain_marker(self, tmp_path):
+        ws = tmp_path / "SYMFLUENCE_data"
+        (ws / "domain_bow").mkdir(parents=True)
+        assert BaseService._looks_like_workspace(ws) is True
 
     def test_get_data_dir_returns_path_only(self, service, monkeypatch, tmp_path):
         monkeypatch.setenv("SYMFLUENCE_DATA_DIR", str(tmp_path / "d"))

--- a/tests/unit/models/base/test_base_runner.py
+++ b/tests/unit/models/base/test_base_runner.py
@@ -987,3 +987,106 @@ class TestRunnerHierarchyBackwardCompat:
         assert hasattr(runner, 'create_slurm_script')
         assert hasattr(runner, 'run_with_retry')
         assert hasattr(runner, 'execute_in_mode')
+
+
+class TestNpmExecutableFallback:
+    """Tests for npm-bundle executable resolution in get_model_executable (#156 G6).
+
+    The npm release stages binaries under canonical names (`summa`, `mizuroute`)
+    in a flat `dist/bin`, not the source-install layout
+    (`installs/summa/bin/summa_sundials.exe`). When the source path is absent the
+    runner must fall back to the npm bundle so workflows run on npm-only installs.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_npm_env(self, monkeypatch):
+        monkeypatch.delenv("SYMFLUENCE_NPM_DIST_BIN", raising=False)
+
+    def test_source_install_preferred_over_npm(self, runner, temp_dir, monkeypatch):
+        """When the source-install exe exists, the npm bundle is not consulted."""
+        src = temp_dir / "data" / "installs" / "summa" / "bin"
+        src.mkdir(parents=True)
+        (src / "summa_sundials.exe").write_text("#!/bin/sh\n")
+
+        npm_bin = temp_dir / "npm" / "dist" / "bin"
+        npm_bin.mkdir(parents=True)
+        (npm_bin / "summa").write_text("#!/bin/sh\n")
+        monkeypatch.setenv("SYMFLUENCE_NPM_DIST_BIN", str(npm_bin))
+
+        result = runner.get_model_executable(
+            "SUMMA_INSTALL_PATH", "installs/summa/bin",
+            default_exe_name="summa_sundials.exe",
+        )
+        assert result.resolve() == (src / "summa_sundials.exe").resolve()
+
+    def test_npm_canonical_name_resolved_when_source_absent(self, runner, temp_dir, monkeypatch):
+        """Source missing -> resolve the registry-canonical npm name (summa)."""
+        npm_bin = temp_dir / "npm" / "dist" / "bin"
+        npm_bin.mkdir(parents=True)
+        (npm_bin / "summa").write_text("#!/bin/sh\n")
+        monkeypatch.setenv("SYMFLUENCE_NPM_DIST_BIN", str(npm_bin))
+
+        result = runner.get_model_executable(
+            "SUMMA_INSTALL_PATH", "installs/summa/bin",
+            default_exe_name="summa_sundials.exe",
+        )
+        assert result.resolve() == (npm_bin / "summa").resolve()
+
+    def test_npm_mizuroute_canonical_name(self, runner, temp_dir, monkeypatch):
+        """mizuRoute's installs/mizuRoute/route/bin maps to npm 'mizuroute'."""
+        npm_bin = temp_dir / "npm" / "dist" / "bin"
+        npm_bin.mkdir(parents=True)
+        (npm_bin / "mizuroute").write_text("#!/bin/sh\n")
+        monkeypatch.setenv("SYMFLUENCE_NPM_DIST_BIN", str(npm_bin))
+
+        result = runner.get_model_executable(
+            "MIZUROUTE_INSTALL_PATH", "installs/mizuRoute/route/bin",
+            default_exe_name="mizuRoute.exe",
+        )
+        assert result.resolve() == (npm_bin / "mizuroute").resolve()
+
+    def test_npm_exe_name_variant_fallback(self, runner, temp_dir, monkeypatch):
+        """Unknown tool (not in registry) falls back to .exe-stripped exe name."""
+        npm_bin = temp_dir / "npm" / "dist" / "bin"
+        npm_bin.mkdir(parents=True)
+        (npm_bin / "customtool").write_text("#!/bin/sh\n")
+        monkeypatch.setenv("SYMFLUENCE_NPM_DIST_BIN", str(npm_bin))
+
+        result = runner.get_model_executable(
+            "CUSTOM_INSTALL_PATH", "installs/customtool/bin",
+            default_exe_name="customtool.exe",
+        )
+        assert result.resolve() == (npm_bin / "customtool").resolve()
+
+    def test_must_exist_raises_when_neither_source_nor_npm(self, runner, temp_dir, monkeypatch):
+        """must_exist still raises if neither source nor npm has the binary."""
+        npm_bin = temp_dir / "npm" / "dist" / "bin"
+        npm_bin.mkdir(parents=True)  # empty bundle
+        monkeypatch.setenv("SYMFLUENCE_NPM_DIST_BIN", str(npm_bin))
+
+        with pytest.raises(FileNotFoundError):
+            runner.get_model_executable(
+                "SUMMA_INSTALL_PATH", "installs/summa/bin",
+                default_exe_name="summa_sundials.exe", must_exist=True,
+            )
+
+    def test_no_npm_bundle_returns_source_path(self, runner, temp_dir, monkeypatch):
+        """With no npm bundle available, the (non-existent) source path is returned."""
+        # Override points at a non-directory -> _find_npm_bin_dir returns None.
+        monkeypatch.setenv("SYMFLUENCE_NPM_DIST_BIN", str(temp_dir / "does-not-exist"))
+        result = runner.get_model_executable(
+            "SUMMA_INSTALL_PATH", "installs/summa/bin",
+            default_exe_name="summa_sundials.exe",
+        )
+        expected = temp_dir / "data" / "installs" / "summa" / "bin" / "summa_sundials.exe"
+        assert result.resolve() == expected.resolve()
+
+    def test_find_npm_bin_dir_env_override_non_dir(self, monkeypatch, temp_dir):
+        monkeypatch.setenv("SYMFLUENCE_NPM_DIST_BIN", str(temp_dir / "nope"))
+        assert BaseModelRunner._find_npm_bin_dir() is None
+
+    def test_find_npm_bin_dir_env_override_valid(self, monkeypatch, temp_dir):
+        d = temp_dir / "bin"
+        d.mkdir()
+        monkeypatch.setenv("SYMFLUENCE_NPM_DIST_BIN", str(d))
+        assert BaseModelRunner._find_npm_bin_dir() == d


### PR DESCRIPTION
Closes the genuinely-remaining install-path work tracked in #156 (the deep G1/G6/G7 items that #155 left open because they need CI-matrix iteration rather than a single edit).

## G7 — deterministic `binary install` location
`binary install`/`validate`/`info`/`doctor` resolved the data dir via env → config → repo-sibling. For an **ad-hoc install** (`pip install symfluence`, no checkout, no env/config) the fallback put binaries in `cwd.parent/SYMFLUENCE_data` (one level *above* the user) and never checked writability.

- One resolver (`_resolve_data_dir`/`_infer_data_dir_fallback`) shared by install/validate/info/doctor **and** config-template repair, so they can't disagree.
- New order after env/config: reuse an existing nearby `SYMFLUENCE_data` **workspace** → repo-sibling (real checkout, writable) → `<cwd>/SYMFLUENCE_data`. Writability validated throughout; the chosen location + reason surfaced in the installer banner.
- Workspace reuse requires a marker (`installs/`, `.symfluence/`, `domain_*`) and is depth-capped (3), so it won't adopt a coincidentally-named or far-away directory.

## G1 — aarch64 source-build verification
#155 made `scripts/symfluence-bootstrap` arch-aware (`gcc -print-multiarch`), but it was never exercised on ARM. Adds `install-validate-arm.yml`: a `ubuntu-24.04-arm` runner does a full bootstrap source build, asserts the multiarch probe resolves to `aarch64-linux-gnu`, and verifies the built SUMMA/mizuRoute binaries are aarch64 and link cleanly. Every lib path is parameterised off the detected triplet (nothing hardcoded to x86_64).

## G6 — npm bundle
- **Runner-resolver fix (correctness):** `get_model_executable` now falls back to the npm `dist/bin` (canonical names via the build registry) when the source-install path is absent — so real workflows run on npm-only installs, not just `binary exec`. Validated against the **real `macos-arm64` v0.8.5 tarball** (summa/mizuroute/fuse/ngen all resolve and load).
- **install.js hardening:** `tar`/`curl` preflight; post-extract `ldd` self-check surfacing unresolved `libnetcdff`/HDF5 sonames; glibc-baseline check that scans the binary **and** bundled `dist/lib/*.so` (the libs drive the real floor).
- **Multi-distro CI matrix** (`npm-multidistro.yml`): clean `npm install -g` across ubuntu 22.04/24.04, debian 11/12, fedora 40, rocky 9, asserting per-distro that bundled binaries resolve and load.

### ⚠️ Release-pipeline finding (not fixed here)
Running the multi-distro matrix locally (Docker, real v0.8.5 tarball) showed the **published Linux tarball is not portable**: bundled `libgfortran.so.5` needs **GLIBC_2.38** (built on glibc 2.39), so it fails on debian:12 (2.36), rocky:9 (2.34) and below; and bundled `libcurl-gnutls` pulls **unbundled** `libxml2`/`libssh`/`libldap`/`librtmp`/`libpsl`. That's a **release-build** fix (older glibc base + bundle transitive deps) for whoever owns the release pipeline — the new install.js self-check now diagnoses it clearly, and the CI matrix will catch it going forward.

## Refactors (self-review)
- Single npm-bundle locator (`core/npm_bundle.py`) replacing the `$(npm root -g)/symfluence/dist/...` pattern that had been re-encoded in 4 places.
- Removed a models→cli layering inversion (`base_runner` reads `core.registries.R` directly instead of `cli.services.build_registry`).

## Testing
521 cli + models/base unit tests pass; ruff/mypy clean; `node --check` clean; both new workflows parse. G7 and the G6 runner fix are unit-tested and validated against real release artifacts. G1 and the G6 multi-distro matrix are authored and locally exercised but get full confirmation only on their first CI run (ARM runner / per-distro).

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).