### PR TITLE
fix(release): make the Linux binary tarball portable across distros (#156 G6)

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -33,7 +33,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-24.04
+          # linux-x86_64 is built INSIDE an old-glibc container (ubuntu:20.04,
+          # glibc 2.31) so the bundled GCC/netCDF/HDF5 runtimes don't carry a
+          # too-new GLIBC_2.3x symbol requirement. This lowers the release floor
+          # from the host's 2.39 to 2.31 — covering RHEL/Rocky 9 (2.34),
+          # Debian 11/12, Ubuntu 20.04+. The host runner only hosts the
+          # container. (#156 G6 release-pipeline glibc floor.)
+          # NOTE: container build not yet exercised in CI — expect minor
+          # iteration (focal toolchain versions) on the first tagged run.
+          - os: ubuntu-22.04
+            container: ubuntu:20.04
             platform: linux-x86_64
             python-version: '3.11'
           - os: macos-latest  # ARM Mac (M1/M2)
@@ -44,6 +53,8 @@ jobs:
             python-version: '3.11'
 
     runs-on: ${{ matrix.os }}
+    # Empty for macOS/Windows rows -> the job runs directly on the host runner.
+    container: ${{ matrix.container || '' }}
     timeout-minutes: 120
 
     env:
@@ -52,6 +63,17 @@ jobs:
       SYMFLUENCE_DATA_DIR: ${{ github.workspace }}/symfluence_data
 
     steps:
+      # The ubuntu:20.04 container is minimal: install what the JS actions and
+      # later steps need (git for `checkout --submodules`, sudo for the apt
+      # steps, file for the bundling step) BEFORE checkout. Runs as root.
+      - name: Bootstrap build container (old-glibc Linux)
+        if: matrix.container != ''
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            sudo git ca-certificates curl wget xz-utils file build-essential
+          git config --global --add safe.directory '*'
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -62,6 +84,15 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+
+      # focal ships cmake 3.16; several model builds need >= 3.20. Use the pip
+      # wheels (recent cmake/ninja), placed ahead of /usr/bin on PATH by the
+      # setup-python environment.
+      - name: Upgrade build tools in container (old-glibc Linux)
+        if: matrix.container != ''
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "cmake>=3.22" ninja
 
       # ========================================================================
       # Pre-Release Validation

--- a/scripts/stage_release_artifacts.sh
+++ b/scripts/stage_release_artifacts.sh
@@ -756,8 +756,23 @@ if [ "$OS_BUNDLE" = "Darwin" ]; then
     print_success "Dependency bundling complete ($BUNDLE_ROUND rounds)"
 
 elif [ "$OS_BUNDLE" = "Linux" ]; then
-    # Linux: bundle non-system shared libraries (e.g. from conda, /opt, etc.)
+    # Linux: bundle the FULL recursive closure of non-system shared libraries so
+    # the tarball is self-contained on a clean distro.
+    #
+    # The previous approach excluded everything under /usr/lib and then
+    # force-bundled a hardcoded allowlist (libnetcdf, libcurl, ...). That missed
+    # transitive deps that live in system paths but are NOT guaranteed present on
+    # the target distro — e.g. libcurl-gnutls pulls libxml2/libssh/libldap/
+    # liblber/librtmp/libpsl, none of which were bundled, so the binaries failed
+    # to load on Debian/RHEL. (#156 G6 release-pipeline finding.)
+    #
+    # Correct policy: bundle EVERY resolved dependency except the core
+    # glibc/loader set, which must always come from the host (bundling libc/libm/
+    # ld-linux would break the dynamic linker). The round loop re-scans newly
+    # bundled libs so the transitive closure is pulled in.
     if command -v ldd >/dev/null 2>&1; then
+        # Core glibc/loader libraries — never bundle these.
+        SYSTEM_LIB_RE='^(linux-vdso|ld-linux.*|libc|libm|libdl|libpthread|librt|libresolv|libutil|libnsl|libanl|libBrokenLocale|libmvec)\.so'
         BUNDLE_ROUND=0
         BUNDLE_CHANGED=1
         while [ $BUNDLE_CHANGED -eq 1 ]; do
@@ -770,31 +785,24 @@ elif [ "$OS_BUNDLE" = "Linux" ]; then
                 [ -L "$elf" ] && continue
                 file "$elf" | grep -q "ELF" || continue
 
-                # Find non-system dependencies
-                DEPS="$(ldd "$elf" 2>/dev/null | grep '=>' | awk '{print $3}' \
-                    | grep -vE '^(/usr/lib|/lib/|/lib64/)' \
-                    || true)"
-
-                # Also force-bundle specific libs that live in system paths
-                # but aren't universally available across Linux distros
-                FORCE_BUNDLE="libopenblas|liblapack|libgfortran|libgomp|libquadmath|libnetcdf|libnetcdff|libhdf5|libhdf5_hl|libsz|libaec|libcurl|libz"
-                FORCE_DEPS="$(ldd "$elf" 2>/dev/null | grep '=>' | awk '{print $3}' \
-                    | grep -E "($FORCE_BUNDLE)" \
-                    || true)"
-                DEPS="$(printf '%s\n%s' "$DEPS" "$FORCE_DEPS" | sort -u | grep -v '^$' || true)"
-
-                for dep in $DEPS; do
+                # Every resolved dependency path (column 3 of "name => /path (0x..)").
+                while IFS= read -r dep; do
                     [ -z "$dep" ] && continue
                     dep_basename="$(basename "$dep")"
-                    [ -f "lib/$dep_basename" ] && continue
 
-                    if [ -f "$dep" ]; then
-                        cp -L "$dep" "lib/$dep_basename"
-                        chmod +x "lib/$dep_basename"
-                        BUNDLE_CHANGED=1
-                        print_success "Bundled $dep_basename (from $dep)"
+                    # Skip the core glibc/loader libs (must come from the host).
+                    if printf '%s' "$dep_basename" | grep -qE "$SYSTEM_LIB_RE"; then
+                        continue
                     fi
-                done
+
+                    [ -f "lib/$dep_basename" ] && continue
+                    [ -f "$dep" ] || continue
+
+                    cp -L "$dep" "lib/$dep_basename"
+                    chmod +x "lib/$dep_basename"
+                    BUNDLE_CHANGED=1
+                    print_success "Bundled $dep_basename (from $dep)"
+                done < <(ldd "$elf" 2>/dev/null | awk '/=>/ && $3 ~ /^\// {print $3}')
             done
         done
         print_success "Dependency bundling complete ($BUNDLE_ROUND rounds)"


### PR DESCRIPTION
Follow-up to #162. While validating the G6 multi-distro matrix locally (Docker, real `v0.8.5` tarball), the published **Linux release tarball turned out not to be portable** — it fails to load on Debian 11/12, RHEL/Rocky 9, etc. Two independent root causes, both in the release-build pipeline; this PR fixes both.

## ① Incomplete library bundling — fixed + verified
`scripts/stage_release_artifacts.sh` excluded everything under `/usr/lib` then force-bundled a hardcoded allowlist (`libnetcdf`, `libcurl`, …). That missed the transitive deps of bundled libs — `libcurl-gnutls` pulls `libxml2/libssh/libldap/liblber/librtmp/libpsl`, none of which were copied in — so the binaries failed with `libxml2.so.2: cannot open shared object file`.

Now it bundles the **full recursive ldd closure**, denylisting only the core glibc/loader set (`libc/libm/ld-linux/…` must come from the host).

**Verified** in Docker against the real `v0.8.5` linux-x86_64 tarball: the previously-missing libs are now bundled, the closure resolves with only `dist/lib` on the path, and `summa --version` runs self-contained on a clean glibc-2.39 host.

## ② glibc floor too high — fixed, needs CI confirmation
The Linux binaries were built on `ubuntu-24.04` (glibc 2.39), so the bundled `libgfortran.so.5` etc. carry a `GLIBC_2.38` symbol requirement and fail on debian:12 (2.36), rocky:9 (2.34) and below. (The SUMMA binary itself only needs 2.34 — it's the *bundled runtimes* that set the floor.)

`release-binaries.yml` now builds `linux-x86_64` **inside a `ubuntu:20.04` container** (glibc 2.31) → covers **RHEL/Rocky 9 (2.34), Debian 11/12, Ubuntu 20.04+**. The host runner just hosts the container; macOS/Windows rows are unchanged. Adaptations: pre-checkout bootstrap (git/sudo/file/build-essential), git `safe.directory`, and a pip-installed modern cmake/ninja (focal ships cmake 3.16).

**Locally verified:** glibc is 2.31, every workflow apt dep resolves on focal, pip `cmake>=3.22` installs (4.3.2). **Not yet exercised:** the full model build on the focal toolchain (gfortran 9, gdal 3.0) — expect minor iteration on the first tagged release. Failure is isolated (matrix `fail-fast: false`, per-platform upload) so it **cannot corrupt a release**.

Combined effect: the in-build **"Test artifact relocatability"** step now runs `summa`/`ngen` under glibc 2.31, turning it into a real portability gate. The `npm-multidistro.yml` matrix (from #162) is the ongoing per-distro check.

### Remaining
Still misses RHEL/Rocky **8** (glibc 2.28) — would need a `manylinux_2_28` container, a larger follow-up.

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).