### PR TITLE
ci(deps): install-manifest consistency guard — completes Tier 2 item 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install minimal deps for linting
         run: |
           python -m pip install --upgrade pip
-          pip install ruff
+          pip install ruff pyyaml
 
       - name: Lint with ruff
         run: |
@@ -51,6 +51,10 @@ jobs:
       - name: Guard generic raises in models/
         run: |
           python scripts/check_model_raises.py
+
+      - name: Guard install-manifest consistency
+        run: |
+          python scripts/check_manifest_consistency.py
 
       - name: Type check with mypy
         continue-on-error: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,3 +88,10 @@ repos:
         language: system
         pass_filenames: false
         files: (symfluence_version\.py|pyproject\.toml|setup\.cfg)
+      - id: check-manifest-consistency
+        name: Guard install-manifest consistency
+        entry: python scripts/check_manifest_consistency.py
+        language: python
+        additional_dependencies: [pyyaml]
+        pass_filenames: false
+        files: (pyproject\.toml|pixi\.toml|environment\.yml)

--- a/pixi.toml
+++ b/pixi.toml
@@ -54,7 +54,9 @@ rich = ">=13.0,<14"
 pydantic = ">=2.0,<3"
 salib = ">=1.4,<2"
 pvlib-python = "*"
-cdsapi = ">=0.6,<1"
+# cdsapi >=0.7 speaks the post-Sept-2024 CDS endpoint; <0.7 silently 404s.
+# Keep in sync with pyproject.toml (enforced by check_manifest_consistency.py).
+cdsapi = ">=0.7,<1"
 
 # Build tools (for compiling external models)
 cmake = "*"

--- a/scripts/check_manifest_consistency.py
+++ b/scripts/check_manifest_consistency.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+"""
+Fail CI if the three install manifests disagree on a core dependency.
+
+Review item 16 (Tier 2): the seven install paths must stay at release quality.
+``pyproject.toml`` (pip/uv/pipx), ``pixi.toml`` (pixi/conda), and
+``environment.yml`` (conda) each declare the dependency stack independently, so
+they drift — a package gets a new upper bound in one and not the others, or is
+dropped from one entirely. That drift is exactly how an install method silently
+starts resolving a different (sometimes broken) version than the others.
+
+This guard checks, for a curated set of CORE packages that must stay consistent:
+
+  1. **Presence** — each core package is declared in all three manifests
+     (accounting for PyPI vs conda naming: netCDF4/netcdf4, torch/pytorch,
+     pvlib/pvlib-python, pint_xarray/pint-xarray, SALib/salib).
+  2. **Version bounds** — where both pyproject.toml and pixi.toml pin bounds,
+     the lower (>=) and upper (<) bounds agree once normalised (2.0 == 2.0.0).
+     environment.yml is intentionally unpinned and is checked for presence only.
+
+Packages that are deliberately ecosystem-specific (gdal as an optional/system
+extra, conda-only build tools, dev-only Jupyter) are simply absent from the
+core list. Run with ``--list`` to print what is checked.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tomllib
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+PIXI = REPO_ROOT / "pixi.toml"
+ENVIRONMENT = REPO_ROOT / "environment.yml"
+
+# Core packages that MUST stay consistent across all three install paths.
+# `names` lists every spelling the package goes by across PyPI and conda so the
+# presence check matches regardless of ecosystem naming. `check_version` is
+# False for packages pixi/pyproject intentionally leave unpinned ("*").
+CORE_PACKAGES: List[Dict] = [
+    {"canonical": "numpy", "names": {"numpy"}},
+    {"canonical": "pandas", "names": {"pandas"}},
+    {"canonical": "scipy", "names": {"scipy"}},
+    {"canonical": "xarray", "names": {"xarray"}},
+    {"canonical": "cftime", "names": {"cftime"}},
+    {"canonical": "numexpr", "names": {"numexpr"}},
+    {"canonical": "bottleneck", "names": {"bottleneck"}},
+    {"canonical": "networkx", "names": {"networkx"}},
+    {"canonical": "scikit-learn", "names": {"scikit-learn"}},
+    {"canonical": "netcdf4", "names": {"netcdf4"}},
+    {"canonical": "h5netcdf", "names": {"h5netcdf"}},
+    {"canonical": "geopandas", "names": {"geopandas"}},
+    {"canonical": "rasterio", "names": {"rasterio"}},
+    {"canonical": "pyproj", "names": {"pyproj"}},
+    {"canonical": "shapely", "names": {"shapely"}},
+    {"canonical": "fiona", "names": {"fiona"}},
+    {"canonical": "torch", "names": {"torch", "pytorch"}},
+    {"canonical": "matplotlib", "names": {"matplotlib"}},
+    {"canonical": "seaborn", "names": {"seaborn"}},
+    {"canonical": "plotly", "names": {"plotly"}},
+    {"canonical": "pyyaml", "names": {"pyyaml"}},
+    {"canonical": "requests", "names": {"requests"}},
+    {"canonical": "psutil", "names": {"psutil"}},
+    {"canonical": "tqdm", "names": {"tqdm"}},
+    {"canonical": "rich", "names": {"rich"}},
+    {"canonical": "pydantic", "names": {"pydantic"}},
+    {"canonical": "salib", "names": {"salib"}},
+    {"canonical": "pvlib", "names": {"pvlib", "pvlib-python"}},
+    {"canonical": "cdsapi", "names": {"cdsapi"}},
+    {"canonical": "distributed", "names": {"distributed"}},
+    {"canonical": "pint-xarray", "names": {"pint-xarray"}},
+    {"canonical": "contextily", "names": {"contextily"}},
+    {"canonical": "rasterstats", "names": {"rasterstats"}},
+]
+
+
+def normalize(name: str) -> str:
+    """Normalise a package name for cross-ecosystem comparison."""
+    # Drop extras/markers and channel prefixes (e.g. ``pytorch::pytorch``).
+    name = name.strip().split("::")[-1]
+    name = re.split(r"[\s;\[<>=!~]", name, maxsplit=1)[0]
+    return name.strip().lower().replace("_", "-")
+
+
+def parse_bounds(spec: str) -> Dict[str, Tuple[int, ...]]:
+    """Parse ``>=X,<Y`` style constraints into ``{op: version-tuple}``."""
+    bounds: Dict[str, Tuple[int, ...]] = {}
+    for op, ver in re.findall(r"(>=|<=|==|>|<)\s*([0-9][0-9.]*)", spec):
+        parts = ver.rstrip(".").split(".")
+        bounds[op] = tuple(int(p) for p in parts if p.isdigit())
+    return bounds
+
+
+def _norm_version(v: Tuple[int, ...]) -> Tuple[int, ...]:
+    """Strip trailing zeros so 2.0.0 == 2.0 == 2."""
+    out = list(v)
+    while len(out) > 1 and out[-1] == 0:
+        out.pop()
+    return tuple(out)
+
+
+def bounds_disagree(a: Dict[str, Tuple[int, ...]], b: Dict[str, Tuple[int, ...]]) -> List[str]:
+    """Return the operators on which two bound sets disagree (both must pin it)."""
+    diffs = []
+    for op in (">=", ">", "<", "<="):
+        if op in a and op in b and _norm_version(a[op]) != _norm_version(b[op]):
+            diffs.append(f"{op}{'.'.join(map(str, a[op]))} vs {op}{'.'.join(map(str, b[op]))}")
+    return diffs
+
+
+def load_pyproject(path: Path) -> Dict[str, str]:
+    """Return {normalized_name: version_spec} from [project] deps + optional deps."""
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    project = data.get("project", {})
+    specs: Dict[str, str] = {}
+    entries = list(project.get("dependencies", []))
+    for group in project.get("optional-dependencies", {}).values():
+        entries.extend(group)
+    for entry in entries:
+        name = normalize(entry)
+        specs[name] = entry
+    return specs
+
+
+def load_pixi(path: Path) -> Dict[str, str]:
+    """Return {normalized_name: version_spec} from pixi [dependencies] + [pypi-dependencies]."""
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    specs: Dict[str, str] = {}
+    for section in ("dependencies", "pypi-dependencies"):
+        for name, val in data.get(section, {}).items():
+            if isinstance(val, dict):  # {version = "...", channel = "..."}
+                val = val.get("version", "*")
+            specs[normalize(name)] = str(val)
+    return specs
+
+
+def load_environment(path: Path) -> Set[str]:
+    """Return the set of normalized package names declared in environment.yml."""
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    names: Set[str] = set()
+    for dep in data.get("dependencies", []):
+        if isinstance(dep, str):
+            names.add(normalize(dep))
+        elif isinstance(dep, dict):  # the `pip:` sub-list
+            for pip_dep in dep.get("pip", []):
+                names.add(normalize(pip_dep))
+    return names
+
+
+def _present(names: Set[str], declared: Set[str]) -> bool:
+    return bool(names & declared)
+
+
+def _spec_for(names: Set[str], specs: Dict[str, str]) -> Optional[str]:
+    for n in names:
+        if n in specs:
+            return specs[n]
+    return None
+
+
+def check_consistency() -> List[str]:
+    """Return a list of human-readable consistency issues (empty == consistent)."""
+    pyproject = load_pyproject(PYPROJECT)
+    pixi = load_pixi(PIXI)
+    env = load_environment(ENVIRONMENT)
+    pyproject_names, pixi_names = set(pyproject), set(pixi)
+
+    issues: List[str] = []
+    for pkg in CORE_PACKAGES:
+        canon, names = pkg["canonical"], pkg["names"]
+
+        missing = [
+            label
+            for label, declared in (
+                ("pyproject.toml", pyproject_names),
+                ("pixi.toml", pixi_names),
+                ("environment.yml", env),
+            )
+            if not _present(names, declared)
+        ]
+        if missing:
+            issues.append(f"{canon}: missing from {', '.join(missing)}")
+            continue  # can't compare bounds if a manifest lacks it
+
+        py_spec = _spec_for(names, pyproject)
+        px_spec = _spec_for(names, pixi)
+        diffs = bounds_disagree(parse_bounds(py_spec or ""), parse_bounds(px_spec or ""))
+        if diffs:
+            issues.append(
+                f"{canon}: version bounds disagree (pyproject '{py_spec}' vs pixi '{px_spec}'): "
+                + "; ".join(diffs)
+            )
+    return issues
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--list", action="store_true", help="print the core package list and exit")
+    args = parser.parse_args()
+
+    if args.list:
+        for pkg in CORE_PACKAGES:
+            print(pkg["canonical"], "->", "/".join(sorted(pkg["names"])))
+        return 0
+
+    issues = check_consistency()
+    if issues:
+        print("Manifest consistency check FAILED — core dependencies disagree across install paths:\n")
+        for issue in issues:
+            print(f"  ❌ {issue}")
+        print(
+            "\nKeep pyproject.toml, pixi.toml, and environment.yml in sync for the listed packages.\n"
+            "If a divergence is intentional, drop the package from CORE_PACKAGES in this script."
+        )
+        return 1
+
+    print(f"Manifest consistency check passed ({len(CORE_PACKAGES)} core packages consistent).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_check_manifest_consistency.py
+++ b/tests/unit/scripts/test_check_manifest_consistency.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Self-test for scripts/check_manifest_consistency.py (review item 16 guard)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_GUARD_PATH = Path(__file__).resolve().parents[3] / "scripts" / "check_manifest_consistency.py"
+_spec = importlib.util.spec_from_file_location("check_manifest_consistency", _GUARD_PATH)
+guard = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(guard)
+
+
+class TestNormalize:
+    def test_case_and_underscore(self):
+        assert guard.normalize("netCDF4") == "netcdf4"
+        assert guard.normalize("pint_xarray") == "pint-xarray"
+        assert guard.normalize("SALib") == "salib"
+
+    def test_strips_channel_prefix(self):
+        assert guard.normalize("pytorch::pytorch") == "pytorch"
+
+    def test_strips_version_and_extras(self):
+        assert guard.normalize("numpy>=2.0.0,<3.0.0") == "numpy"
+        assert guard.normalize("gdal[extra]>=3.0") == "gdal"
+        assert guard.normalize("requests ; python_version>'3'") == "requests"
+
+
+class TestParseBounds:
+    def test_lower_and_upper(self):
+        assert guard.parse_bounds(">=0.7.0,<1.0.0") == {">=": (0, 7, 0), "<": (1, 0, 0)}
+
+    def test_star_has_no_bounds(self):
+        assert guard.parse_bounds("*") == {}
+
+    def test_conda_style(self):
+        assert guard.parse_bounds(">=1.6,<2") == {">=": (1, 6), "<": (2,)}
+
+
+class TestBoundsDisagree:
+    def test_equal_after_normalization(self):
+        # 2.0.0 == 2.0 ; <3.0.0 == <3
+        a = guard.parse_bounds(">=2.0.0,<3.0.0")
+        b = guard.parse_bounds(">=2.0,<3")
+        assert guard.bounds_disagree(a, b) == []
+
+    def test_real_cdsapi_style_mismatch(self):
+        a = guard.parse_bounds(">=0.7.0,<1.0.0")
+        b = guard.parse_bounds(">=0.6,<1")
+        diffs = guard.bounds_disagree(a, b)
+        assert any(">=" in d for d in diffs)
+
+    def test_only_compares_shared_operators(self):
+        # pixi pins only an upper bound; pyproject pins both -> no disagreement
+        a = guard.parse_bounds(">=1.0,<2.0")
+        b = guard.parse_bounds("<2")
+        assert guard.bounds_disagree(a, b) == []
+
+
+def test_repo_manifests_are_consistent():
+    """Regression guard: the three real manifests agree on every core package."""
+    issues = guard.check_consistency()
+    assert issues == [], "Manifest drift detected:\n" + "\n".join(issues)


### PR DESCRIPTION
Closes the last genuine gap in **Tier 2** of the RTI review.

While picking up the requested Tier 2 tails (items 10, 16, 17), I verified the current state of `develop` and found that **items 10 and 17 are already done**:
- **Item 10** (broad-except → traceback): implemented via `exc_info=True` (693 sites / 275 files), commit `1cd8b530`, guarded in pre-commit + `ci.yml` (`check_resilience_logging.py`), allowlist empty. (My earlier "not done" keyed on `logger.exception`, which the implementation didn't use.)
- **Item 17** (Hypothesis property tests over the config model): already present in `tests/unit/config/test_config_properties.py` (flatten round-trip, hash determinism/sensitivity, canonical-vs-alias).

So the only remaining Tier 2 work was **item 16's companion consistency check** across `pyproject.toml` / `pixi.toml` / `environment.yml` (the install matrices themselves already exist).

### What this adds
`scripts/check_manifest_consistency.py` — for 33 curated core packages it asserts:
1. **Presence** in all three manifests, handling PyPI↔conda naming (`netCDF4`/`netcdf4`, `torch`/`pytorch`, `pvlib`/`pvlib-python`, `pint_xarray`, `SALib`).
2. **Matching `>=`/`<` bounds** between `pyproject.toml` and `pixi.toml`, normalised so `2.0 == 2.0.0`. (`environment.yml` is intentionally unpinned → presence-only.)

Wired into `ci.yml` and `.pre-commit-config.yaml` next to the other project guards; self-tested in `tests/unit/scripts/test_check_manifest_consistency.py` (10 tests, incl. a regression test that the real manifests agree).

### It already caught a real bug
`pyproject.toml` pins `cdsapi>=0.7.0` (with a comment that `<0.7` silently 404s on the post-Sept-2024 CDS endpoint), but `pixi.toml` allowed `>=0.6` — so pixi/conda users could resolve the broken `0.6`. **Fixed pixi to `>=0.7`.**

With this, **Tier 2 (items 9–17) is complete.** Remaining review work is Tier 3 (incl. the registry Phase B that's done-in-a-worktree but unmerged) and the 10 open questions.

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).