### PR TITLE
fix(ci): green up Windows unit tests and arm64 dep install

### DIFF
--- a/.github/workflows/install-validate-arm.yml
+++ b/.github/workflows/install-validate-arm.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Install system build deps
         run: |
           set -e
+          # 'universe' carries some of the deps below; ensure it's enabled on
+          # the arm64 ports mirror before resolving package candidates.
+          sudo add-apt-repository -y universe || true
           sudo apt-get update
           sudo apt-get install -y \
             build-essential gfortran cmake make pkg-config \
@@ -98,7 +101,12 @@ jobs:
             libopenblas-dev liblapack-dev \
             libfl-dev libbsd-dev \
             r-base libcurl4-openssl-dev \
-            python3-dev python3-pip python3-numpy cdo
+            python3-dev python3-pip python3-numpy
+          # cdo is a convenience NetCDF CLI, not required to build the Fortran
+          # binaries. On the arm64 ports mirror it intermittently has no
+          # installation candidate, so install it best-effort instead of
+          # failing the whole job (set -e).
+          sudo apt-get install -y cdo || echo "WARN: cdo unavailable on arm64; continuing without it"
           mpicc --version
           gdal-config --version
 

--- a/src/symfluence/cli/services/base.py
+++ b/src/symfluence/cli/services/base.py
@@ -242,6 +242,13 @@ class BaseService:
             if parent == probe:  # reached filesystem root without an existing dir
                 return False
             probe = parent
+        # If the only existing ancestor is the filesystem root/anchor itself
+        # while the requested target is deeper, treat it as not writable:
+        # creating a brand-new top-level directory at the root isn't a valid
+        # data-dir location (and on Windows a bare "/foo" is drive-relative, so
+        # the current drive root spuriously satisfies os.access(..., W_OK)).
+        if probe != path and probe == Path(probe.anchor):
+            return False
         return os.access(probe, os.W_OK)
 
     def _ensure_valid_config_paths(


### PR DESCRIPTION
## Summary

Two unrelated CI failures showed up on `develop` after #163. This fixes both.

### 1. Cross-Platform Testing — Windows unit tests (real bug)
`tests/unit/cli/test_base_service_data_dir.py` failed on `windows-latest`:
- `test_is_writable_dir_for_unrootable_path`
- `test_non_writable_repo_sibling_falls_back_to_cwd`

`BaseService._is_writable_dir(Path("/this-root-should-not-exist-xyz/x"))` returned `True` on Windows. A bare `/foo` is **drive-relative** on Windows, so the walk-up reached the current drive root (which exists and passes `os.access(..., W_OK)`) and the path spuriously looked writable. Linux/macOS pass because `/` isn't writable for the user.

Fix: reject targets whose only existing ancestor is the filesystem root/anchor itself — creating a brand-new top-level directory at the root is never a valid data-dir location. This is platform-agnostic and makes the heuristic explicit rather than relying on root being non-writable.

### 2. aarch64 source build (infra/apt)
`SYMFLUENCE - ARM64 Source Build & Validate` died at "Install system build deps":
```
E: Package 'cdo' has no installation candidate
```
`cdo` is a convenience NetCDF CLI, not required to build the Fortran binaries. It intermittently has no installation candidate on the arm64 ports mirror, and with `set -e` it killed the whole job. Now installed best-effort, with `universe` explicitly enabled.

## Testing
- `pytest tests/unit/cli/test_base_service_data_dir.py` → 17 passed (macOS)
- ruff clean

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).