### PR TITLE
fix(ci): follow symlink in arm64 binary arch verification

### DIFF
--- a/.github/workflows/install-validate-arm.yml
+++ b/.github/workflows/install-validate-arm.yml
@@ -235,7 +235,10 @@ jobs:
               echo "::warning::$name not present at $bin (skipped)"; return 0
             fi
             echo "-> $name: $bin"
-            file "$bin" | tee /tmp/filetype
+            # Follow symlinks (-L): summa.exe is a symlink to summa_sundials.exe,
+            # so `file` on the link reports "symbolic link to ..." instead of the
+            # ELF architecture, which would spuriously fail the aarch64 check.
+            file -L "$bin" | tee /tmp/filetype
             if ! grep -qiE "aarch64|arm64" /tmp/filetype; then
               echo "::error::$name is not an aarch64 binary"; return 1
             fi


### PR DESCRIPTION
## Summary

Follow-up to #165. Now that the arm64 deps step no longer dies on `cdo`, the `aarch64 source build + validate` job reaches its final verify step for the first time — and fails there:

```
-> SUMMA: .../summa/bin/summa.exe
.../summa.exe: symbolic link to summa_sundials.exe
##[error]SUMMA is not an aarch64 binary
```

`summa.exe` is a symlink to `summa_sundials.exe`. The verify step ran `file` on the symlink, which reports `"symbolic link to ..."` instead of the ELF architecture, so the `aarch64|arm64` grep failed even though the underlying binary is a correct aarch64 build.

Fix: use `file -L` to follow the symlink to its target. (`ldd` already follows symlinks, so the link-resolution check needed no change.)

## Testing
Dispatched the workflow on this branch via `workflow_dispatch` to confirm the full aarch64 build now passes end-to-end.

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).