### PR TITLE
fix(ci): pin h5py<3.16 to match netCDF4's bundled HDF5 (fixes ARM64 red)

### DIFF
--- a/.github/workflows/install-validate-arm.yml
+++ b/.github/workflows/install-validate-arm.yml
@@ -203,7 +203,11 @@ jobs:
           pip install -e ".[test]"
           # Force wheel-based h5py/netCDF4 (bootstrap may rebuild from source
           # against system libnetcdf w/ PnetCDF dispatch -> import-time failures).
-          pip install --force-reinstall --only-binary :all: h5py netCDF4
+          # Pin h5py<3.16: 3.16.0 bundles HDF5 2.0.0, but netCDF4 1.7.4 still
+          # bundles 1.14.6. Loading both into one process dual-loads two libhdf5
+          # builds and corrupts netCDF4's HDF5 state. h5py 3.15.x bundles 1.14.6,
+          # matching netCDF4. Lift this cap once netCDF4 wheels also ship HDF5 2.0.
+          pip install --force-reinstall --only-binary :all: 'h5py<3.16' netCDF4
 
       - name: Activate venv for subsequent steps
         run: |

--- a/.github/workflows/install-validate.yml
+++ b/.github/workflows/install-validate.yml
@@ -185,7 +185,9 @@ jobs:
           #   - Fortran binaries (SUMMA, mizuRoute) run as separate subprocesses
           #   - LD_LIBRARY_PATH does NOT include system HDF5 paths at test time
           #   - Wheel RUNPATH correctly resolves to bundled libraries
-          pip install --force-reinstall --only-binary :all: h5py netCDF4
+          # Pin h5py<3.16 so its bundled HDF5 (1.14.6) matches netCDF4 1.7.4;
+          # 3.16.0 bundles HDF5 2.0.0 and would dual-load a second libhdf5.
+          pip install --force-reinstall --only-binary :all: 'h5py<3.16' netCDF4
 
 
       - name: Add external tools to PATH
@@ -616,7 +618,9 @@ jobs:
 
           # Force wheel-based h5py/netCDF4 (bootstrap may have rebuilt from source
           # against system libnetcdf which has PnetCDF — causes pfnc_inq_vardimid)
-          pip install --force-reinstall --only-binary :all: h5py netCDF4
+          # Pin h5py<3.16 so its bundled HDF5 (1.14.6) matches netCDF4 1.7.4;
+          # 3.16.0 bundles HDF5 2.0.0 and would dual-load a second libhdf5.
+          pip install --force-reinstall --only-binary :all: 'h5py<3.16' netCDF4
 
       - name: Add external tools to PATH
         run: |


### PR DESCRIPTION
## Problem

The **SYMFLUENCE - ARM64 Source Build & Validate** job on `develop` is red ([run #26987434593](https://github.com/symfluence-org/SYMFLUENCE/actions/runs/26987434593)). Its *Validate binaries via CLI + import smoke* step fails on:

```
AssertionError: HDF5 dual-load mismatch
h5py 3.16.0, HDF5 2.0.0
netCDF4 1.7.4, HDF5 1.14.6
```

## Root cause

h5py **3.16.0** (released 2026-03-06) bumped its bundled HDF5 to **2.0.0**, while netCDF4 1.7.4 still bundles **1.14.6**. The jobs run `pip install --only-binary :all: h5py netCDF4`, so both wheels land in one venv carrying two different `libhdf5` builds. Importing h5py corrupts netCDF4's HDF5 state (`NetCDF: HDF error`). The ARM job asserts the two HDF5 versions match and hard-fails; the x86 job only warns, so the same hazard was silently present there too.

This is an upstream wheel-bundling break, not a code regression.

## Fix

Pin `h5py<3.16` across the ARM and x86 install/validate jobs. This resolves to **3.15.1**, whose aarch64/x86 wheels bundle `libhdf5 …so.310.5.1` = **HDF5 1.14.6** — verified by inspecting the wheels — exactly matching netCDF4 1.7.4. Both wheels then share one libhdf5, so the assert passes and the dual-load corruption is genuinely eliminated (not just silenced).

Comment in each site notes to lift the cap once netCDF4 wheels also ship HDF5 2.0.

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).