### PR TITLE
fix(ci): pin h5py to match netCDF4 bundled HDF5 on arm64

### DIFF
--- a/.github/workflows/install-validate-arm.yml
+++ b/.github/workflows/install-validate-arm.yml
@@ -203,7 +203,11 @@ jobs:
           pip install -e ".[test]"
           # Force wheel-based h5py/netCDF4 (bootstrap may rebuild from source
           # against system libnetcdf w/ PnetCDF dispatch -> import-time failures).
-          pip install --force-reinstall --only-binary :all: h5py netCDF4
+          # Pin h5py to 3.14.0: it bundles HDF5 1.14.6, matching the netCDF4
+          # 1.7.4 wheel's bundled HDF5 1.14.6. The latest h5py (3.16.x) jumped
+          # to HDF5 2.0.0, which mismatches netCDF4's 1.14.6 and trips the
+          # dual-load guard asserted in the import smoke step below.
+          pip install --force-reinstall --only-binary :all: 'h5py==3.14.0' netCDF4
 
       - name: Activate venv for subsequent steps
         run: |


### PR DESCRIPTION
## Summary

Third and final blocker in the arm64 `source build + validate` job, surfaced after #165 (cdo deps) and #166 (symlink verify) let the job reach its import smoke step for the first time.

The smoke step asserts h5py and netCDF4 bundle the same libhdf5:
```
h5py    → HDF5 2.0.0   (h5py 3.16.x wheel)
netCDF4 → HDF5 1.14.6  (netCDF4 1.7.4 wheel)
AssertionError: HDF5 dual-load mismatch
```
The latest h5py wheel jumped to HDF5 2.0.0 while netCDF4 1.7.4 still bundles 1.14.6. On x86 the versions happened to align; on arm64 they don't.

Fix: pin `h5py==3.14.0`, whose arm64 wheel bundles **HDF5 1.14.6** — verified by inspecting the wheel's bundled `libhdf5-*.so.310.5.1`, byte-for-byte the same soname as the netCDF4 1.7.4 wheel's. Restores parity and satisfies the dual-load guard.

## Validation
Will dispatch the arm64 workflow on this branch to confirm the job now passes end-to-end (steps 1–14 already pass on develop; this targets steps 15–16).

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).