### PR TITLE
fix(ci): pin h5py>=3.16 on x86_64 to avoid same-version HDF5 dual-load

### DIFF
--- a/.github/workflows/install-validate.yml
+++ b/.github/workflows/install-validate.yml
@@ -185,9 +185,15 @@ jobs:
           #   - Fortran binaries (SUMMA, mizuRoute) run as separate subprocesses
           #   - LD_LIBRARY_PATH does NOT include system HDF5 paths at test time
           #   - Wheel RUNPATH correctly resolves to bundled libraries
-          # Pin h5py<3.16 so its bundled HDF5 (1.14.6) matches netCDF4 1.7.4;
-          # 3.16.0 bundles HDF5 2.0.0 and would dual-load a second libhdf5.
-          pip install --force-reinstall --only-binary :all: 'h5py<3.16' netCDF4
+          # Pin h5py>=3.16 on x86_64: its wheel bundles HDF5 2.0.0, deliberately
+          # DIFFERENT from netCDF4 1.7.4's bundled HDF5 1.14.6. The two private
+          # libhdf5 copies then export differently-versioned symbols and stay
+          # isolated. Forcing them to the SAME version (h5py<3.16 -> 1.14.6)
+          # makes their identical un-versioned globals interpose, corrupting
+          # HDF5 dimscales at write time ("NetCDF: Problem with HDF5 dimscales").
+          # NOTE: arm64 wheels behave oppositely and DO need matching versions
+          # (h5py<3.16) — see install-validate-arm.yml. Do not unify these pins.
+          pip install --force-reinstall --only-binary :all: 'h5py>=3.16' netCDF4
 
 
       - name: Add external tools to PATH
@@ -618,9 +624,11 @@ jobs:
 
           # Force wheel-based h5py/netCDF4 (bootstrap may have rebuilt from source
           # against system libnetcdf which has PnetCDF — causes pfnc_inq_vardimid)
-          # Pin h5py<3.16 so its bundled HDF5 (1.14.6) matches netCDF4 1.7.4;
-          # 3.16.0 bundles HDF5 2.0.0 and would dual-load a second libhdf5.
-          pip install --force-reinstall --only-binary :all: 'h5py<3.16' netCDF4
+          # Pin h5py>=3.16 on x86_64: bundled HDF5 2.0.0 must stay DIFFERENT from
+          # netCDF4 1.7.4's 1.14.6 so the two private libhdf5 copies don't
+          # interpose and corrupt HDF5 dimscales at write time. arm64 needs the
+          # opposite (matching) pin — see install-validate-arm.yml.
+          pip install --force-reinstall --only-binary :all: 'h5py>=3.16' netCDF4
 
       - name: Add external tools to PATH
         run: |


### PR DESCRIPTION
## Problem

`SYMFLUENCE - Full Install & Validate` (x86_64) has been **red on `develop` since the #168 merge**. Every netCDF-writing test errors at setup:

```
RuntimeError: NetCDF: HDF error
RuntimeError: NetCDF: Problem with HDF5 dimscales
```

PR #169 (PostProcessor spelling) is innocent — it inherited a broken `develop`.

## Root cause

The `h5py<3.16` pin added in #168 fixed the **arm64** job but regressed **x86_64**. The `h5py` and `netCDF4` pip wheels each bundle a private, hash-sonamed copy of libhdf5. On x86_64, when both copies are the **same** version (`h5py<3.16` → HDF5 1.14.6, identical to netCDF4 1.7.4's 1.14.6) their un-versioned global symbols interpose and HDF5 state is corrupted at write time. When they **differ** (h5py 3.16 → HDF5 2.0.0) the copies stay isolated.

| develop run | h5py | bundled HDF5 | x86_64 | arm64 |
|---|---|---|---|---|
| #166 (no pin) | 3.16.0 | 2.0.0 | ✅ | ❌ |
| #168/#169 (`h5py<3.16`) | 3.15.1 | 1.14.6 | ❌ | ✅ |

The two architectures have **opposite** failure modes, so a single shared pin can't satisfy both. The CI "HDF5 versions match: True (good)" diagnostic is blind to dual-loading.

## Fix

Pin `h5py>=3.16` on **x86_64** (both install steps in `install-validate.yml`) to keep its bundled HDF5 deliberately different from netCDF4's. `install-validate-arm.yml` keeps `h5py<3.16` unchanged. Inline comments document that the two pins must stay divergent by architecture.

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).