### PR TITLE
fix(optimization): surface swallowed calibration-import failures; skip self-training models in SA

### DIFF
--- a/src/symfluence/core/_bootstrap.py
+++ b/src/symfluence/core/_bootstrap.py
@@ -97,18 +97,24 @@ def _bootstrap_model_aliases(R: type) -> None:  # noqa: N803
     may be declared here before the plugin entry points register the canonical
     keys.
 
-    Only hyphenated spellings whose hyphen-free form is the *actual* canonical
-    registration are aliased here. Note this differs from the BMI-adapter
-    aliases above: e.g. the BMI adapter is registered as ``XAJ`` whereas the
-    standalone runner is registered as ``XINANJIANG``, so no runner-level alias
-    is added for it. The guard below additionally refuses to shadow a real
-    registration with an alias.
+    Two kinds of alias live here. First, hyphenated spellings whose hyphen-free
+    form is the *actual* canonical registration (``HEC-HMS`` -> ``HECHMS``).
+    Note this differs from the BMI-adapter aliases above: e.g. the BMI adapter
+    is registered as ``XAJ`` whereas the standalone runner is registered as
+    ``XINANJIANG``, so no runner-level alias is added for it. Second, common
+    alternate / short names a config (or a derived sensitivity-analysis label)
+    may use for a model whose canonical key differs (``RHESS`` -> ``RHESSYS``;
+    the SUMMA+MODFLOW coupling -> the ``COUPLED_GW`` calibration pipeline). The
+    guard below additionally refuses to shadow a real registration with an alias.
     """
     # alias -> canonical, applied across every model-component registry
     model_aliases = {
         "HEC-HMS": "HECHMS",
         "SAC-SMA": "SACSMA",
         "CLM-PARFLOW": "CLMPARFLOW",
+        # Alternate / short names whose canonical key differs from the spelling.
+        "RHESS": "RHESSYS",
+        "SUMMA-MODFLOW": "COUPLED_GW",
     }
     component_registries = (
         R.runners,

--- a/src/symfluence/core/constants.py
+++ b/src/symfluence/core/constants.py
@@ -444,6 +444,12 @@ class SupportedModels:
     discovery, or ``R.plotters`` for already-registered plotters).
     """
 
+    #: Models whose "calibration" is internal training (gradient descent during
+    #: the run step), not an external DDS/PSO parameter search. They register no
+    #: optimizer/worker and have no calibrated parameters, so both the calibration
+    #: and sensitivity-analysis paths skip them rather than reporting a failure.
+    SELF_TRAINING = frozenset({'LSTM', 'GNN'})
+
     @classmethod
     def is_valid(cls, model_name: str) -> bool:
         """Return True if *model_name* is a model registered with the framework."""

--- a/src/symfluence/evaluation/analysis_manager.py
+++ b/src/symfluence/evaluation/analysis_manager.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import pandas as pd
 
+from symfluence.core.constants import SupportedModels
 from symfluence.core.exceptions import EvaluationError, symfluence_error_handler
 from symfluence.core.mixins import ConfigurableMixin
 from symfluence.core.registries import R
@@ -423,6 +424,27 @@ class AnalysisManager(ConfigurableMixin):
             ''
         )
         hydrological_models = [m.strip().upper() for m in str(models_str).split(',') if m.strip()]
+
+        # Self-training models (LSTM/GNN) learn their weights during run_model and
+        # expose no calibrated parameters, so there is nothing to perturb for a
+        # sensitivity analysis. Skip them here — exactly as the calibration path
+        # does — rather than letting them fail and drag the whole step to "no
+        # results for any configured model".
+        skipped_self_training = [m for m in hydrological_models if m in SupportedModels.SELF_TRAINING]
+        if skipped_self_training:
+            self.logger.info(
+                "Skipping sensitivity analysis for %s — these models train internally "
+                "during run_model and have no parameters to perturb.",
+                ', '.join(skipped_self_training),
+            )
+            hydrological_models = [m for m in hydrological_models if m not in SupportedModels.SELF_TRAINING]
+
+        if not hydrological_models:
+            self.logger.info(
+                "No models with calibratable parameters configured; "
+                "skipping sensitivity analysis."
+            )
+            return None
 
         for model in hydrological_models:
             try:

--- a/src/symfluence/optimization/_autodiscover.py
+++ b/src/symfluence/optimization/_autodiscover.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""
+Calibration component auto-discovery.
+
+Each model registers its optimizer / parameter manager / worker via decorators
+(``@R.optimizers.add('X')`` etc.) that only fire when the model's
+``calibration.<component>`` module is *imported*. This helper scans every model
+package and imports those modules so the decorators run.
+
+The important behaviour here is *how import failures are reported*. There are
+two very different reasons an import can fail, and conflating them is what made
+the old bare ``except ... : logger.debug(...)`` so misleading:
+
+* The model genuinely has no calibration support for this component (no
+  ``calibration`` subpackage, or no ``optimizer.py``). This is expected for the
+  many run-only models — log at DEBUG and move on.
+* The module *exists* but raised on import — almost always a missing optional
+  dependency (e.g. a compiled model binding) or a real bug in that module. The
+  old code swallowed this at DEBUG, so the model silently vanished from the
+  registry and the user later saw a baffling ``No optimizer registered for
+  model: X``. We now surface these at WARNING with the actual cause.
+"""
+
+import importlib
+import logging
+import pkgutil
+
+
+def discover_calibration_components(component: str, logger: logging.Logger) -> None:
+    """Import every model's ``calibration.<component>`` module to fire its decorator.
+
+    Parameters
+    ----------
+    component:
+        The calibration submodule to import for each model, e.g. ``"optimizer"``
+        or ``"parameter_manager"``.
+    logger:
+        Logger used for the DEBUG (no support) and WARNING (real failure) lines.
+    """
+    try:
+        import symfluence.models as models_pkg
+    except ImportError:
+        return
+
+    for _importer, model_name, is_pkg in pkgutil.iter_modules(models_pkg.__path__):
+        if not is_pkg:
+            continue
+
+        module_path = f'symfluence.models.{model_name}.calibration.{component}'
+        try:
+            importlib.import_module(module_path)
+        except ModuleNotFoundError as exc:
+            missing = exc.name or ''
+            # The target module — or its `calibration` parent — genuinely does
+            # not exist: this model has no calibration support for `component`.
+            if missing == module_path or module_path.startswith(missing + '.'):
+                logger.debug("No calibration.%s module for model '%s'", component, model_name)
+            else:
+                # The module exists but a dependency it imports is missing.
+                logger.warning(
+                    "Model '%s': calibration.%s could not import dependency '%s', so the "
+                    "model will NOT be available for calibration. Install the missing "
+                    "dependency, or run `python -c \"import %s\"` to see the full traceback.",
+                    model_name, component, missing, module_path,
+                )
+        except (ImportError, AttributeError) as exc:
+            # The module exists and was found, but raised while importing — a real
+            # error in that module (bad import, registration-time failure, ...).
+            logger.warning(
+                "Model '%s': calibration.%s exists but failed to import (%s: %s), so the "
+                "model will NOT be available for calibration. Run "
+                "`python -c \"import %s\"` to see the full traceback.",
+                model_name, component, type(exc).__name__, exc, module_path,
+            )

--- a/src/symfluence/optimization/model_optimizers/__init__.py
+++ b/src/symfluence/optimization/model_optimizers/__init__.py
@@ -23,29 +23,16 @@ def _register_optimizers():
 
     Scans ``symfluence.models.*`` for sub-packages that contain a
     ``calibration.optimizer`` module and imports each one to trigger its
-    ``@register_optimizer`` decorator.  Models whose dependencies are not
-    installed are silently skipped.
+    ``@register_optimizer`` decorator.  Models with no calibration support are
+    skipped silently; models whose optimizer module *exists but fails to
+    import* are surfaced at WARNING (see ``discover_calibration_components``)
+    so a missing dependency no longer masquerades as "No optimizer registered".
     """
-    import importlib
     import logging
-    import pkgutil
 
-    logger = logging.getLogger(__name__)
+    from symfluence.optimization._autodiscover import discover_calibration_components
 
-    try:
-        import symfluence.models as models_pkg
-    except ImportError:
-        return
-
-    for _importer, model_name, is_pkg in pkgutil.iter_modules(models_pkg.__path__):
-        if not is_pkg:
-            continue
-        module_path = f'symfluence.models.{model_name}.calibration.optimizer'
-        try:
-            importlib.import_module(module_path)
-        except (ImportError, ModuleNotFoundError, AttributeError):
-            # Expected for models without calibration support or missing deps
-            logger.debug("Skipped optimizer for %s", model_name)
+    discover_calibration_components('optimizer', logging.getLogger(__name__))
 
 
 # Trigger registration on import

--- a/src/symfluence/optimization/optimization_manager.py
+++ b/src/symfluence/optimization/optimization_manager.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 import pandas as pd
 
 from symfluence.core.base_manager import BaseManager
+from symfluence.core.constants import SupportedModels
 from symfluence.core.registries import R
 from symfluence.optimization.core import TransformationManager
 from symfluence.optimization.optimization_results_manager import OptimizationResultsManager
@@ -24,8 +25,9 @@ if TYPE_CHECKING:
 
 # Models whose "calibration" is internal training (gradient descent during the
 # run step), not an external DDS/PSO parameter search. They register no
-# optimizer/worker and are skipped by the registry calibration path.
-_SELF_TRAINING_MODELS = frozenset({'LSTM', 'GNN'})
+# optimizer/worker and are skipped by the registry calibration path. Canonical
+# definition lives in SupportedModels so the sensitivity-analysis path shares it.
+_SELF_TRAINING_MODELS = SupportedModels.SELF_TRAINING
 
 
 class OptimizationManager(BaseManager):

--- a/src/symfluence/optimization/parameter_managers/__init__.py
+++ b/src/symfluence/optimization/parameter_managers/__init__.py
@@ -28,29 +28,16 @@ def _register_parameter_managers():
 
     Scans ``symfluence.models.*`` for sub-packages that contain a
     ``calibration.parameter_manager`` module and imports each one to
-    trigger its ``@register_parameter_manager`` decorator.  Models whose
-    dependencies are not installed are silently skipped.
+    trigger its ``@register_parameter_manager`` decorator.  Models with no
+    calibration support are skipped silently; models whose parameter-manager
+    module *exists but fails to import* are surfaced at WARNING (see
+    ``discover_calibration_components``) instead of vanishing silently.
     """
-    import importlib
     import logging
-    import pkgutil
 
-    logger = logging.getLogger(__name__)
+    from symfluence.optimization._autodiscover import discover_calibration_components
 
-    try:
-        import symfluence.models as models_pkg
-    except ImportError:
-        return
-
-    for _importer, model_name, is_pkg in pkgutil.iter_modules(models_pkg.__path__):
-        if not is_pkg:
-            continue
-        module_path = f'symfluence.models.{model_name}.calibration.parameter_manager'
-        try:
-            importlib.import_module(module_path)
-        except (ImportError, ModuleNotFoundError, AttributeError):
-            # Expected for models without calibration support or missing deps
-            logger.debug("Skipped parameter manager for %s", model_name)
+    discover_calibration_components('parameter_manager', logging.getLogger(__name__))
 
 
 # Trigger registration on import

--- a/src/symfluence/optimization/workers/__init__.py
+++ b/src/symfluence/optimization/workers/__init__.py
@@ -55,11 +55,18 @@ def __getattr__(name):
         try:
             module = import_module(worker_mapping[name])
             return getattr(module, name)
-        except (ImportError, AttributeError):
+        except ImportError as exc:
+            # Surface the real cause (e.g. a missing optional dependency) rather
+            # than collapsing every failure into a generic "not found".
             raise AttributeError(
-                f"Worker '{name}' not found. Ensure the model package is installed "
-                f"and the worker is defined in {worker_mapping[name]}"
-            ) from None
+                f"Worker '{name}' could not be imported from '{worker_mapping[name]}' "
+                f"({type(exc).__name__}: {exc}). Ensure the model package and its "
+                f"dependencies are installed."
+            ) from exc
+        except AttributeError as exc:
+            raise AttributeError(
+                f"Worker class '{name}' is not defined in '{worker_mapping[name]}'."
+            ) from exc
 
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 

--- a/tests/unit/evaluation/test_sensitivity_loud_fail.py
+++ b/tests/unit/evaluation/test_sensitivity_loud_fail.py
@@ -136,3 +136,57 @@ def test_analysis_manager_raises_when_no_model_produces_results(monkeypatch, tmp
     assert "SUMMA" in msg
     assert "FUSE" in msg
     assert "non-numeric bounds" in msg
+
+
+def _make_manager(hydrological_model):
+    """Build an AnalysisManager wired to a fake config, bypassing __init__."""
+    from symfluence.evaluation.analysis_manager import AnalysisManager
+
+    cfg = MagicMock()
+    cfg.model.hydrological_model = hydrological_model
+    cfg.analysis.run_sensitivity_analysis = True
+
+    mgr = AnalysisManager.__new__(AnalysisManager)
+    mgr.config = cfg
+    mgr.logger = logging.getLogger("test_sa_self_training")
+    mgr.reporting_manager = MagicMock()
+    mgr._get_config_value = lambda getter, default=None, **_: (
+        getter() if callable(getter) else default
+    )
+    return mgr
+
+
+def test_self_training_only_config_skips_without_failing(monkeypatch):
+    """A config of only self-training models (LSTM/GNN) has no parameters to
+    perturb. Sensitivity analysis must return None (clean skip), NOT raise
+    EvaluationError — these models would otherwise drag the whole step to
+    'no results for any configured model'."""
+    mgr = _make_manager("LSTM,GNN")
+
+    # Guard: the analyzer paths must never be reached for self-training models.
+    def explode(model):
+        raise AssertionError(f"sensitivity analysis should not run for {model}")
+
+    monkeypatch.setattr(mgr, "_run_generic_sensitivity_analysis", explode)
+
+    assert mgr.run_sensitivity_analysis() is None
+
+
+def test_self_training_models_excluded_from_mixed_config(monkeypatch):
+    """In a mixed config, LSTM/GNN are dropped and only the calibratable
+    models are analyzed — and the 'no results' aggregation never mentions the
+    skipped self-training models."""
+    mgr = _make_manager("LSTM,SUMMA")
+
+    analyzed = []
+
+    def record(model):
+        analyzed.append(model)
+        return {"param_a": {"S1": 0.5}}
+
+    monkeypatch.setattr(mgr, "_run_generic_sensitivity_analysis", record)
+
+    results = mgr.run_sensitivity_analysis()
+
+    assert analyzed == ["SUMMA"], f"LSTM should have been skipped, saw: {analyzed}"
+    assert results is not None and "LSTM" not in results


### PR DESCRIPTION
## Summary

The registry calibration path silently swallowed import failures during auto-discovery of each model's `calibration.optimizer` / `calibration.parameter_manager` module, logging only at `DEBUG`. A model whose module **existed but failed to import** (missing optional dependency, or a real bug) vanished from the registry and later surfaced as a misleading `No optimizer registered for model: X`.

This was hit in practice on a multi-model Bow-at-Banff sweep: heavy models appeared "unregistered" when their optimizer modules couldn't import on the cluster, with no trail back to the real cause.

## Changes

- **Surface swallowed import failures.** New `optimization/_autodiscover.py` with `discover_calibration_components()`, which distinguishes:
  - *model has no calibration module* → `DEBUG` (expected for run-only models), from
  - *module exists but failed to import* → `WARNING` naming the model, the component, the actual missing dependency / error, and a copy-paste command to reproduce the traceback.

  Both auto-discovery loops (`model_optimizers`, `parameter_managers`) now use it. Since workers register as a side-effect of the optimizer import, this surfaces missing workers too.
- **Preserve the real cause** (`from exc`) in the worker lazy-importer instead of collapsing every failure into a generic "not found".
- **Add model-name aliases** `RHESS → RHESSYS` and `SUMMA-MODFLOW → COUPLED_GW`, so alternate/short spellings resolve (alongside the existing `CLM-PARFLOW`).
- **Skip self-training models (LSTM/GNN) in the sensitivity-analysis path**, mirroring the calibration path, so they no longer drag the step to "no results for any configured model". The canonical set is hoisted to `SupportedModels.SELF_TRAINING` so both paths share one definition.

## Tests

- New regression tests for the LSTM/GNN sensitivity-analysis skip (clean `None` return on self-training-only configs; exclusion from mixed configs).
- `tests/unit/core/test_model_aliases.py` and `tests/unit/evaluation/test_sensitivity_loud_fail.py` pass (11 tests); ruff clean.

## Notes

- No behavior change for models that already registered correctly — this only makes failures visible and resolves alternate model-name spellings.

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).