### PR TITLE
fix(coupling): hand each iteration's fresh upstream output to the downstream model

### DIFF
--- a/src/symfluence/models/coupled/calibration/optimizer.py
+++ b/src/symfluence/models/coupled/calibration/optimizer.py
@@ -56,3 +56,37 @@ class CoupledModelOptimizer(BaseModelOptimizer):
 
     def _run_model_for_final_evaluation(self, output_dir: Path) -> bool:
         return self.worker.run_model(self.config, self.project_dir / 'settings', output_dir)
+
+    def _update_file_manager_output_path(self, output_dir: Path) -> None:
+        """Point the land model's output into ``output_dir/<land>`` (mirrors COUPLED_GW).
+
+        The coupled worker runs each model into ``output_dir/<model>`` and the routing model reads
+        the land output from there, so SUMMA must write to ``output_dir/SUMMA`` (not ``output_dir/``).
+        Also restores settingsPath to the project land settings (where the trial params were written).
+        """
+        if self.land_model_name != 'SUMMA':
+            return super()._update_file_manager_output_path(output_dir)
+        fm = self._get_final_file_manager_path()
+        if not fm.exists() or not fm.is_file():
+            return
+        try:
+            land_output = str(output_dir / self.land_model_name)
+            if not land_output.endswith('/'):
+                land_output += '/'
+            land_settings = str(self.project_dir / 'settings' / self.land_model_name)
+            if not land_settings.endswith('/'):
+                land_settings += '/'
+            with open(fm, encoding='utf-8') as f:
+                lines = f.readlines()
+            out = []
+            for line in lines:
+                if 'outputPath' in line and not line.strip().startswith('!'):
+                    out.append(f"outputPath '{land_output}' \n")
+                elif 'settingsPath' in line and not line.strip().startswith('!'):
+                    out.append(f"settingsPath '{land_settings}' \n")
+                else:
+                    out.append(line)
+            with open(fm, 'w', encoding='utf-8') as f:
+                f.writelines(out)
+        except (FileNotFoundError, IOError, ValueError) as e:
+            self.logger.error(f"Failed to update file manager output path: {e}")

--- a/src/symfluence/models/coupled/calibration/worker.py
+++ b/src/symfluence/models/coupled/calibration/worker.py
@@ -136,15 +136,30 @@ class CoupledModelWorker(BaseWorker):
         return True
 
     def _run_sequential(self, config: Dict[str, Any], settings_dir: Path, output_dir: Path, **kwargs) -> bool:
-        """Run each model in graph order; each downstream worker discovers its upstream output."""
-        run_kwargs = {k: v for k, v in kwargs.items() if k not in ('sim_dir', 'output_dir', 'settings_dir')}
+        """Run each model in graph order, handing THIS iteration's upstream output to the next.
+
+        Mirrors the CoupledGW worker: each model runs into ``output_dir/<model>`` and the downstream
+        worker receives ``coupling_source_dir`` = the upstream model's fresh output dir, so it routes
+        this iteration's runoff (not a stale project-level file). Output dirs are recreated each call
+        to avoid stale NetCDF from a prior killed iteration.
+        """
+        import shutil
+        run_kwargs = {k: v for k, v in kwargs.items()
+                      if k not in ('sim_dir', 'output_dir', 'settings_dir', 'coupling_source_dir')}
+        prev_output: Optional[Path] = None
         for model in self._models:
             mdir = Path(output_dir) / model
+            if mdir.exists():
+                shutil.rmtree(mdir, ignore_errors=True)
             mdir.mkdir(parents=True, exist_ok=True)
-            ok = self._worker(model).run_model(config, self._settings_for(settings_dir, model), mdir, **run_kwargs)
+            kw = dict(run_kwargs, sim_dir=mdir)
+            if prev_output is not None:
+                kw['coupling_source_dir'] = prev_output   # downstream reads THIS iteration's output
+            ok = self._worker(model).run_model(config, self._settings_for(settings_dir, model), mdir, **kw)
             if not ok:
                 self.logger.error(f"Coupled chain failed at model '{model}'")
                 return False
+            prev_output = mdir
         return True
 
     def calculate_metrics(self, output_dir: Path, config: Dict[str, Any], **kwargs) -> Dict[str, Any]:


### PR DESCRIPTION
Completes the sequential coupled fresh-read handoff — the SYMFLUENCE side of the SUMMA→dRoute coupling. Pairs with the dRoute worker's `coupling_source_dir` consumption (merged in symfluence-org/dRoute#10 and via PR #175). Without this, the coupled worker never passes `coupling_source_dir`, so routing evaluates **stale** runoff during calibration.

## Changes
- **`CoupledModelWorker._run_sequential`**: run each model into `output_dir/<model>`, recreate that dir each iteration (avoids stale NetCDF from a killed run), and pass `coupling_source_dir` = the upstream model's fresh output dir to the downstream worker — so routing reads *this* iteration's runoff, not a stale project-level file.
- **`CoupledModelOptimizer._update_file_manager_output_path`**: point the SUMMA file manager's `outputPath` at `output_dir/SUMMA` (and restore `settingsPath` to the project land settings), mirroring the CoupledGW pattern, so the routing model can locate the land output.

## Validation
75/75 coupling unit tests pass; ruff clean.