### PR TITLE
fix(hype): reconcile river/catchment id mismatch in lumped GeoData

### DIFF
--- a/src/symfluence/models/hype/geodata_manager.py
+++ b/src/symfluence/models/hype/geodata_manager.py
@@ -212,6 +212,30 @@ class HYPEGeoDataManager:
         # 6. Final merging
         base_df = base_df.join(cat_props, on='subid')
 
+        # Positional fallback for id-label mismatch between the river network
+        # and the catchment shapefile. For lumped/single-subbasin domains the
+        # river reach id (e.g. LINKNO=1) often differs from the catchment id
+        # (e.g. GRU_ID=<domain>), so the id-based join above leaves area/lat/lon
+        # as NaN and the only subbasin gets dropped -> empty GeoData -> HYPE
+        # fails. When the row counts match (1:1, the lumped case), assign the
+        # catchment properties positionally instead of by id.
+        join_cols = ['area', 'latitude', 'longitude']
+        if base_df[join_cols].isna().any(axis=None) and len(base_df) == len(cat_props):
+            self.logger.warning(
+                "Catchment id-join left %d/%d sub-basins without geometry; "
+                "river/catchment ids differ — filling positionally (1:1 lumped).",
+                int(base_df[join_cols].isna().any(axis=1).sum()), len(base_df),
+            )
+            for col in join_cols:
+                base_df[col] = cat_props[col].to_numpy()
+            # For a single lumped basin, also reconcile the subbasin id to the
+            # catchment id. The forcing/observation files (Pobs/Tobs/Qobs) are
+            # keyed by the catchment id, so a river-reach subid (e.g. 1) would
+            # make HYPE fail to match forcing/obs ("halt: loading observations").
+            # maindown is the outlet (0) here, so topology is unaffected.
+            if len(base_df) == 1:
+                base_df['subid'] = [int(cat_props.index[0])]
+
         # Robust elevation mapping
         elev_col = 'mean' if 'mean' in elevation_data.columns else 'elev_mean'
 


### PR DESCRIPTION
## Summary
Follow-up to #179. On **lumped / single-subbasin** domains, HYPE produced an **empty GeoData** (every sub-basin dropped) and then, once geometry was present, **halted while loading observations** — because the river-network reach id differs from the catchment id.

## Root cause
`geodata_manager.create_geofiles` builds sub-basin ids from the **river network** (e.g. `LINKNO=1`) but joins catchment `area/lat/lon` by id from the **catchment** shapefile (e.g. `GRU_ID=<domain>`). The id-based join yields NaN → the only sub-basin is dropped → empty GeoData → HYPE rc=1. Even with geometry filled, the river-derived `subid` (1) does not match the forcing/observation files (`Pobs/Tobs/Qobs` are keyed by the catchment id, e.g. 3), so HYPE halts loading observations.

(Domains where the two ids happen to coincide — e.g. `GRU_ID == LINKNO == 105` — worked, masking the bug.)

## Fix
For the 1:1 (lumped) case:
- fill catchment geometry **positionally** when the id-join leaves it empty;
- reconcile the single sub-basin `subid` to the **catchment id** so it matches the forcing/obs columns. `maindown` is the outlet (0), so topology is unaffected.

## Verification
On a domain that previously produced empty GeoData / rc=1: GeoData now has a valid row (`subid` matches `Pobs`), HYPE **completes** and produces non-zero discharge across the full 2000–2008 period. Combined with #179, HYPE now runs the full lumped large-sample.

- `tests/unit/models/hype/` + `test_hype_mesh_registry.py`: **40 passed**.
- Pre-commit (ruff, mypy, bandit, resilience guards) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)