### PR TITLE
Fix Linux release portability: $ORIGIN RPATH on versioned bundled libs

### DIFF
--- a/scripts/stage_release_artifacts.sh
+++ b/scripts/stage_release_artifacts.sh
@@ -956,12 +956,21 @@ elif [ "$OS_TYPE" = "Linux" ]; then
             print_success "$binary_name: set RPATH to \$ORIGIN/../lib"
         done
 
-        for lib in lib/*.so; do
+        # Match versioned sonames too (libnetcdf.so.18, libnetcdff.so.7, the
+        # bundled curl deps, ...). The old `lib/*.so` glob only caught unversioned
+        # names like libsumma.so, leaving every bundled SYSTEM library with an
+        # empty RPATH — so a transitively-needed lib (e.g. libnetcdff -> libnetcdf)
+        # fell back to system paths and failed on a clean machine. They all live
+        # in the same dir, so $ORIGIN is correct for each.
+        for lib in lib/*.so lib/*.so.*; do
             [ -f "$lib" ] || continue
+            [ -L "$lib" ] && continue
+            file "$lib" | grep -q "ELF" || continue
             lib_name="$(basename "$lib")"
 
-            patchelf --set-rpath '$ORIGIN' "$lib" 2>/dev/null || true
-            print_success "$lib_name: set RPATH to \$ORIGIN"
+            patchelf --set-rpath '$ORIGIN' "$lib" 2>/dev/null \
+                && print_success "$lib_name: set RPATH to \$ORIGIN" \
+                || print_warning "$lib_name: patchelf --set-rpath failed"
         done
     else
         print_warning "patchelf not available — skipping Linux RPATH fix"


### PR DESCRIPTION
## Summary

The Linux release tarball bundled all required libraries but they weren't **findable** on a clean machine — the real npm-tarball portability bug.

`stage_release_artifacts.sh`'s RPATH-rewriting glob was `lib/*.so`, which matches unversioned names (`libsumma.so`) but **not** versioned sonames (`libnetcdf.so.18`, `libnetcdff.so.7`, the bundled curl deps). Those bundled system libraries were left with an empty RPATH, so a transitively-needed lib (`libnetcdff` → `libnetcdf`) fell back to system paths and failed with `libnetcdf.so.18: cannot open shared object file` on a machine without the libs installed.

CI's relocatability test never caught this because the build runner has the libs on the system path — it's not a true clean-machine test.

## Fix
- Glob `lib/*.so lib/*.so.*` so every bundled ELF lib gets `$ORIGIN` (they share one dir).
- Report patchelf success/failure honestly instead of `|| true` printing success unconditionally.

## Validation (gold-standard, clean machine)
Ran the actual Linux artifact in a fresh `ubuntu:24.04` amd64 container with **no** `LD_LIBRARY_PATH` and **no** system scientific libraries. Before the fix: `error while loading shared libraries: libnetcdf.so.18`. After: summa/fuse/mizuroute/mesh/hype all load and execute (hitting expected missing-arg/config errors, not loader errors).

This makes the published 0.9.0 npm/GitHub-release Linux binaries actually portable.

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).