### PR TITLE
chore(release): bump version to 0.9.0

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symfluence",
-  "version": "0.8.5",
+  "version": "0.9.0",
   "description": "SYnergistic Modelling Framework for Linking and Unifying Earth-system Nexii for Computational Exploration - Pre-compiled hydrological modeling tools",
   "main": "index.js",
   "bin": {

--- a/src/symfluence/symfluence_version.py
+++ b/src/symfluence/symfluence_version.py
@@ -8,4 +8,4 @@ Update this when cutting a release.
 # Semantic version (PEP 440-friendly)
 from __future__ import annotations
 
-__version__ = "0.8.5"
+__version__ = "0.9.0"

--- a/tools/npm/package.json
+++ b/tools/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symfluence",
-  "version": "0.8.5",
+  "version": "0.9.0",
   "description": "Structure for Unifying Multiple Modeling Alternatives - Pre-compiled hydrological modeling tools",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Bumps the version `0.8.5 → 0.9.0` across the three synchronized manifests
(`src/symfluence/symfluence_version.py` source of truth + `tools/npm/package.json` + `npm/package.json`); `check_version_sync.sh` passes.

Prepares the **0.9.0** tag. Highlights since 0.8.5:
- Windows external-tool binary support (full mingw-w64 toolchain; ngen, rhessys, summa, mizuroute, … build + relocate)
- Linux/npm tarball portability fix ($ORIGIN RPATH on versioned bundled libs)
- Coupled SUMMA + dRoute calibration (land-only routing handoff)
- Registry-contract conformance + config/test hardening

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).