### PR TITLE
fix(config): normalize paths to POSIX in strict-config guard for Windows

### DIFF
--- a/scripts/check_shipped_configs_strict.py
+++ b/scripts/check_shipped_configs_strict.py
@@ -120,7 +120,8 @@ def evaluate() -> Tuple[List[Tuple[str, List[str]]], List[Tuple[str, int]], List
         + glob.glob(str(REPO_ROOT / "examples" / "**" / "*.yaml"), recursive=True)
     )
     for f in shipped:
-        rel = str(Path(f).relative_to(REPO_ROOT))
+        # Use POSIX separators so EXEMPT's forward-slash patterns match on Windows too.
+        rel = Path(f).relative_to(REPO_ROOT).as_posix()
         if _is_exempt(rel):
             try:
                 reported.append((rel, len(_unknown_keys(Path(f)))))


### PR DESCRIPTION
## Problem

The **Cross-Platform Testing** workflow was failing only on the **Windows** unit-test job, on the new strict-config test `test_enforced_configs_have_no_unknown_keys` (introduced in `f3bd3e41`, RTI Q3 / #191). It flagged hundreds of `examples\paper_case_studies\...` configs as having unknown keys. Linux and macOS passed.

## Root cause

A path-separator bug in `scripts/check_shipped_configs_strict.py`. `evaluate()` built the relative path with `str(Path(f).relative_to(REPO_ROOT))`, which on Windows yields **backslash** separators (`examples\paper_case_studies\...`). The `EXEMPT` patterns use **forward slashes** (`examples/paper_case_studies/**`, `src/symfluence/resources/...`), so `_is_exempt()`'s `rel.startswith(...)` / `rel == pattern` checks never matched on Windows. The paper research archive and doc templates were therefore *enforced* instead of *exempted*, failing CI. POSIX runners passed because `/` is already their separator.

## Fix

Normalize to POSIX separators when computing the relative path:

```python
rel = Path(f).relative_to(REPO_ROOT).as_posix()
```

`EXEMPT`'s forward-slash patterns now match on every platform.

## Verification

- `tests/unit/config/test_shipped_configs_strict.py` passes locally
- Guard reports `57 config(s) enforced strict-clean; 1625 exempt`
- `_is_exempt` correctly matches both the `paper_case_studies` archive and the template patterns

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).