### PR TITLE
feat(observations): route StreamflowMetrics through the model-ready store

### DIFF
--- a/src/symfluence/evaluation/utilities/streamflow_metrics.py
+++ b/src/symfluence/evaluation/utilities/streamflow_metrics.py
@@ -67,6 +67,21 @@ class StreamflowMetrics:
             Tuple of (values, datetime_index), or (None, None) on error
         """
         try:
+            # Strategy 0: model-ready observations store (grouped NetCDF).
+            # Mirrors StreamflowEvaluator.get_observed_data_path(), which already
+            # prefers the store — keeps the two streamflow loaders consistent.
+            # Any miss falls through to the legacy preprocessed-CSV path below.
+            store_path = (
+                project_dir / 'data' / 'model_ready' / 'observations'
+                / f'{domain_name}_observations.nc'
+            )
+            if store_path.exists():
+                store_series = self._read_observations_store(store_path, domain_name, discharge_col)
+                if store_series is not None and not store_series.empty:
+                    if resample_freq:
+                        store_series = store_series.resample(resample_freq).mean()
+                    return np.asarray(store_series.values), cast(pd.DatetimeIndex, store_series.index)
+
             obs_file = config.get('OBSERVATIONS_PATH', 'default')
             if obs_file == 'default' or not obs_file:
                 obs_file = resolve_data_subdir(project_dir, 'observations') / 'streamflow' / 'preprocessed' / f"{domain_name}_streamflow_processed.csv"
@@ -102,6 +117,69 @@ class StreamflowMetrics:
         except Exception as e:  # noqa: BLE001 — must-not-raise contract
             logger.error(f"Error loading observations: {e}")
             return None, None
+
+    def _read_observations_store(
+        self,
+        store_path: Path,
+        domain_name: str,
+        discharge_col: str = 'discharge_cms',
+    ) -> Optional[pd.Series]:
+        """Read the streamflow series from the model-ready observations store.
+
+        Opens the ``streamflow`` group of the grouped NetCDF written by
+        ``ObservationsNetCDFBuilder`` and returns a datetime-indexed Series in
+        m3 s-1, or ``None`` when the group/variable is missing or unreadable.
+        Never raises — callers fall back to the legacy CSV on ``None``.
+
+        Args:
+            store_path: Path to ``{domain}_observations.nc``.
+            domain_name: Used to pick the matching gauge when multi-gauge.
+            discharge_col: Preferred data-variable name (fuzzy fallback applied).
+        """
+        try:
+            import xarray as xr
+
+            with xr.open_dataset(store_path, group='streamflow') as ds:
+                if not ds.data_vars:
+                    return None
+
+                # Pick the discharge variable (exact, then fuzzy — mirrors the CSV path).
+                if discharge_col in ds.data_vars:
+                    var = discharge_col
+                else:
+                    cands = [v for v in ds.data_vars
+                             if 'discharge' in str(v).lower() or 'flow' in str(v).lower()]
+                    if not cands:
+                        return None
+                    var = cands[0]
+
+                da = ds[var]
+                if 'time' not in da.dims:
+                    return None
+
+                # Collapse the spatial (gauge) dim to a single series: prefer the
+                # gauge whose id matches the domain, else the first.
+                spatial = [d for d in da.dims if d != 'time']
+                if spatial:
+                    dim = spatial[0]
+                    idx = 0
+                    id_var = next(
+                        (c for c in ('gauge_id', f'{dim}_id', dim) if c in ds.variables),
+                        None,
+                    )
+                    if id_var is not None:
+                        ids = [str(x) for x in np.atleast_1d(ds[id_var].values)]
+                        if domain_name in ids:
+                            idx = ids.index(domain_name)
+                    da = da.isel({dim: idx})
+
+                # xarray decodes time -> datetime64 and masks _FillValue (-9999.0) to NaN.
+                series = da.to_series().dropna()
+                return series if not series.empty else None
+
+        except Exception as e:  # noqa: BLE001 — must-not-raise; CSV fallback follows
+            logger.debug(f"Could not read observations store {store_path}: {e}")
+            return None
 
     def get_catchment_area(
         self,

--- a/tests/unit/evaluation/test_streamflow_metrics_observations.py
+++ b/tests/unit/evaluation/test_streamflow_metrics_observations.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Tests for StreamflowMetrics reading the model-ready observations store.
+
+Validates the additive "strategy-0" added to ``StreamflowMetrics.load_observations``:
+the model-ready store is preferred when present, the legacy preprocessed CSV remains
+the fallback, and a corrupt/absent store never raises. The key guarantee is that the
+store path yields the *same* series as the CSV path, so calibration objectives do not
+silently drift.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+netCDF4 = pytest.importorskip('netCDF4')  # noqa: N816
+pytest.importorskip('xarray')
+
+from symfluence.data.model_ready.observations_builder import ObservationsNetCDFBuilder
+from symfluence.evaluation.utilities import streamflow_metrics as sm_module
+from symfluence.evaluation.utilities.streamflow_metrics import StreamflowMetrics
+
+DOMAIN = 'test'
+
+
+def _csv_path(project_dir: Path) -> Path:
+    return (
+        project_dir / 'observations' / 'streamflow' / 'preprocessed'
+        / f'{DOMAIN}_streamflow_processed.csv'
+    )
+
+
+def _write_streamflow_csv(project_dir: Path, values: np.ndarray) -> Path:
+    path = _csv_path(project_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    dates = pd.date_range('2020-01-01', periods=len(values), freq='D')
+    pd.DataFrame({'datetime': dates, 'discharge_cms': values}).to_csv(path, index=False)
+    return path
+
+
+def _build_store(project_dir: Path) -> Path:
+    result = ObservationsNetCDFBuilder(project_dir=project_dir, domain_name=DOMAIN).build()
+    assert result is not None and result.exists()
+    # Sanity: builder wrote to the path load_observations looks for.
+    assert result == project_dir / 'data' / 'model_ready' / 'observations' / f'{DOMAIN}_observations.nc'
+    return result
+
+
+def test_reads_store_when_present_and_ignores_diverged_csv(tmp_path):
+    """Store is preferred over the legacy CSV when both exist."""
+    original = np.arange(1, 41, dtype=float)
+    _write_streamflow_csv(tmp_path, original)
+    _build_store(tmp_path)
+
+    # Diverge the CSV after the store was built; the store value must win.
+    _write_streamflow_csv(tmp_path, original + 1000.0)
+
+    values, index = StreamflowMetrics().load_observations({}, tmp_path, DOMAIN)
+
+    assert values is not None and index is not None
+    np.testing.assert_allclose(np.sort(values), np.sort(original), rtol=1e-5)
+    assert values.max() < 100  # not the +1000 CSV
+
+
+def test_store_equals_csv_for_same_data(tmp_path):
+    """No objective drift: store result matches the CSV-derived series."""
+    values = np.linspace(2.0, 50.0, 40)
+    _write_streamflow_csv(tmp_path, values)
+
+    # CSV-only result (no store yet)
+    csv_values, csv_index = StreamflowMetrics().load_observations({}, tmp_path, DOMAIN)
+
+    # Build store and read again
+    _build_store(tmp_path)
+    store_values, store_index = StreamflowMetrics().load_observations({}, tmp_path, DOMAIN)
+
+    assert csv_values is not None and store_values is not None
+    np.testing.assert_allclose(
+        np.sort(store_values), np.sort(csv_values), rtol=1e-5
+    )
+    assert len(store_index) == len(csv_index)
+
+
+def test_store_absent_falls_back_to_csv(tmp_path):
+    values = np.arange(1, 31, dtype=float)
+    _write_streamflow_csv(tmp_path, values)
+    # No store built.
+
+    out_values, _ = StreamflowMetrics().load_observations({}, tmp_path, DOMAIN)
+
+    assert out_values is not None
+    np.testing.assert_allclose(np.sort(out_values), np.sort(values), rtol=1e-5)
+
+
+def test_corrupt_store_falls_back_to_csv_without_raising(tmp_path):
+    values = np.arange(1, 31, dtype=float)
+    _write_streamflow_csv(tmp_path, values)
+
+    # An empty NetCDF with no 'streamflow' group — the store read must miss
+    # and fall through to the CSV rather than raising.
+    store = tmp_path / 'data' / 'model_ready' / 'observations' / f'{DOMAIN}_observations.nc'
+    store.parent.mkdir(parents=True, exist_ok=True)
+    netCDF4.Dataset(str(store), 'w', format='NETCDF4').close()
+
+    out_values, _ = StreamflowMetrics().load_observations({}, tmp_path, DOMAIN)
+
+    assert out_values is not None
+    np.testing.assert_allclose(np.sort(out_values), np.sort(values), rtol=1e-5)
+
+
+def test_gapped_data_matches_csv_and_no_sentinel(tmp_path):
+    """Gap days (written as the -9999.0 fill) decode to NaN exactly like the CSV
+    path — the sentinel never leaks, and store/CSV outputs are identical."""
+    values = np.arange(1, 41, dtype=float)
+    values[5] = np.nan
+    values[12] = np.nan
+    _write_streamflow_csv(tmp_path, values)
+
+    # CSV-only baseline (legacy behaviour: NaN at the gap days after resample).
+    csv_values, _ = StreamflowMetrics().load_observations({}, tmp_path, DOMAIN)
+
+    _build_store(tmp_path)
+    store_values, _ = StreamflowMetrics().load_observations({}, tmp_path, DOMAIN)
+
+    assert store_values is not None and csv_values is not None
+    # The -9999.0 fill must never surface as a real value.
+    assert not np.any(store_values == -9999.0)
+    # Store reproduces the CSV series exactly, NaN positions included.
+    np.testing.assert_allclose(store_values, csv_values, rtol=1e-5, equal_nan=True)
+
+
+def test_module_and_instance_loaders_agree(tmp_path):
+    values = np.linspace(1.0, 20.0, 25)
+    _write_streamflow_csv(tmp_path, values)
+    _build_store(tmp_path)
+
+    inst_values, _ = StreamflowMetrics().load_observations({}, tmp_path, DOMAIN)
+    mod_values, _ = sm_module.load_observations({}, tmp_path, DOMAIN)
+
+    assert inst_values is not None and mod_values is not None
+    np.testing.assert_array_equal(inst_values, mod_values)

--- a/tools/quality/broad_exception_allowlist.txt
+++ b/tools/quality/broad_exception_allowlist.txt
@@ -452,6 +452,7 @@ src/symfluence/evaluation/sensitivity_analysis.py:SensitivityAnalyzer.perform_se
 src/symfluence/evaluation/structure_ensemble.py:BaseStructureEnsembleAnalyzer.analyze_results:except Exception as e:  # noqa: BLE001 — must-not-raise contract
 src/symfluence/evaluation/structure_ensemble.py:BaseStructureEnsembleAnalyzer.run_analysis:except Exception as e:  # noqa: BLE001 — must-not-raise contract
 src/symfluence/evaluation/structure_ensemble.py:BaseStructureEnsembleAnalyzer.visualize_results:except Exception as e:  # noqa: BLE001 — must-not-raise contract
+src/symfluence/evaluation/utilities/streamflow_metrics.py:StreamflowMetrics._read_observations_store:except Exception as e:  # noqa: BLE001 — must-not-raise; CSV fallback follows
 src/symfluence/evaluation/utilities/streamflow_metrics.py:StreamflowMetrics.calculate_metrics:except Exception as e:  # noqa: BLE001 — must-not-raise contract
 src/symfluence/evaluation/utilities/streamflow_metrics.py:StreamflowMetrics.calculate_metrics:except Exception as e:  # noqa: BLE001 — must-not-raise contract
 src/symfluence/evaluation/utilities/streamflow_metrics.py:StreamflowMetrics.evaluate_streamflow:except Exception as e:  # noqa: BLE001 — must-not-raise contract


### PR DESCRIPTION
## Summary
Routes `StreamflowMetrics.load_observations()` through the model-ready observations store before the legacy preprocessed CSV, so the ~16 worker-based model calibrations stop bypassing the datastore. This aligns them with `StreamflowEvaluator`, which already prefers the store.

## Detail
- New `_read_observations_store` helper reads the grouped NetCDF (`/streamflow` group, `discharge_cms`), masking the `-9999.0` fill to NaN.
- The CSV path is unchanged and remains the fallback; the store read never raises (falls through on any miss).
- Store and CSV yield identical series → **no calibration objective drift** (asserted by test).

## Tests
`tests/unit/evaluation/test_streamflow_metrics_observations.py` — store-vs-CSV equality, absent/corrupt-store fallback, `-9999` handling, module/instance parity. Full `tests/unit/` suite green (8305 passed) when integrated with the sibling datastore PRs.

Part of the "all models through the model-ready datastore" series (observations gap).

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).
