### PR TITLE
feat(attributes): model-ready attributes reader + SUMMA pilot + CLM fix

### DIFF
--- a/src/symfluence/data/model_ready/__init__.py
+++ b/src/symfluence/data/model_ready/__init__.py
@@ -9,6 +9,7 @@ Materializes forcings, observations, and attributes into a structured
 """
 from __future__ import annotations
 
+from .attributes_reader import AttributesReader, open_canonical_attributes
 from .cf_conventions import CF_STANDARD_NAMES, build_global_attrs
 from .path_resolver import resolve_model_ready_path
 from .source_metadata import SourceMetadata
@@ -20,4 +21,6 @@ __all__ = [
     'build_global_attrs',
     'resolve_model_ready_path',
     'ModelReadyStoreBuilder',
+    'AttributesReader',
+    'open_canonical_attributes',
 ]

--- a/src/symfluence/data/model_ready/attributes_builder.py
+++ b/src/symfluence/data/model_ready/attributes_builder.py
@@ -255,6 +255,7 @@ class AttributesNetCDFBuilder:
         grp = root.createGroup('terrain')
         n = len(gdf)
         grp.createDimension('hru', n)
+        self._write_hru_id(grp, gdf)
 
         if 'elev_mean' in gdf.columns:
             v = grp.createVariable('elev_mean', 'f8', ('hru',))
@@ -277,6 +278,7 @@ class AttributesNetCDFBuilder:
         grp = root.createGroup('soil')
         n = len(gdf)
         grp.createDimension('hru', n)
+        self._write_hru_id(grp, gdf)
 
         # Look for USGS soil fraction columns
         soil_cols = [c for c in gdf.columns if c.startswith('USGS_')]
@@ -310,6 +312,7 @@ class AttributesNetCDFBuilder:
         grp = root.createGroup('landcover')
         n = len(gdf)
         grp.createDimension('hru', n)
+        self._write_hru_id(grp, gdf)
 
         land_cols = [c for c in gdf.columns if c.startswith('IGBP_')]
         n_class = len(land_cols)
@@ -477,3 +480,19 @@ class AttributesNetCDFBuilder:
         except Exception as e:  # noqa: BLE001 — preprocessing resilience
             logger.debug("Could not read %s: %s", path, e, exc_info=True)
             return None
+
+    def _write_hru_id(self, grp, gdf) -> None:
+        """Write an ``hru_id`` coordinate to a per-HRU group when available.
+
+        Per-HRU groups (terrain, soil, landcover) are built from independent
+        intersection shapefiles, so consumers must join on an explicit id
+        rather than row position.  This stamps the catchment HRU id (when the
+        column is present) so :class:`AttributesReader.per_hru_values` can
+        return an order-independent ``{hru_id: value}`` mapping.
+        """
+        id_col = self._cfg('CATCHMENT_SHP_HRUID', 'HRU_ID')
+        if id_col not in getattr(gdf, 'columns', []):
+            return
+        id_v = grp.createVariable('hru_id', str, ('hru',))
+        for i, sid in enumerate(gdf[id_col].astype(str).tolist()):
+            id_v[i] = sid

--- a/src/symfluence/data/model_ready/attributes_reader.py
+++ b/src/symfluence/data/model_ready/attributes_reader.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""
+Reader for the model-ready attributes store.
+
+Provides ``open_canonical_attributes`` — the single entry point model
+preprocessors call to read per-HRU catchment attributes (terrain, soil,
+landcover, climate, ...) from the grouped NetCDF written by
+``AttributesNetCDFBuilder``.  Returns ``None`` when the store is absent so
+callers transparently fall back to reading the source shapefiles, mirroring
+the "open returns None ⇒ use legacy" contract used by ``forcing_reader`` and
+``path_resolver``.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence
+
+from .path_resolver import resolve_model_ready_path
+
+if TYPE_CHECKING:
+    import pandas as pd
+    import xarray as xr
+
+logger = logging.getLogger(__name__)
+
+
+def open_canonical_attributes(
+    project_dir: Path,
+    domain_name: str,
+) -> Optional["AttributesReader"]:
+    """Open the model-ready attributes store for a domain.
+
+    Args:
+        project_dir: Root of the SYMFLUENCE domain directory.
+        domain_name: Name of the hydrological domain.
+
+    Returns:
+        An :class:`AttributesReader`, or ``None`` if no attributes store
+        exists (so callers keep their legacy shapefile path).
+    """
+    attrs_dir = resolve_model_ready_path(project_dir, 'attributes')
+    if not attrs_dir.exists():
+        return None
+
+    candidate = attrs_dir / f'{domain_name}_attributes.nc'
+    if not candidate.exists():
+        matches = sorted(attrs_dir.glob('*_attributes.nc'))
+        if not matches:
+            return None
+        candidate = matches[0]
+
+    try:
+        return AttributesReader(candidate)
+    except Exception as e:  # noqa: BLE001 — absent/corrupt store ⇒ legacy fallback
+        logger.debug("Could not open attributes store %s: %s", candidate, e)
+        return None
+
+
+class AttributesReader:
+    """Thin reader over the grouped attributes NetCDF.
+
+    The store keeps each attribute family in its own group (``terrain``,
+    ``soil``, ``landcover``, ``climate``, ``hydrogeology``, ``hru_identity``,
+    ``topology``, plus ``*_extended`` CSV groups).  Per-HRU groups share the
+    ``hru`` dimension and carry an ``hru_id`` coordinate for safe joins.
+    """
+
+    def __init__(self, store_path: Path) -> None:
+        """Open the store and cache its group list.
+
+        Args:
+            store_path: Path to ``{domain}_attributes.nc``.
+        """
+        import netCDF4  # noqa: N813
+
+        self.store_path = store_path
+        with netCDF4.Dataset(str(store_path), 'r') as ds:
+            self._groups: List[str] = list(ds.groups.keys())
+
+    @property
+    def groups(self) -> List[str]:
+        """List of groups present in the store."""
+        return list(self._groups)
+
+    def has_group(self, group: str) -> bool:
+        """Return True if *group* exists in the store."""
+        return group in self._groups
+
+    def group(self, name: str) -> "xr.Dataset":
+        """Open a single group as an xarray Dataset (caller closes it)."""
+        import xarray as xr
+
+        return xr.open_dataset(self.store_path, group=name)
+
+    def has_variable(self, group: str, var: str) -> bool:
+        """Return True if *var* exists in *group*."""
+        if not self.has_group(group):
+            return False
+        with self.group(group) as ds:
+            return var in ds.variables
+
+    def to_dataframe(self, group: str, index: Optional[str] = None) -> "pd.DataFrame":
+        """Return a group as a DataFrame, optionally indexed by *index*."""
+        with self.group(group) as ds:
+            df = ds.to_dataframe().reset_index()
+        if index is not None and index in df.columns:
+            df = df.set_index(index)
+        return df
+
+    def variable(
+        self,
+        group: str,
+        var: str,
+        *,
+        reduce: Optional[str] = None,
+    ):
+        """Read a single variable from a group.
+
+        Args:
+            group: Group name.
+            var: Variable name.
+            reduce: Optional reduction — ``'mean'``, ``'min'``, ``'max'`` —
+                applied with NaN-skipping to return a scalar.
+
+        Returns:
+            The variable's numpy array, a reduced float, or ``None`` if the
+            group/variable is missing.
+        """
+        import numpy as np
+
+        if not self.has_group(group):
+            return None
+        with self.group(group) as ds:
+            if var not in ds.variables:
+                return None
+            values = ds[var].values
+        if reduce is None:
+            return values
+        reducers = {'mean': np.nanmean, 'min': np.nanmin, 'max': np.nanmax}
+        if reduce not in reducers:
+            raise ValueError(f"Unknown reduce '{reduce}'; expected one of {list(reducers)}")
+        return float(reducers[reduce](values))
+
+    def find_variable(
+        self,
+        group: str,
+        keywords: Sequence[str],
+        *,
+        reduce: Optional[str] = None,
+    ):
+        """Read the first variable in *group* whose name contains any keyword.
+
+        Case-insensitive substring match, useful when the exact column name
+        varies by source (e.g. ``sand_0-5cm_mean`` vs ``sand_frac``).
+        """
+        if not self.has_group(group):
+            return None
+        with self.group(group) as ds:
+            for name in ds.variables:
+                lname = str(name).lower()
+                if any(kw.lower() in lname for kw in keywords):
+                    return self.variable(group, str(name), reduce=reduce)
+        return None
+
+    def hru_ids(self, group: str = 'hru_identity') -> Optional[List[str]]:
+        """Return the ordered ``hru_id`` list from a group, or None."""
+        ids = self._read_ids(group, 'hru_id')
+        return ids
+
+    def per_hru_values(self, group: str, var: str) -> Optional[Dict[str, float]]:
+        """Return a ``{hru_id: value}`` mapping for a per-HRU variable.
+
+        Joins *var* against the group's own ``hru_id`` coordinate, so the
+        mapping is order-independent and safe across groups.  Returns ``None``
+        if the group, the variable, or the ``hru_id`` coordinate is missing.
+        """
+        ids = self._read_ids(group, 'hru_id')
+        if ids is None:
+            return None
+        values = self.variable(group, var)
+        if values is None or len(values) != len(ids):
+            return None
+        return {hid: float(v) for hid, v in zip(ids, values)}
+
+    def _read_ids(self, group: str, id_var: str) -> Optional[List[str]]:
+        """Read a string id coordinate from a group as a list of str."""
+        import numpy as np
+
+        if not self.has_group(group):
+            return None
+        with self.group(group) as ds:
+            if id_var not in ds.variables:
+                return None
+            return [str(x) for x in np.atleast_1d(ds[id_var].values)]

--- a/src/symfluence/models/clm/surface_generator.py
+++ b/src/symfluence/models/clm/surface_generator.py
@@ -137,23 +137,25 @@ class CLMSurfaceGenerator:
         if pct_sand is not None and pct_clay is not None:
             return float(pct_sand), float(pct_clay)
 
-        # Try model-ready attributes NetCDF
+        # Try the model-ready attributes store. SoilGrids sand/clay percentages
+        # live in the `soil_extended` group (column names vary by source, e.g.
+        # `sand_0-5cm_mean`); the core `soil` group only carries class fractions.
+        # Search both groups; keep the defaults if neither yields a value.
         try:
-            import xarray as xr
-            attrs_dir = self.pp.project_dir / 'data' / 'model_ready' / 'attributes'
-            attrs_files = list(attrs_dir.glob('*_attributes.nc')) if attrs_dir.exists() else []
-            if attrs_files:
-                ds = xr.open_dataset(attrs_files[0])
-                for sand_key in ['sand_frac', 'PCT_SAND', 'sand_0-5cm_mean']:
-                    if sand_key in ds:
-                        default_sand = float(ds[sand_key].values.mean())
+            from symfluence.data.model_ready import open_canonical_attributes
+
+            reader = open_canonical_attributes(self.pp.project_dir, self.pp.domain_name)
+            if reader is not None:
+                for group in ('soil_extended', 'soil'):
+                    sand = reader.find_variable(group, ['sand'], reduce='mean')
+                    clay = reader.find_variable(group, ['clay'], reduce='mean')
+                    if sand is not None and clay is not None:
+                        default_sand, default_clay = float(sand), float(clay)
+                        logger.info(
+                            "Loaded soil fractions from attributes store "
+                            f"(/{group}/): sand={default_sand:.1f}%, clay={default_clay:.1f}%"
+                        )
                         break
-                for clay_key in ['clay_frac', 'PCT_CLAY', 'clay_0-5cm_mean']:
-                    if clay_key in ds:
-                        default_clay = float(ds[clay_key].values.mean())
-                        break
-                ds.close()
-                logger.info(f"Loaded soil fractions from attributes: sand={default_sand:.1f}%, clay={default_clay:.1f}%")
         except Exception as e:  # noqa: BLE001 — model execution resilience
             logger.debug(f"Could not load soil attributes: {e}", exc_info=True)
 

--- a/src/symfluence/models/summa/attributes_manager.py
+++ b/src/symfluence/models/summa/attributes_manager.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 # Third-party imports
 import geopandas as gpd
@@ -768,33 +768,76 @@ class SummaAttributesManager(ConfigurableMixin):
         intersect_hruId_var = self._get_config_value(lambda: self.config.paths.catchment_hruid)
         elev_column = 'elev_mean'
 
-        shp = gpd.read_file(intersect_path / intersect_name)
-
         connect_hrus = self._get_config_value(
             lambda: self.config.model.summa.connect_hrus, default='no'
         )
         do_downHRUindex = connect_hrus == 'yes'
+
+        # Prefer the model-ready attributes store (terrain/elev_mean keyed by
+        # hru_id); fall back to the DEM intersection shapefile when the store is
+        # absent or a given HRU is missing. The store's elev_mean is copied from
+        # the same shapefile, so per-HRU values are identical — no objective drift.
+        store_elev = self._load_store_elevation()
+        shp = None if store_elev else gpd.read_file(intersect_path / intersect_name)
 
         with nc4.Dataset(attribute_file, "r+") as att:
             gru_data: Dict[int, List[Tuple[Any, float]]] = {}
             for idx in range(len(att['hruId'])):
                 hru_id = att['hruId'][idx]
                 gru_id = att['hru2gruId'][idx]
-                shp_mask = (shp[intersect_hruId_var].astype(int) == hru_id)
 
-                if any(shp_mask):
-                    elevation = shp[elev_column][shp_mask].values[0]
+                elevation = store_elev.get(int(hru_id)) if store_elev else None
+                if elevation is None:
+                    if shp is None:
+                        shp = gpd.read_file(intersect_path / intersect_name)
+                    shp_mask = (shp[intersect_hruId_var].astype(int) == hru_id)
+                    if any(shp_mask):
+                        elevation = float(shp[elev_column][shp_mask].values[0])
+
+                if elevation is not None:
                     att['elevation'][idx] = elevation
-
                     if do_downHRUindex:
-                        if gru_id not in gru_data:
-                            gru_data[gru_id] = []
-                        gru_data[gru_id].append((hru_id, elevation))
+                        gru_data.setdefault(gru_id, []).append((hru_id, elevation))
                 else:
                     self.logger.warning(f"No elevation data found for HRU {hru_id}")
 
             if do_downHRUindex:
                 self._set_downHRUindex(att, gru_data)
+
+    def _load_store_elevation(self) -> Optional[Dict[int, float]]:
+        """Load per-HRU mean elevation from the model-ready attributes store.
+
+        Returns an ``{hru_id: elevation}`` mapping keyed by integer HRU id, or
+        ``None`` when the store/terrain group is unavailable so the caller falls
+        back to the DEM intersection shapefile.
+        """
+        try:
+            from symfluence.data.model_ready import open_canonical_attributes
+
+            domain_name = self.project_dir.name.replace('domain_', '', 1)
+            reader = open_canonical_attributes(self.project_dir, domain_name)
+            if reader is None:
+                return None
+            raw = reader.per_hru_values('terrain', 'elev_mean')
+            if not raw:
+                return None
+            mapping: Dict[int, float] = {}
+            for key, value in raw.items():
+                try:
+                    mapping[int(float(key))] = float(value)
+                except (ValueError, TypeError):
+                    continue
+            if mapping:
+                self.logger.info(
+                    f"Using elevation from model-ready attributes store ({len(mapping)} HRUs)"
+                )
+                return mapping
+            return None
+        except Exception as e:  # noqa: BLE001 — model execution resilience
+            self.logger.debug(
+                f"Could not read elevation from attributes store: {e}", exc_info=True
+            )
+            return None
 
     def _set_downHRUindex(self, att, gru_data):
         """Set the downHRUindex based on elevation data or D8 flow direction."""

--- a/tests/unit/data/model_ready/test_attributes_reader.py
+++ b/tests/unit/data/model_ready/test_attributes_reader.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Tests for the model-ready attributes reader and its builder hru_id support.
+
+Covers ``open_canonical_attributes`` / ``AttributesReader`` plus the builder
+change that stamps an ``hru_id`` coordinate into the per-HRU groups so they can
+be joined safely (the reason the store was previously write-only).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+netCDF4 = pytest.importorskip('netCDF4')  # noqa: N816
+gpd = pytest.importorskip('geopandas')
+pytest.importorskip('xarray')
+
+from shapely.geometry import box
+
+from symfluence.data.model_ready import open_canonical_attributes
+from symfluence.data.model_ready.attributes_builder import AttributesNetCDFBuilder
+
+DOMAIN = 'test'
+HRU_IDS = ['hru_0', 'hru_1', 'hru_2']
+ELEV = np.array([870.0, 1320.5, 1980.0])
+
+
+def _catchment_shp(tmp_path: Path) -> None:
+    path = tmp_path / 'shapefiles' / 'catchment' / f'{DOMAIN}_HRUs_lumped.shp'
+    path.parent.mkdir(parents=True, exist_ok=True)
+    gpd.GeoDataFrame({
+        'HRU_ID': HRU_IDS,
+        'HRU_area': np.full(3, 2.0e6),
+        'geometry': [box(i, 50, i + 1, 51) for i in range(3)],
+    }, crs='EPSG:4326').to_file(path)
+
+
+def _dem_intersection_shp(tmp_path: Path, *, reversed_order: bool = False) -> None:
+    """DEM intersection carrying HRU_ID + elev_mean. When reversed_order, the
+    rows are in the opposite order to the catchment to prove the join is
+    order-independent rather than positional."""
+    path = (
+        tmp_path / 'shapefiles' / 'catchment_intersection'
+        / 'with_dem' / 'catchment_with_dem.shp'
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    order = slice(None, None, -1) if reversed_order else slice(None)
+    gpd.GeoDataFrame({
+        'HRU_ID': list(HRU_IDS)[order],
+        'elev_mean': ELEV[order],
+        'geometry': [box(i, 50, i + 1, 51) for i in range(3)],
+    }, crs='EPSG:4326').to_file(path)
+
+
+def _soilclass_csv(tmp_path: Path) -> None:
+    path = tmp_path / 'attributes' / 'soilclass' / f'{DOMAIN}_attributes.csv'
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame({
+        'sand_0-5cm_mean': [40.0, 50.0, 60.0],
+        'clay_0-5cm_mean': [15.0, 20.0, 25.0],
+    }).to_csv(path, index=False)
+
+
+def _build(tmp_path: Path) -> Path:
+    result = AttributesNetCDFBuilder(project_dir=tmp_path, domain_name=DOMAIN).build()
+    assert result is not None and result.exists()
+    return result
+
+
+def test_open_returns_none_when_absent(tmp_path):
+    assert open_canonical_attributes(tmp_path, DOMAIN) is None
+
+
+def test_builder_stamps_hru_id_into_terrain(tmp_path):
+    _catchment_shp(tmp_path)
+    _dem_intersection_shp(tmp_path)
+    result = _build(tmp_path)
+
+    ds = netCDF4.Dataset(str(result), 'r')
+    try:
+        terrain = ds.groups['terrain']
+        assert 'hru_id' in terrain.variables
+        assert [str(x) for x in terrain.variables['hru_id'][:]] == HRU_IDS
+    finally:
+        ds.close()
+
+
+def test_reader_groups_and_has_group(tmp_path):
+    _catchment_shp(tmp_path)
+    _dem_intersection_shp(tmp_path)
+    _build(tmp_path)
+
+    reader = open_canonical_attributes(tmp_path, DOMAIN)
+    assert reader is not None
+    assert 'terrain' in reader.groups
+    assert reader.has_group('terrain')
+    assert not reader.has_group('nonexistent')
+    assert reader.has_variable('terrain', 'elev_mean')
+
+
+def test_per_hru_values_is_order_independent(tmp_path):
+    """The join keys on hru_id, so reversed intersection rows still map right."""
+    _catchment_shp(tmp_path)
+    _dem_intersection_shp(tmp_path, reversed_order=True)
+    _build(tmp_path)
+
+    reader = open_canonical_attributes(tmp_path, DOMAIN)
+    mapping = reader.per_hru_values('terrain', 'elev_mean')
+
+    assert mapping is not None
+    assert mapping['hru_0'] == pytest.approx(870.0)
+    assert mapping['hru_1'] == pytest.approx(1320.5)
+    assert mapping['hru_2'] == pytest.approx(1980.0)
+
+
+def test_variable_reduce_mean(tmp_path):
+    _catchment_shp(tmp_path)
+    _dem_intersection_shp(tmp_path)
+    _build(tmp_path)
+
+    reader = open_canonical_attributes(tmp_path, DOMAIN)
+    mean_elev = reader.variable('terrain', 'elev_mean', reduce='mean')
+    assert mean_elev == pytest.approx(float(ELEV.mean()))
+
+
+def test_find_variable_for_soil_sand_clay(tmp_path):
+    """CLM's path: locate sand/clay in soil_extended by keyword, mean-reduced."""
+    _catchment_shp(tmp_path)
+    _soilclass_csv(tmp_path)
+    _build(tmp_path)
+
+    reader = open_canonical_attributes(tmp_path, DOMAIN)
+    assert reader.has_group('soil_extended')
+    sand = reader.find_variable('soil_extended', ['sand'], reduce='mean')
+    clay = reader.find_variable('soil_extended', ['clay'], reduce='mean')
+    assert sand == pytest.approx(50.0)
+    assert clay == pytest.approx(20.0)
+
+
+def test_missing_group_and_variable_return_none(tmp_path):
+    _catchment_shp(tmp_path)
+    _dem_intersection_shp(tmp_path)
+    _build(tmp_path)
+
+    reader = open_canonical_attributes(tmp_path, DOMAIN)
+    assert reader.variable('nonexistent', 'x') is None
+    assert reader.variable('terrain', 'nonexistent') is None
+    assert reader.per_hru_values('nonexistent', 'x') is None

--- a/tools/quality/broad_exception_allowlist.txt
+++ b/tools/quality/broad_exception_allowlist.txt
@@ -235,6 +235,7 @@ src/symfluence/data/model_ready/attributes_builder.py:AttributesNetCDFBuilder._b
 src/symfluence/data/model_ready/attributes_builder.py:AttributesNetCDFBuilder._build_hru_identity_group:except Exception:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/model_ready/attributes_builder.py:AttributesNetCDFBuilder._build_hydrogeology_group:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/model_ready/attributes_builder.py:AttributesNetCDFBuilder._read_shapefile:except Exception as e:  # noqa: BLE001 — preprocessing resilience
+src/symfluence/data/model_ready/attributes_reader.py:open_canonical_attributes:except Exception as e:  # noqa: BLE001 — absent/corrupt store ⇒ legacy fallback
 src/symfluence/data/model_ready/forcings_builder.py:ForcingsStoreBuilder._enrich_metadata:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/model_ready/forcings_builder.py:ForcingsStoreBuilder._forcing_timestep_seconds:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/model_ready/observations_builder.py:ObservationsNetCDFBuilder._read_timeseries_csv:except Exception as e:  # noqa: BLE001 — preprocessing resilience
@@ -1071,6 +1072,7 @@ src/symfluence/models/rhessys/worldfile_generator.py:RHESSysWorldfileGenerator.g
 src/symfluence/models/state/manager.py:StateManager.export_to_fews:except Exception as e:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/summa/attributes_manager.py:SummaAttributesManager._calculate_aspect_from_dem:except Exception as e:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/summa/attributes_manager.py:SummaAttributesManager._calculate_tan_slope_from_dem:except Exception as e:  # noqa: BLE001 — model execution resilience
+src/symfluence/models/summa/attributes_manager.py:SummaAttributesManager._load_store_elevation:except Exception as e:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/summa/attributes_manager.py:SummaAttributesManager.insert_aspect:except Exception as e:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/summa/attributes_manager.py:SummaAttributesManager.insert_land_class:except Exception as e:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/summa/attributes_manager.py:SummaAttributesManager.insert_soil_class:except Exception as e:  # noqa: BLE001 — model execution resilience


### PR DESCRIPTION
## Summary
Makes the model-ready **attributes** store consumable (it was effectively write-only) and wires SUMMA as the pilot consumer.

## Detail
- New `open_canonical_attributes` / `AttributesReader` (`data/model_ready/attributes_reader.py`) — single entry point, `None` when absent so callers fall back to shapefiles.
- **Builder fix:** stamp an `hru_id` coordinate into the per-HRU groups (terrain/soil/landcover). These groups are built from independent intersection shapefiles, so consumers must join on `hru_id` rather than row position — this was the missing piece that left the store write-only.
- **SUMMA pilot:** `insert_elevation` reads `terrain/elev_mean` keyed by `hru_id`, with a guarded DEM-shapefile fallback. Store values are copied from that same shapefile → identical results, no drift.
- **CLM fix:** the soil-fraction read probed the file root for `sand_frac`, which never matched (soil lives in a group; the core `soil` group carries class fractions, not sand/clay %). It now searches the `soil_extended` group via the reader, keeping the default fallback.

## Tests
`tests/unit/data/model_ready/test_attributes_reader.py` — reader API, builder `hru_id`, an order-independent join test, and the CLM soil-keyword search. Full `tests/unit/` suite green (8305 passed) when integrated.

Part of the "all models through the model-ready datastore" series (attributes gap).

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).
