### PR TITLE
feat(forcing): route bypass models through the model-ready store

### DIFF
--- a/src/symfluence/core/mixins/project.py
+++ b/src/symfluence/core/mixins/project.py
@@ -28,6 +28,22 @@ def resolve_data_subdir(project_dir: Path, subdir: str) -> Path:
     return new_path
 
 
+def resolve_forcing_basin_path(project_dir: Path) -> Path:
+    """Resolve the basin-averaged forcing directory, store-first.
+
+    Prefers the model-ready forcings store (``data/model_ready/forcings``) when
+    it exists and holds NetCDF files, otherwise falls back to the legacy
+    ``{data/}forcing/basin_averaged_data`` location. Mirrors the logic
+    ``BaseModelPreProcessor`` uses to set ``self.forcing_basin_path`` so that
+    preprocessors which do not call ``super().__init__`` (and therefore lack
+    that attribute) resolve forcing identically.
+    """
+    store = project_dir / 'data' / 'model_ready' / 'forcings'
+    if store.exists() and any(store.glob('*.nc')):
+        return store
+    return resolve_data_subdir(project_dir, 'forcing') / 'basin_averaged_data'
+
+
 class ProjectContextMixin(ConfigMixin):
     """
     Mixin providing standard project context attributes.

--- a/src/symfluence/models/clm/preprocessor.py
+++ b/src/symfluence/models/clm/preprocessor.py
@@ -133,7 +133,8 @@ class CLMPreProcessor(BaseModelPreProcessor):  # type: ignore[misc]
         from .forcing_processor import CLMForcingProcessor
 
         lat, lon, _ = self.domain_generator.get_catchment_centroid()
-        forcing_data_dir = self.project_forcing_dir / 'basin_averaged_data'
+        # Store-first (model_ready/forcings), else legacy basin_averaged_data.
+        forcing_data_dir = self.forcing_basin_path
         if not forcing_data_dir.exists():
             forcing_data_dir = self.project_forcing_dir
 

--- a/src/symfluence/models/clmparflow/preprocessor.py
+++ b/src/symfluence/models/clmparflow/preprocessor.py
@@ -31,7 +31,7 @@ from typing import Optional
 
 import numpy as np
 
-from symfluence.core.mixins.project import resolve_data_subdir
+from symfluence.core.mixins.project import resolve_data_subdir, resolve_forcing_basin_path
 from symfluence.core.registries import R
 from symfluence.models.base.base_preprocessor import BaseModelPreProcessor
 
@@ -89,7 +89,7 @@ class CLMParFlowPreProcessor(BaseModelPreProcessor):
         return default
 
     def _get_forcing_dir(self) -> Optional[Path]:
-        basin_avg = resolve_data_subdir(self.project_dir, 'forcing') / 'basin_averaged_data'
+        basin_avg = resolve_forcing_basin_path(self.project_dir)
         if basin_avg.exists():
             nc_files = list(basin_avg.glob('*_remapped*.nc'))
             if nc_files:

--- a/src/symfluence/models/cwatm/preprocessor.py
+++ b/src/symfluence/models/cwatm/preprocessor.py
@@ -252,15 +252,9 @@ class CWatMPreProcessor(BaseModelPreProcessor):  # type: ignore[misc]
         )
         if forcing_path and forcing_path != 'default':
             return Path(forcing_path)
-        domain_name = self._get_config_value(
-            lambda: self.config.domain.name,
-            default='Bow_at_Banff', dict_key='DOMAIN_NAME',
-        )
-        data_dir = self._get_config_value(
-            lambda: self.config.system.data_dir,
-            default='.', dict_key='SYMFLUENCE_DATA_DIR',
-        )
-        return Path(data_dir) / f'domain_{domain_name}' / 'forcing' / 'basin_averaged_data'
+        # Store-first basin-averaged forcing (model_ready/forcings when present,
+        # else legacy forcing/basin_averaged_data) — resolved by the base class.
+        return self.forcing_basin_path
 
     def _generate_settings_ini(self) -> None:
         """Generate the CWatM settings.ini file.

--- a/src/symfluence/models/ignacio/preprocessor.py
+++ b/src/symfluence/models/ignacio/preprocessor.py
@@ -260,8 +260,9 @@ class IGNACIOPreProcessor(BaseModelPreProcessor):
             # Search all forcing directories, filtering by dataset name
             # (e.g. CARRA, ERA5) when multiple datasets coexist.
             forcing_dataset = self.config_dict.get('FORCING_DATASET', 'ERA5')
+            # Store-first basin-averaged forcing, then legacy merged/raw dirs.
             forcing_dirs = [
-                self.project_forcing_dir / 'basin_averaged_data',
+                self.forcing_basin_path,
                 self.project_forcing_dir / 'merged_path',
                 self.project_forcing_dir / 'raw_data',
             ]

--- a/src/symfluence/models/lisflood/preprocessor.py
+++ b/src/symfluence/models/lisflood/preprocessor.py
@@ -489,13 +489,9 @@ class LisfloodPreProcessor(BaseModelPreProcessor):  # type: ignore[misc]
         )
         if forcing_path and forcing_path != "default":
             return Path(forcing_path)
-        domain_name = self._get_config_value(
-            lambda: self.config.domain.name, default="Bow_at_Banff", dict_key="DOMAIN_NAME"
-        )
-        data_dir = self._get_config_value(
-            lambda: self.config.system.data_dir, default=".", dict_key="SYMFLUENCE_DATA_DIR"
-        )
-        return Path(data_dir) / f"domain_{domain_name}" / "forcing" / "basin_averaged_data"
+        # Store-first basin-averaged forcing (model_ready/forcings when present,
+        # else legacy forcing/basin_averaged_data) — resolved by the base class.
+        return self.forcing_basin_path
 
     def _generate_settings_xml(self) -> None:
         """Generate a complete LISFLOOD settings XML.

--- a/src/symfluence/models/lstm/preprocessor.py
+++ b/src/symfluence/models/lstm/preprocessor.py
@@ -132,8 +132,8 @@ class LSTMPreProcessor(BaseModelPreProcessor):
         """
         self.logger.info("Loading data for LSTM model")
 
-        # Load forcing data
-        forcing_path = self.project_forcing_dir / 'basin_averaged_data'
+        # Load forcing data — store-first (model_ready/forcings), else legacy.
+        forcing_path = self.forcing_basin_path
         self.logger.info(f"Looking for forcing files in: {forcing_path}")
 
         # Check if directory exists

--- a/src/symfluence/models/parflow/preprocessor.py
+++ b/src/symfluence/models/parflow/preprocessor.py
@@ -25,7 +25,7 @@ from typing import Optional
 
 import numpy as np
 
-from symfluence.core.mixins.project import resolve_data_subdir
+from symfluence.core.mixins.project import resolve_forcing_basin_path
 from symfluence.core.registries import R
 from symfluence.models.base.base_preprocessor import BaseModelPreProcessor
 
@@ -80,7 +80,7 @@ class ParFlowPreProcessor(BaseModelPreProcessor):
         return default
 
     def _get_forcing_dir(self) -> Optional[Path]:
-        basin_avg = resolve_data_subdir(self.project_dir, 'forcing') / 'basin_averaged_data'
+        basin_avg = resolve_forcing_basin_path(self.project_dir)
         if basin_avg.exists():
             nc_files = list(basin_avg.glob('*_remapped*.nc'))
             if nc_files:

--- a/src/symfluence/models/pcrglobwb/preprocessor.py
+++ b/src/symfluence/models/pcrglobwb/preprocessor.py
@@ -555,15 +555,9 @@ class PCRGLOBWBPreProcessor(BaseModelPreProcessor):  # type: ignore[misc]
         )
         if forcing_path and forcing_path != 'default':
             return Path(forcing_path)
-        domain_name = self._get_config_value(
-            lambda: self.config.domain.name,
-            default='Bow_at_Banff', dict_key='DOMAIN_NAME',
-        )
-        data_dir = self._get_config_value(
-            lambda: self.config.system.data_dir,
-            default='.', dict_key='SYMFLUENCE_DATA_DIR',
-        )
-        return Path(data_dir) / f'domain_{domain_name}' / 'forcing' / 'basin_averaged_data'
+        # Store-first basin-averaged forcing (model_ready/forcings when present,
+        # else legacy forcing/basin_averaged_data) — resolved by the base class.
+        return self.forcing_basin_path
 
     def _write_nc(self, path: Path, ds: xr.Dataset) -> None:
         """Write a NetCDF without _FillValue on any variable.

--- a/src/symfluence/models/pihm/preprocessor.py
+++ b/src/symfluence/models/pihm/preprocessor.py
@@ -30,7 +30,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-from symfluence.core.mixins.project import resolve_data_subdir
+from symfluence.core.mixins.project import resolve_forcing_basin_path
 from symfluence.core.registries import R
 from symfluence.models.base.base_preprocessor import BaseModelPreProcessor
 
@@ -133,7 +133,7 @@ class PIHMPreProcessor(BaseModelPreProcessor):
 
     def _find_forcing_files(self, start_dt, end_dt):
         """Find ERA5 basin-averaged forcing NetCDF files covering the time range."""
-        forcing_dir = resolve_data_subdir(self.project_dir, 'forcing') / "basin_averaged_data"
+        forcing_dir = resolve_forcing_basin_path(self.project_dir)
         if not forcing_dir.exists():
             self.logger.warning(
                 f"Forcing directory not found: {forcing_dir}. "

--- a/src/symfluence/models/rhessys/climate_generator.py
+++ b/src/symfluence/models/rhessys/climate_generator.py
@@ -22,7 +22,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-from symfluence.core.mixins.project import resolve_data_subdir
+from symfluence.core.mixins.project import resolve_data_subdir, resolve_forcing_basin_path
 from symfluence.data.utils.variable_utils import VariableHandler
 
 logger = logging.getLogger(__name__)
@@ -53,7 +53,7 @@ class RHESSysClimateGenerator:
 
         # Setup paths — climate files are forcing data
         self.climate_dir = resolve_data_subdir(self.project_dir, 'forcing') / 'RHESSys_input' / 'clim'
-        self.forcing_basin_path = resolve_data_subdir(self.project_dir, 'forcing') / 'basin_averaged_data'
+        self.forcing_basin_path = resolve_forcing_basin_path(self.project_dir)
         self.forcing_raw_path = resolve_data_subdir(self.project_dir, 'forcing') / 'raw_data'
 
         # Get forcing dataset info

--- a/src/symfluence/models/wflow/preprocessor.py
+++ b/src/symfluence/models/wflow/preprocessor.py
@@ -299,13 +299,9 @@ class WflowPreProcessor(BaseModelPreProcessor):  # type: ignore[misc]
         )
         if forcing_path and forcing_path != 'default':
             return Path(forcing_path)
-        domain_name = self._get_config_value(
-            lambda: self.config.domain.name, default='Bow_at_Banff', dict_key='DOMAIN_NAME'
-        )
-        data_dir = self._get_config_value(
-            lambda: self.config.system.data_dir, default='.', dict_key='SYMFLUENCE_DATA_DIR'
-        )
-        return Path(data_dir) / f'domain_{domain_name}' / 'forcing' / 'basin_averaged_data'
+        # Store-first basin-averaged forcing (model_ready/forcings when present,
+        # else legacy forcing/basin_averaged_data) — resolved by the base class.
+        return self.forcing_basin_path
 
     def _generate_toml_config(self) -> None:
         self.logger.info("Generating Wflow TOML configuration...")

--- a/tests/unit/core/test_mixins.py
+++ b/tests/unit/core/test_mixins.py
@@ -18,7 +18,7 @@ import pytest
 from symfluence.core.config.models import SymfluenceConfig
 from symfluence.core.mixins.config import ConfigMixin
 from symfluence.core.mixins.configurable import ConfigurableMixin
-from symfluence.core.mixins.project import resolve_data_subdir
+from symfluence.core.mixins.project import resolve_data_subdir, resolve_forcing_basin_path
 
 
 class _Configurable(ConfigurableMixin):
@@ -88,6 +88,32 @@ def test_resolve_data_subdir_prefers_new_then_legacy(tmp_path):
     # New layout present -> preferred over legacy.
     (project / "data" / "shapefiles").mkdir(parents=True)
     assert resolve_data_subdir(project, "shapefiles") == project / "data" / "shapefiles"
+
+
+def test_resolve_forcing_basin_path_prefers_store_then_legacy(tmp_path):
+    project = tmp_path / "domain_x"
+    # Establish the legacy forcing layout so resolve_data_subdir resolves to it.
+    legacy = project / "forcing" / "basin_averaged_data"
+    legacy.mkdir(parents=True)
+    store = project / "data" / "model_ready" / "forcings"
+
+    # No store -> legacy basin_averaged_data path.
+    assert resolve_forcing_basin_path(project) == legacy
+
+    # Store dir exists but is empty -> still legacy (must hold NetCDF files).
+    store.mkdir(parents=True)
+    assert resolve_forcing_basin_path(project) == legacy
+
+    # Store populated with a NetCDF -> store wins.
+    (store / "forcing_2020.nc").write_bytes(b"")
+    assert resolve_forcing_basin_path(project) == store
+
+
+def test_resolve_forcing_basin_path_respects_data_layout(tmp_path):
+    """When no store, falls back through resolve_data_subdir (data/forcing)."""
+    project = tmp_path / "domain_y"
+    (project / "data" / "forcing").mkdir(parents=True)
+    assert resolve_forcing_basin_path(project) == project / "data" / "forcing" / "basin_averaged_data"
 
 
 # ---- LoggingMixin / TimingMixin -----------------------------------------


### PR DESCRIPTION
## Summary
Eleven model preprocessors hardcoded `forcing/basin_averaged_data`, bypassing the model-ready forcings store that `BaseModelPreProcessor` already resolves. This routes them all through the store-first path. Builds on #197 (canonical forcing contract).

## Detail
- Subclass preprocessors (wflow, pcrglobwb, cwatm, lisflood, lstm, clm, ignacio) now return `self.forcing_basin_path`, preserving any explicit `FORCING_PATH` override.
- Preprocessors that deliberately skip `super().__init__` (parflow, clmparflow, pihm) and the RHESSys climate generator use a new shared helper `resolve_forcing_basin_path(project_dir)`, mirroring the base-class logic (`model_ready/forcings` when populated, else legacy `basin_averaged_data`).
- Behaviour is unchanged when no store exists; the helper also corrects a latent bug where the hardcoded path ignored the `data/forcing` layout.

## Deferred (follow-up)
Adopting #197's `open_canonical_forcing` in-memory reader (canonical names + real timestep, replacing each model's bespoke variable lists / `*3600` heuristics) is left to a **test-first** follow-up: these models currently have no unit tests, so a value-changing migration needs new tests to guard against objective drift.

## Tests
`tests/unit/core/test_mixins.py` — `resolve_forcing_basin_path` store-first / legacy / data-layout resolution. Models/core/data suites (5874) and full `tests/unit/` (8305) green.

Part of the "all models through the model-ready datastore" series (forcing gap).

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).
