### PR TITLE
feat(forcing): adopt canonical reader in LISFLOOD/CWatM/PCR-GLOBWB (test-first)

### DIFF
--- a/src/symfluence/models/cwatm/preprocessor.py
+++ b/src/symfluence/models/cwatm/preprocessor.py
@@ -25,6 +25,10 @@ import pandas as pd
 import xarray as xr
 
 from symfluence.core.registries import R
+from symfluence.data.model_ready.forcing_reader import (
+    forcing_timestep_seconds,
+    open_canonical_forcing,
+)
 from symfluence.models.base.base_preprocessor import BaseModelPreProcessor
 
 
@@ -114,42 +118,28 @@ class CWatMPreProcessor(BaseModelPreProcessor):  # type: ignore[misc]
         if not forcing_files:
             raise FileNotFoundError(f"No forcing files found in {forcing_path}")
 
-        ds_forcing = xr.open_mfdataset(forcing_files, combine='by_coords')
+        # Canonical reader: variables under SYMFLUENCE names with a declared
+        # timestep, so we no longer guess source names, units, or the timestep.
+        ds_forcing = open_canonical_forcing(forcing_files)
         ds_forcing = ds_forcing.sel(time=slice(str(start_date), str(end_date)))
 
         time_vals = pd.DatetimeIndex(ds_forcing.time.values)
-        if len(time_vals) > 1:
-            dt_hours = (time_vals[1] - time_vals[0]).total_seconds() / 3600.0
-        else:
-            dt_hours = 24.0
+        dt_seconds = forcing_timestep_seconds(ds_forcing)
+        dt_hours = dt_seconds / 3600.0
         is_subdaily = dt_hours < 24.0
         if is_subdaily:
             self.logger.info(
                 f"Sub-daily forcing ({dt_hours:.0f}h) — resampling to daily"
             )
 
-        # Extract precipitation
-        precip_raw = self._extract_forcing_var(
-            ds_forcing,
-            ['pptrate', 'precipitation_flux', 'mtpr', 'tp', 'precipitation', 'PREC', 'precip'],
-            props['lat'], props['lon'],
-        )
+        # Precipitation: canonical pptrate is a rate (kg m-2 s-1); convert to
+        # metres per source step (m = mm / 1000).
+        precip_raw = self._extract_forcing_var(ds_forcing, ['pptrate'], props['lat'], props['lon'])
         precip_raw = np.maximum(precip_raw, 0.0)
-        if precip_raw.max() < 0.1:
-            precip_m_per_step = precip_raw * (dt_hours * 3600.0) / 1000.0
-        elif precip_raw.max() < 200:
-            precip_m_per_step = precip_raw / 1000.0
-        else:
-            precip_m_per_step = precip_raw
+        precip_m_per_step = precip_raw * dt_seconds / 1000.0
 
-        # Extract temperature
-        temp_raw = self._extract_forcing_var(
-            ds_forcing,
-            ['airtemp', 't2m', 'temperature', 'TEMP', 'air_temperature', 'tas'],
-            props['lat'], props['lon'],
-        )
-        if temp_raw.mean() > 100:
-            temp_raw = temp_raw - 273.15
+        # Temperature: canonical airtemp is in kelvin.
+        temp_raw = self._extract_forcing_var(ds_forcing, ['airtemp'], props['lat'], props['lon']) - 273.15
 
         ds_forcing.close()
 

--- a/src/symfluence/models/lisflood/preprocessor.py
+++ b/src/symfluence/models/lisflood/preprocessor.py
@@ -15,6 +15,10 @@ import pandas as pd
 import xarray as xr
 
 from symfluence.core.registries import R
+from symfluence.data.model_ready.forcing_reader import (
+    forcing_timestep_seconds,
+    open_canonical_forcing,
+)
 from symfluence.models.base.base_preprocessor import BaseModelPreProcessor
 
 
@@ -381,32 +385,24 @@ class LisfloodPreProcessor(BaseModelPreProcessor):  # type: ignore[misc]
         if not forcing_files:
             raise FileNotFoundError(f"No forcing files found in {forcing_path}")
 
-        ds_forcing = xr.open_mfdataset(forcing_files, combine="by_coords")
+        # Canonical reader: variables under SYMFLUENCE names with a declared
+        # timestep, so we no longer guess source names, units, or the timestep.
+        ds_forcing = open_canonical_forcing(forcing_files)
         ds_forcing = ds_forcing.sel(time=slice(str(start_date), str(end_date)))
 
         dx = 0.01
         lat = np.array([props["lat"] - dx, props["lat"], props["lat"] + dx])
         lon = np.array([props["lon"] - dx, props["lon"], props["lon"] + dx])
 
-        # Precipitation (kg/m²/s → mm/timestep at source resolution)
-        precip = self._extract_forcing_var(
-            ds_forcing,
-            ["precipitation_flux", "pptrate", "mtpr", "tp", "precipitation", "PREC", "precip"],
-            props["lat"],
-            props["lon"],
-        )
+        # Precipitation: canonical pptrate is a rate (kg m-2 s-1 = mm s-1);
+        # scale by the declared timestep to mm per source step.
+        precip = self._extract_forcing_var(ds_forcing, ["pptrate"], props["lat"], props["lon"])
         raw_times = pd.DatetimeIndex(ds_forcing.time.values)
-        source_dt = raw_times.to_series().diff().median().total_seconds()
-        if precip.max() < 0.1:
-            precip = precip * source_dt
-        precip = np.maximum(precip, 0.0)
+        source_dt = forcing_timestep_seconds(ds_forcing)
+        precip = np.maximum(precip * source_dt, 0.0)
 
-        # Temperature (K → degC)
-        temp = self._extract_forcing_var(
-            ds_forcing, ["airtemp", "t2m", "temperature", "TEMP", "air_temperature", "tas"], props["lat"], props["lon"]
-        )
-        if temp.mean() > 100:
-            temp = temp - 273.15
+        # Temperature: canonical airtemp is in kelvin.
+        temp = self._extract_forcing_var(ds_forcing, ["airtemp"], props["lat"], props["lon"]) - 273.15
 
         ds_forcing.close()
 

--- a/src/symfluence/models/pcrglobwb/preprocessor.py
+++ b/src/symfluence/models/pcrglobwb/preprocessor.py
@@ -16,6 +16,10 @@ import pandas as pd
 import xarray as xr
 
 from symfluence.core.registries import R
+from symfluence.data.model_ready.forcing_reader import (
+    forcing_timestep_seconds,
+    open_canonical_forcing,
+)
 from symfluence.models.base.base_preprocessor import BaseModelPreProcessor
 
 _OPENDAP_BASE = (
@@ -401,15 +405,14 @@ class PCRGLOBWBPreProcessor(BaseModelPreProcessor):  # type: ignore[misc]
         if not forcing_files:
             raise FileNotFoundError(f"No forcing files found in {forcing_path}")
 
-        ds_forcing = xr.open_mfdataset(forcing_files, combine='by_coords')
+        # Canonical reader: variables under SYMFLUENCE names with a declared
+        # timestep, so we no longer guess source names, units, or the timestep.
+        ds_forcing = open_canonical_forcing(forcing_files)
         ds_forcing = ds_forcing.sel(time=slice(str(start_date), str(end_date)))
 
-        # Detect timestep
         time_vals = pd.DatetimeIndex(ds_forcing.time.values)
-        if len(time_vals) > 1:
-            dt_hours = (time_vals[1] - time_vals[0]).total_seconds() / 3600.0
-        else:
-            dt_hours = 24.0
+        dt_seconds = forcing_timestep_seconds(ds_forcing)
+        dt_hours = dt_seconds / 3600.0
         is_subdaily = dt_hours < 24.0
         if is_subdaily:
             self.logger.info(
@@ -417,35 +420,14 @@ class PCRGLOBWBPreProcessor(BaseModelPreProcessor):  # type: ignore[misc]
                 f"will resample to daily for PCR-GLOBWB"
             )
 
-        # Extract precipitation
-        precip_raw = self._extract_forcing_var(
-            ds_forcing,
-            ['pptrate', 'precipitation_flux', 'mtpr', 'tp', 'precipitation', 'PREC', 'precip'],
-            props['lat'], props['lon'],
-        )
+        # Precipitation: canonical pptrate is a rate (kg m-2 s-1); convert to
+        # metres per source step (m = mm / 1000).
+        precip_raw = self._extract_forcing_var(ds_forcing, ['pptrate'], props['lat'], props['lon'])
         precip_raw = np.maximum(precip_raw, 0.0)
+        precip_m_per_step = precip_raw * dt_seconds / 1000.0
 
-        # Convert precipitation rate to m/day
-        # kg/m2/s (= mm/s): max typically < 0.1
-        # mm/hr: max typically 1-50
-        # mm/day: max typically 1-200
-        if precip_raw.max() < 0.1:
-            # kg/m2/s — convert rate to m per timestep-hour, then daily sum handles the rest
-            precip_m_per_step = precip_raw * (dt_hours * 3600.0) / 1000.0
-        elif precip_raw.max() < 200:
-            # mm/timestep — convert to m/timestep
-            precip_m_per_step = precip_raw / 1000.0
-        else:
-            precip_m_per_step = precip_raw
-
-        # Extract temperature, ensure Celsius
-        temp_raw = self._extract_forcing_var(
-            ds_forcing,
-            ['airtemp', 't2m', 'temperature', 'TEMP', 'air_temperature', 'tas'],
-            props['lat'], props['lon'],
-        )
-        if temp_raw.mean() > 100:
-            temp_raw = temp_raw - 273.15
+        # Temperature: canonical airtemp is in kelvin.
+        temp_raw = self._extract_forcing_var(ds_forcing, ['airtemp'], props['lat'], props['lon']) - 273.15
 
         ds_forcing.close()
 

--- a/tests/unit/models/cwatm/test_forcing_canonical.py
+++ b/tests/unit/models/cwatm/test_forcing_canonical.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Canonical-forcing-reader behaviour for the CWatM preprocessor.
+
+CWatM's old ingestion guessed precipitation units from value ranges (a 3-way
+branch on ``precip_raw.max()``). With the canonical reader, ``pptrate`` is
+always a rate in kg m-2 s-1, so precipitation is deterministically
+``pptrate * timestep / 1000`` m per step and temperature is ``airtemp - 273.15``.
+"""
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from symfluence.core.config.models import SymfluenceConfig
+from symfluence.models.cwatm.preprocessor import CWatMPreProcessor
+
+_PROPS = {"lat": 51.0, "lon": -115.0, "area_m2": 2.0e9, "elev": 1500.0}
+
+
+@pytest.fixture
+def cwatm_config(tmp_path):
+    return SymfluenceConfig(**{
+        "SYMFLUENCE_DATA_DIR": str(tmp_path / "data"),
+        "SYMFLUENCE_CODE_DIR": str(tmp_path / "code"),
+        "DOMAIN_NAME": "test_domain",
+        "EXPERIMENT_ID": "test_run",
+        "EXPERIMENT_TIME_START": "2005-01-01 00:00",
+        "EXPERIMENT_TIME_END": "2005-03-01 23:00",
+        "DOMAIN_DEFINITION_METHOD": "lumped",
+        "SUB_GRID_DISCRETIZATION": "GRUs",
+        "HYDROLOGICAL_MODEL": "CWATM",
+        "FORCING_DATASET": "ERA5",
+        "FORCING_TIME_STEP_SIZE": 86400,
+    })
+
+
+@pytest.fixture
+def mock_logger():
+    return Mock()
+
+
+def _write_canonical_forcing(forcing_dir, pptrate_value, *, n=10):
+    forcing_dir.mkdir(parents=True, exist_ok=True)
+    times = pd.date_range("2005-01-02", periods=n, freq="D")
+    xr.Dataset(
+        {
+            "pptrate": ("time", np.full(n, pptrate_value, dtype="f8")),  # kg m-2 s-1
+            "airtemp": ("time", np.full(n, 283.15, dtype="f8")),         # K -> 10 degC
+        },
+        coords={"time": times},
+    ).to_netcdf(forcing_dir / "forcing.nc")
+
+
+def _run(pp):
+    pp._create_directory_structure()
+    with patch.object(pp, "_get_catchment_properties", return_value=_PROPS):
+        pp._generate_forcing()
+
+
+def test_precip_in_m_per_day_and_temp_celsius(cwatm_config, mock_logger):
+    pp = CWatMPreProcessor(cwatm_config, mock_logger)
+    pp._create_directory_structure()
+    _write_canonical_forcing(pp.forcing_basin_path, 1e-4)  # daily, 1e-4 kg/m2/s
+
+    with patch.object(pp, "_get_catchment_properties", return_value=_PROPS):
+        pp._generate_forcing()
+
+    precip = xr.open_dataset(pp.forcing_out_dir / "precipitation.nc")
+    tavg = xr.open_dataset(pp.forcing_out_dir / "tavg.nc")
+    try:
+        # 1e-4 kg/m2/s * 86400 s / 1000 = 8.64e-3 m/day
+        assert float(precip["precipitation"].isel(lat=0, lon=0).mean()) == pytest.approx(8.64e-3, rel=1e-3)
+        assert float(tavg["tavg"].isel(lat=0, lon=0).mean()) == pytest.approx(10.0, abs=1e-3)
+    finally:
+        precip.close()
+        tavg.close()
+
+
+def test_high_rate_precip_not_misclassified_as_depth(cwatm_config, mock_logger):
+    """An extreme rate (0.5 kg/m2/s) must be scaled by the timestep. The old
+    3-way value-range guess would have treated it as mm/day (÷1000)."""
+    pp = CWatMPreProcessor(cwatm_config, mock_logger)
+    pp._create_directory_structure()
+    _write_canonical_forcing(pp.forcing_basin_path, 0.5)
+
+    with patch.object(pp, "_get_catchment_properties", return_value=_PROPS):
+        pp._generate_forcing()
+
+    precip = xr.open_dataset(pp.forcing_out_dir / "precipitation.nc")
+    try:
+        # canonical: 0.5 * 86400 / 1000 = 43.2 m/day ; legacy guess -> 5e-4
+        assert float(precip["precipitation"].isel(lat=0, lon=0).mean()) == pytest.approx(43.2, rel=1e-3)
+    finally:
+        precip.close()

--- a/tests/unit/models/lisflood/test_forcing_canonical.py
+++ b/tests/unit/models/lisflood/test_forcing_canonical.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Canonical-forcing-reader behaviour for the LISFLOOD preprocessor.
+
+Verifies that ``_generate_forcing`` reads forcing through the model-ready
+canonical reader (``open_canonical_forcing``): precipitation is taken from the
+canonical ``pptrate`` (kg m-2 s-1) and scaled by the declared timestep to
+mm/step, and temperature from ``airtemp`` (K) converted to degC — without the
+old value-range heuristics (``precip.max() < 0.1`` / ``temp.mean() > 100``).
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from symfluence.models.lisflood.preprocessor import LisfloodPreProcessor
+
+_PROPS = {"lat": 51.0, "lon": -115.0, "area_m2": 2.0e9, "elev": 1500.0}
+
+
+def _write_canonical_forcing(forcing_dir, pptrate_value, *, n=10, timestep_attr=None):
+    """Write a tiny canonical forcing NetCDF into the preprocessor's forcing dir."""
+    forcing_dir.mkdir(parents=True, exist_ok=True)
+    times = pd.date_range("2005-01-02", periods=n, freq="D")
+    ds = xr.Dataset(
+        {
+            "pptrate": ("time", np.full(n, pptrate_value, dtype="f8")),   # kg m-2 s-1
+            "airtemp": ("time", np.full(n, 283.15, dtype="f8")),          # K -> 10 degC
+        },
+        coords={"time": times},
+    )
+    if timestep_attr is not None:
+        ds.attrs["timestep_seconds"] = float(timestep_attr)
+    ds.to_netcdf(forcing_dir / "forcing.nc")
+    return forcing_dir
+
+
+def test_precip_scaled_by_timestep_and_temp_to_celsius(lisflood_config, mock_logger, setup_lisflood_directories):
+    """Realistic canonical forcing → pptrate * dt mm/day, airtemp - 273.15 degC."""
+    pp = LisfloodPreProcessor(lisflood_config, mock_logger)
+    pp._create_directory_structure()
+    _write_canonical_forcing(pp.forcing_basin_path, 1e-4)  # 1e-4 kg/m2/s, daily
+
+    with patch.object(pp, "_get_catchment_properties", return_value=_PROPS):
+        pp._generate_forcing()
+
+    pr = xr.open_dataset(pp.forcing_out_dir / "pr.nc")
+    ta = xr.open_dataset(pp.forcing_out_dir / "ta.nc")
+    try:
+        # daily timestep: 1e-4 kg/m2/s * 86400 s = 8.64 mm/day
+        assert float(pr["pr"].isel(y=0, x=0).mean()) == pytest.approx(8.64, rel=1e-3)
+        assert float(ta["ta"].isel(y=0, x=0).mean()) == pytest.approx(10.0, abs=1e-3)
+    finally:
+        pr.close()
+        ta.close()
+
+
+def test_high_rate_precip_is_not_treated_as_depth(lisflood_config, mock_logger, setup_lisflood_directories):
+    """An (extreme) rate whose magnitude exceeds the old 0.1 guard must still be
+    scaled by the timestep — the canonical contract says pptrate is always a
+    rate. The legacy `precip.max() < 0.1` heuristic would have left it unscaled."""
+    pp = LisfloodPreProcessor(lisflood_config, mock_logger)
+    pp._create_directory_structure()
+    _write_canonical_forcing(pp.forcing_basin_path, 0.5)  # 0.5 kg/m2/s (extreme), daily
+
+    with patch.object(pp, "_get_catchment_properties", return_value=_PROPS):
+        pp._generate_forcing()
+
+    pr = xr.open_dataset(pp.forcing_out_dir / "pr.nc")
+    try:
+        # canonical: 0.5 * 86400 = 43200 ; legacy heuristic would have left 0.5
+        assert float(pr["pr"].isel(y=0, x=0).mean()) == pytest.approx(43200.0, rel=1e-3)
+    finally:
+        pr.close()

--- a/tests/unit/models/pcrglobwb/test_forcing_canonical.py
+++ b/tests/unit/models/pcrglobwb/test_forcing_canonical.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Canonical-forcing-reader behaviour for the PCR-GLOBWB preprocessor.
+
+Like CWatM, PCR-GLOBWB used a 3-way value-range guess for precipitation units.
+With the canonical reader ``pptrate`` is always kg m-2 s-1, so precipitation is
+deterministically ``pptrate * timestep / 1000`` m/day and temperature is
+``airtemp - 273.15`` degC.
+"""
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from symfluence.core.config.models import SymfluenceConfig
+from symfluence.models.pcrglobwb.preprocessor import PCRGLOBWBPreProcessor
+
+_PROPS = {"lat": 51.0, "lon": -115.0, "area_m2": 2.0e9, "elev": 1500.0}
+
+
+@pytest.fixture
+def pcrglobwb_config(tmp_path):
+    return SymfluenceConfig(**{
+        "SYMFLUENCE_DATA_DIR": str(tmp_path / "data"),
+        "SYMFLUENCE_CODE_DIR": str(tmp_path / "code"),
+        "DOMAIN_NAME": "test_domain",
+        "EXPERIMENT_ID": "test_run",
+        "EXPERIMENT_TIME_START": "2005-01-01 00:00",
+        "EXPERIMENT_TIME_END": "2005-03-01 23:00",
+        "DOMAIN_DEFINITION_METHOD": "lumped",
+        "SUB_GRID_DISCRETIZATION": "GRUs",
+        "HYDROLOGICAL_MODEL": "PCRGLOBWB",
+        "FORCING_DATASET": "ERA5",
+        "FORCING_TIME_STEP_SIZE": 86400,
+    })
+
+
+@pytest.fixture
+def mock_logger():
+    return Mock()
+
+
+def _write_canonical_forcing(forcing_dir, pptrate_value, *, n=10):
+    forcing_dir.mkdir(parents=True, exist_ok=True)
+    times = pd.date_range("2005-01-02", periods=n, freq="D")
+    xr.Dataset(
+        {
+            "pptrate": ("time", np.full(n, pptrate_value, dtype="f8")),  # kg m-2 s-1
+            "airtemp": ("time", np.full(n, 283.15, dtype="f8")),         # K -> 10 degC
+        },
+        coords={"time": times},
+    ).to_netcdf(forcing_dir / "forcing.nc")
+
+
+def _prepare(pp):
+    """Construct dirs and inject a small grid (skip the bounds-based setup)."""
+    pp._create_directory_structure()
+    pp.grid_lats = np.array([51.5, 51.0, 50.5])
+    pp.grid_lons = np.array([-115.5, -115.0, -114.5])
+    pp.nrows = 3
+    pp.ncols = 3
+
+
+def test_precip_m_per_day_and_temp_celsius(pcrglobwb_config, mock_logger):
+    pp = PCRGLOBWBPreProcessor(pcrglobwb_config, mock_logger)
+    _prepare(pp)
+    _write_canonical_forcing(pp.forcing_basin_path, 1e-4)
+
+    with patch.object(pp, "_get_catchment_properties", return_value=_PROPS):
+        pp._generate_forcing()
+
+    precip = xr.open_dataset(pp.forcing_out_dir / "precipitation.nc")
+    temp = xr.open_dataset(pp.forcing_out_dir / "temperature.nc")
+    try:
+        assert float(precip["precipitation"].isel(lat=0, lon=0).mean()) == pytest.approx(8.64e-3, rel=1e-3)
+        assert float(temp["temperature"].isel(lat=0, lon=0).mean()) == pytest.approx(10.0, abs=1e-3)
+    finally:
+        precip.close()
+        temp.close()
+
+
+def test_high_rate_precip_not_misclassified_as_depth(pcrglobwb_config, mock_logger):
+    pp = PCRGLOBWBPreProcessor(pcrglobwb_config, mock_logger)
+    _prepare(pp)
+    _write_canonical_forcing(pp.forcing_basin_path, 0.5)
+
+    with patch.object(pp, "_get_catchment_properties", return_value=_PROPS):
+        pp._generate_forcing()
+
+    precip = xr.open_dataset(pp.forcing_out_dir / "precipitation.nc")
+    try:
+        # canonical: 0.5 * 86400 / 1000 = 43.2 m/day ; legacy guess -> 5e-4
+        assert float(precip["precipitation"].isel(lat=0, lon=0).mean()) == pytest.approx(43.2, rel=1e-3)
+    finally:
+        precip.close()


### PR DESCRIPTION
## Summary
Follow-up to #200. Adopts #197's canonical forcing reader (`open_canonical_forcing` + `forcing_timestep_seconds`) in the process-model preprocessors that previously parsed forcing NetCDF themselves with bespoke variable-name candidate lists and value-range unit/timestep **guesses**.

**Stacks on #200** (`feat/forcing-canonical-migration`) — review/merge that first.

## Models migrated (test-first)
| Model | Old heuristic | Now |
|-------|---------------|-----|
| LISFLOOD | `precip.max() < 0.1` guard; time-axis `dt` | `pptrate × forcing_timestep_seconds`; `airtemp − 273.15` |
| CWatM | 3-way `precip_raw.max()` unit guess | `pptrate × dt / 1000` m/step |
| PCR-GLOBWB | 3-way `precip_raw.max()` unit guess | `pptrate × dt / 1000` m/day |

Each now reads variables under the canonical SYMFLUENCE vocabulary with the store's **declared** timestep, removing the duplicated guess-the-units/timestep logic (the bug class #197 was created to kill).

## Why test-first
These models had no forcing unit tests. Each migration ships with a `test_forcing_canonical.py` that:
1. asserts the realistic case is unchanged, **and**
2. asserts an extreme-rate case the old heuristic mishandled (e.g. a `0.5 kg/m²/s` rate that the 3-way guard treated as mm/day) — these tests are **red on the old code, green on the new**.

## Tests
6 new canonical tests + full per-model suites green (lisflood 159, cwatm 28, pcrglobwb 34). Models/core/data suites: 5880 passed.

## Remaining (future follow-up)
`wflow`, `lstm`, `ignacio`, `parflow`, `clmparflow`, `pihm`, `rhessys` still parse forcing themselves. `wflow` has the clearest active bug (hardcoded `× 3600` hourly assumption) but, like parflow/clmparflow/pihm/rhessys, has no preprocessor test harness yet — deferred so each can be migrated test-first.

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).
