### PR TITLE
refactor(forcing): CFIF (CF standard names) as canonical vocabulary + wflow/ignacio *3600 fixes

### DIFF
--- a/src/symfluence/data/model_ready/cf_conventions.py
+++ b/src/symfluence/data/model_ready/cf_conventions.py
@@ -98,38 +98,41 @@ CF_STANDARD_NAMES: Dict[str, Dict[str, str]] = {
 # ---------------------------------------------------------------------------
 # Canonical forcing vocabulary (single source of truth)
 # ---------------------------------------------------------------------------
-# The model-ready store exposes forcing under these canonical names (the SUMMA
-# vocabulary, which the CARRA/EASYMORE store already uses). Every accepted source
-# alias maps to the canonical name + its CF standard key + canonical units, so
-# the CARRA/ERA5-specific knowledge lives HERE and nowhere else. Model adapters
-# must resolve through this map (see open_canonical_forcing / resolve_forcing_var)
-# rather than carrying their own ``_find_variable`` candidate lists.
+# The model-ready store exposes forcing under canonical **CFIF** names — CF
+# standard names with underscores (``precipitation_flux``, ``air_temperature``,
+# ...), matching the ``data.preprocessing.cfif`` vocabulary the acquisition layer
+# already normalises to. Every accepted source alias (including the SUMMA-native
+# shorthand) maps to the CF name + its native SUMMA name + canonical units, so the
+# CARRA/ERA5-specific knowledge lives HERE and nowhere else. Model adapters resolve
+# through this map (see open_canonical_forcing / resolve_forcing_var) and read the
+# CF names; only model-native layers translate to ``pptrate``/``airtemp`` via the
+# ``summa`` field (or cfif.CFIF_TO_SUMMA_MAPPING).
 CANONICAL_FORCING: Dict[str, Dict[str, object]] = {
-    'pptrate':  {'cf': 'precipitation_flux', 'units': 'kg m-2 s-1', 'kind': 'rate',
-                 'aliases': ['pptrate', 'precipitation_flux', 'precipitation',
+    'precipitation_flux': {'summa': 'pptrate', 'units': 'kg m-2 s-1', 'kind': 'rate',
+                 'aliases': ['precipitation_flux', 'pptrate', 'precipitation',
                              'pr', 'precip', 'tp', 'PREC', 'total_precipitation']},
-    'airtemp':  {'cf': 'air_temperature', 'units': 'K', 'kind': 'state',
-                 'aliases': ['airtemp', 'air_temperature', 'temperature',
+    'air_temperature': {'summa': 'airtemp', 'units': 'K', 'kind': 'state',
+                 'aliases': ['air_temperature', 'airtemp', 'temperature',
                              'tas', 'temp', 't2m', 'AIR_TEMP', '2m_temperature']},
-    'SWRadAtm': {'cf': 'surface_downwelling_shortwave_flux', 'units': 'W m-2', 'kind': 'state',
-                 'aliases': ['SWRadAtm', 'surface_downwelling_shortwave_flux',
+    'surface_downwelling_shortwave_flux': {'summa': 'SWRadAtm', 'units': 'W m-2', 'kind': 'state',
+                 'aliases': ['surface_downwelling_shortwave_flux', 'SWRadAtm',
                              'shortwave', 'rsds', 'swdown', 'ssrd']},
-    'LWRadAtm': {'cf': 'surface_downwelling_longwave_flux', 'units': 'W m-2', 'kind': 'state',
-                 'aliases': ['LWRadAtm', 'surface_downwelling_longwave_flux',
+    'surface_downwelling_longwave_flux': {'summa': 'LWRadAtm', 'units': 'W m-2', 'kind': 'state',
+                 'aliases': ['surface_downwelling_longwave_flux', 'LWRadAtm',
                              'longwave', 'rlds', 'lwdown', 'strd']},
-    'windspd':  {'cf': 'wind_speed', 'units': 'm s-1', 'kind': 'state',
-                 'aliases': ['windspd', 'wind_speed', 'sfcWind', 'wind', 'ws', 'si10']},
-    'spechum':  {'cf': 'specific_humidity', 'units': 'kg kg-1', 'kind': 'state',
-                 'aliases': ['spechum', 'specific_humidity', 'huss', 'q', 'qair']},
-    'airpres':  {'cf': 'surface_air_pressure', 'units': 'Pa', 'kind': 'state',
-                 'aliases': ['airpres', 'surface_air_pressure', 'surface_pressure',
+    'wind_speed': {'summa': 'windspd', 'units': 'm s-1', 'kind': 'state',
+                 'aliases': ['wind_speed', 'windspd', 'sfcWind', 'wind', 'ws', 'si10']},
+    'specific_humidity': {'summa': 'spechum', 'units': 'kg kg-1', 'kind': 'state',
+                 'aliases': ['specific_humidity', 'spechum', 'huss', 'q', 'qair']},
+    'surface_air_pressure': {'summa': 'airpres', 'units': 'Pa', 'kind': 'state',
+                 'aliases': ['surface_air_pressure', 'airpres', 'surface_pressure',
                              'ps', 'sp', 'pres']},
 }
 
-# Reverse map: any accepted alias -> the CF standard key (for metadata enrichment).
+# Reverse map: any accepted alias -> the canonical CF name (for metadata enrichment).
 CANONICAL_FORCING_ALIASES: Dict[str, str] = {
-    str(alias): str(spec['cf'])
-    for spec in CANONICAL_FORCING.values()
+    str(alias): str(cf_name)
+    for cf_name, spec in CANONICAL_FORCING.items()
     for alias in spec['aliases']  # type: ignore[union-attr]
 }
 

--- a/src/symfluence/data/model_ready/forcing_reader.py
+++ b/src/symfluence/data/model_ready/forcing_reader.py
@@ -5,10 +5,13 @@
 Canonical forcing reader for the model-ready store.
 
 Single entry point every model adapter should use to load basin-averaged
-forcing. It guarantees the canonical SYMFLUENCE vocabulary (pptrate, airtemp,
-SWRadAtm, LWRadAtm, windspd, spechum, airpres) regardless of the source dataset
-(CARRA, ERA5, ...) and exposes the forcing timestep via ``ds.attrs['timestep_seconds']``,
-so adapters never re-parse raw variable names, units, or guess the timestep.
+forcing. It guarantees the canonical CFIF vocabulary — CF standard names with
+underscores (precipitation_flux, air_temperature, surface_downwelling_shortwave_flux,
+surface_downwelling_longwave_flux, wind_speed, specific_humidity, surface_air_pressure)
+— regardless of the source dataset (CARRA, ERA5, ...) and exposes the forcing
+timestep via ``ds.attrs['timestep_seconds']``, so adapters never re-parse raw
+variable names, units, or guess the timestep. Model-native layers (e.g. SUMMA's
+Fortran binary) translate these to their shorthand via cfif.CFIF_TO_SUMMA_MAPPING.
 """
 from __future__ import annotations
 
@@ -27,10 +30,10 @@ logger = logging.getLogger(__name__)
 def open_canonical_forcing(
     forcing_files: Union[Path, List[Path]],
 ) -> xr.Dataset:
-    """Open model-ready forcing and return it under canonical names.
+    """Open model-ready forcing and return it under canonical CFIF names.
 
-    - Aliased source variables (e.g. ``precipitation_flux`` -> ``pptrate``) are
-      renamed to the canonical vocabulary.
+    - Aliased source variables (e.g. ``pptrate`` -> ``precipitation_flux``) are
+      renamed to the canonical CF vocabulary.
     - ``ds.attrs['timestep_seconds']`` is set from the store's declared attribute
       or, failing that, inferred from the time axis.
 

--- a/src/symfluence/models/cwatm/preprocessor.py
+++ b/src/symfluence/models/cwatm/preprocessor.py
@@ -132,14 +132,14 @@ class CWatMPreProcessor(BaseModelPreProcessor):  # type: ignore[misc]
                 f"Sub-daily forcing ({dt_hours:.0f}h) — resampling to daily"
             )
 
-        # Precipitation: canonical pptrate is a rate (kg m-2 s-1); convert to
-        # metres per source step (m = mm / 1000).
-        precip_raw = self._extract_forcing_var(ds_forcing, ['pptrate'], props['lat'], props['lon'])
+        # Precipitation: canonical precipitation_flux is a rate (kg m-2 s-1);
+        # convert to metres per source step (m = mm / 1000).
+        precip_raw = self._extract_forcing_var(ds_forcing, ['precipitation_flux'], props['lat'], props['lon'])
         precip_raw = np.maximum(precip_raw, 0.0)
         precip_m_per_step = precip_raw * dt_seconds / 1000.0
 
-        # Temperature: canonical airtemp is in kelvin.
-        temp_raw = self._extract_forcing_var(ds_forcing, ['airtemp'], props['lat'], props['lon']) - 273.15
+        # Temperature: canonical air_temperature is in kelvin.
+        temp_raw = self._extract_forcing_var(ds_forcing, ['air_temperature'], props['lat'], props['lon']) - 273.15
 
         ds_forcing.close()
 

--- a/src/symfluence/models/gsflow/preprocessor.py
+++ b/src/symfluence/models/gsflow/preprocessor.py
@@ -233,8 +233,8 @@ class GSFLOWPreProcessor(BaseModelPreProcessor):  # type: ignore[misc]
         ds = open_canonical_forcing(forcing_files)
         ds = ds.sel(time=slice(str(start_date), str(end_date)))
 
-        airtemp = ds['airtemp'].values.squeeze()    # K
-        pptrate = ds['pptrate'].values.squeeze()     # mm s-1 (== kg m-2 s-1)
+        airtemp = ds['air_temperature'].values.squeeze()      # K
+        pptrate = ds['precipitation_flux'].values.squeeze()   # mm s-1 (== kg m-2 s-1)
         times = pd.DatetimeIndex(ds['time'].values)
         dt_seconds = forcing_timestep_seconds(ds)
 

--- a/src/symfluence/models/ignacio/preprocessor.py
+++ b/src/symfluence/models/ignacio/preprocessor.py
@@ -20,6 +20,10 @@ from typing import Any, Dict, Optional
 import yaml
 
 from symfluence.core.registries import R
+from symfluence.data.model_ready.forcing_reader import (
+    forcing_timestep_seconds,
+    open_canonical_forcing,
+)
 from symfluence.models.base.base_preprocessor import BaseModelPreProcessor
 
 logger = logging.getLogger(__name__)
@@ -254,7 +258,6 @@ class IGNACIOPreProcessor(BaseModelPreProcessor):
         try:
             import numpy as np
             import pandas as pd
-            import xarray as xr
 
             # Find forcing files matching the configured dataset.
             # Search all forcing directories, filtering by dataset name
@@ -296,13 +299,14 @@ class IGNACIOPreProcessor(BaseModelPreProcessor):
             chunks = []
             for nc_file in sorted(nc_files):
                 try:
-                    ds = xr.open_dataset(nc_file)
+                    ds = open_canonical_forcing([nc_file])
 
                     if 'hru' in ds.dims:
                         ds = ds.mean(dim='hru')
 
                     times = pd.to_datetime(ds.time.values)
                     n = len(times)
+                    dt_seconds = forcing_timestep_seconds(ds)
 
                     temp_c = (ds['air_temperature'].values - 273.15
                               if 'air_temperature' in ds
@@ -323,7 +327,7 @@ class IGNACIOPreProcessor(BaseModelPreProcessor):
 
                     wd = np.random.uniform(0, 360, n)
 
-                    precip_mm = (ds['precipitation_flux'].values * 3600
+                    precip_mm = (ds['precipitation_flux'].values * dt_seconds
                                  if 'precipitation_flux' in ds
                                  else np.zeros(n))
 

--- a/src/symfluence/models/lisflood/preprocessor.py
+++ b/src/symfluence/models/lisflood/preprocessor.py
@@ -394,15 +394,15 @@ class LisfloodPreProcessor(BaseModelPreProcessor):  # type: ignore[misc]
         lat = np.array([props["lat"] - dx, props["lat"], props["lat"] + dx])
         lon = np.array([props["lon"] - dx, props["lon"], props["lon"] + dx])
 
-        # Precipitation: canonical pptrate is a rate (kg m-2 s-1 = mm s-1);
-        # scale by the declared timestep to mm per source step.
-        precip = self._extract_forcing_var(ds_forcing, ["pptrate"], props["lat"], props["lon"])
+        # Precipitation: canonical precipitation_flux is a rate (kg m-2 s-1 = mm
+        # s-1); scale by the declared timestep to mm per source step.
+        precip = self._extract_forcing_var(ds_forcing, ["precipitation_flux"], props["lat"], props["lon"])
         raw_times = pd.DatetimeIndex(ds_forcing.time.values)
         source_dt = forcing_timestep_seconds(ds_forcing)
         precip = np.maximum(precip * source_dt, 0.0)
 
-        # Temperature: canonical airtemp is in kelvin.
-        temp = self._extract_forcing_var(ds_forcing, ["airtemp"], props["lat"], props["lon"]) - 273.15
+        # Temperature: canonical air_temperature is in kelvin.
+        temp = self._extract_forcing_var(ds_forcing, ["air_temperature"], props["lat"], props["lon"]) - 273.15
 
         ds_forcing.close()
 

--- a/src/symfluence/models/mhm/preprocessor.py
+++ b/src/symfluence/models/mhm/preprocessor.py
@@ -528,16 +528,16 @@ class MHMPreProcessor(BaseModelPreProcessor):  # type: ignore[misc]
         props = self._get_catchment_properties()
         times = forcing_ds['time'].values if 'time' in forcing_ds else pd.date_range(start_date, end_date, freq='D')
 
-        # Forcing arrives under the canonical vocabulary (pptrate kg m-2 s-1 == mm
-        # s-1, airtemp K) from open_canonical_forcing -- read by canonical name.
-        if 'pptrate' in forcing_ds:
-            precip = forcing_ds['pptrate'].values * 86400.0  # mm/s -> mm/day rate
+        # Forcing arrives under the canonical CFIF vocabulary (precipitation_flux
+        # kg m-2 s-1 == mm s-1, air_temperature K) from open_canonical_forcing.
+        if 'precipitation_flux' in forcing_ds:
+            precip = forcing_ds['precipitation_flux'].values * 86400.0  # mm/s -> mm/day rate
         else:
-            logger.warning("No canonical precip (pptrate); using zeros")
+            logger.warning("No canonical precip (precipitation_flux); using zeros")
             precip = np.zeros(len(times))
 
-        if 'airtemp' in forcing_ds:
-            temp = forcing_ds['airtemp'].values
+        if 'air_temperature' in forcing_ds:
+            temp = forcing_ds['air_temperature'].values
             if np.nanmean(temp) > 100:   # Kelvin
                 temp = temp - 273.15
         else:

--- a/src/symfluence/models/pcrglobwb/preprocessor.py
+++ b/src/symfluence/models/pcrglobwb/preprocessor.py
@@ -420,14 +420,14 @@ class PCRGLOBWBPreProcessor(BaseModelPreProcessor):  # type: ignore[misc]
                 f"will resample to daily for PCR-GLOBWB"
             )
 
-        # Precipitation: canonical pptrate is a rate (kg m-2 s-1); convert to
-        # metres per source step (m = mm / 1000).
-        precip_raw = self._extract_forcing_var(ds_forcing, ['pptrate'], props['lat'], props['lon'])
+        # Precipitation: canonical precipitation_flux is a rate (kg m-2 s-1);
+        # convert to metres per source step (m = mm / 1000).
+        precip_raw = self._extract_forcing_var(ds_forcing, ['precipitation_flux'], props['lat'], props['lon'])
         precip_raw = np.maximum(precip_raw, 0.0)
         precip_m_per_step = precip_raw * dt_seconds / 1000.0
 
-        # Temperature: canonical airtemp is in kelvin.
-        temp_raw = self._extract_forcing_var(ds_forcing, ['airtemp'], props['lat'], props['lon']) - 273.15
+        # Temperature: canonical air_temperature is in kelvin.
+        temp_raw = self._extract_forcing_var(ds_forcing, ['air_temperature'], props['lat'], props['lon']) - 273.15
 
         ds_forcing.close()
 

--- a/src/symfluence/models/prms/preprocessor.py
+++ b/src/symfluence/models/prms/preprocessor.py
@@ -200,8 +200,8 @@ class PRMSPreProcessor(BaseModelPreProcessor):  # type: ignore[misc]
         ds = open_canonical_forcing(forcing_files)
         ds = ds.sel(time=slice(str(start_date), str(end_date)))
 
-        airtemp = ds['airtemp'].values.squeeze()   # K
-        pptrate = ds['pptrate'].values.squeeze()   # mm s-1 (== kg m-2 s-1)
+        airtemp = ds['air_temperature'].values.squeeze()      # K
+        pptrate = ds['precipitation_flux'].values.squeeze()   # mm s-1 (== kg m-2 s-1)
 
         times = pd.DatetimeIndex(ds['time'].values)
         dt_seconds = forcing_timestep_seconds(ds)
@@ -221,12 +221,14 @@ class PRMSPreProcessor(BaseModelPreProcessor):  # type: ignore[misc]
         # (PRMS swrad units). 1 W m-2 sustained over a day = 86400 J m-2 =
         # 86400/41840 = 2.0651 Langleys.
         if self.use_obs_solar:
-            if 'SWRadAtm' in ds:
-                sw = pd.Series(ds['SWRadAtm'].values.squeeze(), index=times).clip(lower=0.0)
+            if 'surface_downwelling_shortwave_flux' in ds:
+                sw = pd.Series(ds['surface_downwelling_shortwave_flux'].values.squeeze(),
+                               index=times).clip(lower=0.0)
                 daily['swrad'] = (sw.resample('D').mean() * 2.0651)
             else:
                 logger.warning("PRMS_USE_OBS_SOLAR set but no canonical shortwave "
-                               "(SWRadAtm) in forcing; falling back to ddsolrad estimate")
+                               "(surface_downwelling_shortwave_flux) in forcing; "
+                               "falling back to ddsolrad estimate")
 
         # Drop any days with all NaN
         daily = daily.dropna(how='all')

--- a/src/symfluence/models/wflow/preprocessor.py
+++ b/src/symfluence/models/wflow/preprocessor.py
@@ -15,6 +15,10 @@ import pandas as pd
 import xarray as xr
 
 from symfluence.core.registries import R
+from symfluence.data.model_ready.forcing_reader import (
+    forcing_timestep_seconds,
+    open_canonical_forcing,
+)
 from symfluence.models.base.base_preprocessor import BaseModelPreProcessor
 
 
@@ -188,27 +192,23 @@ class WflowPreProcessor(BaseModelPreProcessor):  # type: ignore[misc]
             forcing_files = sorted(forcing_path.glob('**/*.nc'))
         if not forcing_files:
             raise FileNotFoundError(f"No forcing files found in {forcing_path}")
-        ds_forcing = xr.open_mfdataset(forcing_files, combine='by_coords')
+        # Canonical reader: CF-named variables with a declared timestep, so we no
+        # longer guess source names, units, or assume an hourly step.
+        ds_forcing = open_canonical_forcing(forcing_files)
         ds_forcing = ds_forcing.sel(time=slice(str(start_date), str(end_date)))
 
         dx = 0.01
         lat = np.array([props['lat'] - dx, props['lat'], props['lat'] + dx])
         lon = np.array([props['lon'] - dx, props['lon'], props['lon'] + dx])
 
-        precip = self._extract_forcing_var(
-            ds_forcing, ['precipitation_flux', 'mtpr', 'tp', 'precipitation', 'PREC', 'precip'],
-            props['lat'], props['lon']
-        )
-        if precip.max() < 0.1:
-            precip = precip * 3600.0
-        precip = np.maximum(precip, 0.0)
+        # Precipitation: CF precipitation_flux is a rate (kg m-2 s-1 = mm s-1);
+        # scale by the declared timestep to mm per step (was hardcoded *3600).
+        precip = self._extract_forcing_var(ds_forcing, ['precipitation_flux'], props['lat'], props['lon'])
+        dt_seconds = forcing_timestep_seconds(ds_forcing)
+        precip = np.maximum(precip * dt_seconds, 0.0)
 
-        temp = self._extract_forcing_var(
-            ds_forcing, ['t2m', 'temperature', 'TEMP', 'air_temperature', 'tas'],
-            props['lat'], props['lon']
-        )
-        if temp.mean() > 100:
-            temp = temp - 273.15
+        # Temperature: CF air_temperature is in kelvin.
+        temp = self._extract_forcing_var(ds_forcing, ['air_temperature'], props['lat'], props['lon']) - 273.15
 
         times = pd.DatetimeIndex(ds_forcing.time.values)
         pet = self._estimate_pet(temp, times, props['lat'])

--- a/tests/unit/data/model_ready/test_forcing_reader.py
+++ b/tests/unit/data/model_ready/test_forcing_reader.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Tests for the canonical forcing reader's CFIF (CF standard name) contract.
+
+``open_canonical_forcing`` must return forcing under canonical CF names
+(``precipitation_flux``, ``air_temperature``, ...) regardless of whether the
+source used SUMMA-native shorthand (``pptrate``/``airtemp``) or other dataset
+aliases, and must expose the timestep via ``ds.attrs['timestep_seconds']``.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+pytest.importorskip("xarray")
+import xarray as xr
+
+from symfluence.data.model_ready.cf_conventions import (
+    CANONICAL_FORCING,
+    resolve_forcing_var,
+)
+from symfluence.data.model_ready.forcing_reader import (
+    forcing_timestep_seconds,
+    open_canonical_forcing,
+)
+
+CF_NAMES = {
+    "precipitation_flux", "air_temperature", "surface_downwelling_shortwave_flux",
+    "surface_downwelling_longwave_flux", "wind_speed", "specific_humidity",
+    "surface_air_pressure",
+}
+
+
+def _write(tmp_path, data_vars):
+    times = pd.date_range("2020-01-01", periods=8, freq="D")
+    ds = xr.Dataset(
+        {k: ("time", np.linspace(1, 8, 8)) for k in data_vars},
+        coords={"time": times},
+    )
+    path = tmp_path / "forcing.nc"
+    ds.to_netcdf(path)
+    return path
+
+
+def test_canonical_forcing_is_keyed_by_cf_names():
+    assert set(CANONICAL_FORCING) == CF_NAMES
+    # Each entry still records its SUMMA-native shorthand for model-native layers.
+    assert CANONICAL_FORCING["precipitation_flux"]["summa"] == "pptrate"
+    assert CANONICAL_FORCING["air_temperature"]["summa"] == "airtemp"
+
+
+def test_summa_source_names_are_renamed_to_cf(tmp_path):
+    path = _write(tmp_path, ["pptrate", "airtemp", "SWRadAtm"])
+    ds = open_canonical_forcing(path)
+    assert "precipitation_flux" in ds
+    assert "air_temperature" in ds
+    assert "surface_downwelling_shortwave_flux" in ds
+    assert "pptrate" not in ds and "airtemp" not in ds
+
+
+def test_era5_style_aliases_are_renamed_to_cf(tmp_path):
+    path = _write(tmp_path, ["tp", "t2m", "ssrd"])
+    ds = open_canonical_forcing(path)
+    assert "precipitation_flux" in ds
+    assert "air_temperature" in ds
+    assert "surface_downwelling_shortwave_flux" in ds
+
+
+def test_already_cf_named_source_is_unchanged(tmp_path):
+    path = _write(tmp_path, ["precipitation_flux", "air_temperature"])
+    ds = open_canonical_forcing(path)
+    assert "precipitation_flux" in ds and "air_temperature" in ds
+
+
+def test_timestep_inferred_from_daily_axis(tmp_path):
+    path = _write(tmp_path, ["pptrate"])
+    ds = open_canonical_forcing(path)
+    assert forcing_timestep_seconds(ds) == pytest.approx(86400.0)
+
+
+def test_resolve_forcing_var_accepts_cf_key_and_aliases(tmp_path):
+    path = _write(tmp_path, ["pptrate"])
+    ds = xr.open_dataset(path)
+    try:
+        # Resolves the SUMMA source under the CF canonical key.
+        assert resolve_forcing_var(ds, "precipitation_flux") == "pptrate"
+    finally:
+        ds.close()

--- a/tests/unit/models/ignacio/test_forcing_canonical.py
+++ b/tests/unit/models/ignacio/test_forcing_canonical.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Canonical-forcing-reader behaviour for the IGNACIO (fire) preprocessor.
+
+IGNACIO converted CF ``precipitation_flux`` to its weather CSV with a hardcoded
+``* 3600`` (hourly assumption). With the canonical reader it scales by the
+declared timestep instead, so daily forcing is no longer undercounted 24x.
+"""
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from symfluence.core.config.models import SymfluenceConfig
+from symfluence.models.ignacio.preprocessor import IGNACIOPreProcessor
+
+
+@pytest.fixture
+def ignacio_config(tmp_path):
+    return SymfluenceConfig(**{
+        "SYMFLUENCE_DATA_DIR": str(tmp_path / "data"),
+        "SYMFLUENCE_CODE_DIR": str(tmp_path / "code"),
+        "DOMAIN_NAME": "test_domain",
+        "EXPERIMENT_ID": "test_run",
+        "EXPERIMENT_TIME_START": "2005-01-01 00:00",
+        "EXPERIMENT_TIME_END": "2005-03-01 23:00",
+        "DOMAIN_DEFINITION_METHOD": "lumped",
+        "SUB_GRID_DISCRETIZATION": "GRUs",
+        "HYDROLOGICAL_MODEL": "IGNACIO",
+        "FORCING_DATASET": "ERA5",
+        "FORCING_TIME_STEP_SIZE": 86400,
+    })
+
+
+def _write_cf_forcing(forcing_dir, pptrate_value, *, n=10):
+    forcing_dir.mkdir(parents=True, exist_ok=True)
+    times = pd.date_range("2005-01-02", periods=n, freq="D")
+    xr.Dataset(
+        {
+            "precipitation_flux": ("time", np.full(n, pptrate_value, dtype="f8")),  # kg m-2 s-1
+            "air_temperature": ("time", np.full(n, 283.15, dtype="f8")),            # K -> 10 degC
+            "wind_speed": ("time", np.full(n, 2.0, dtype="f8")),
+        },
+        coords={"time": times},
+    ).to_netcdf(forcing_dir / "ERA5_forcing.nc")
+
+
+def test_precip_scaled_by_declared_timestep(ignacio_config):
+    pp = IGNACIOPreProcessor(ignacio_config, Mock())
+    pp.ignacio_input_dir.mkdir(parents=True, exist_ok=True)
+    _write_cf_forcing(pp.forcing_basin_path, 1e-4)  # daily, 1e-4 kg/m2/s
+
+    weather_csv = pp._convert_era5_to_weather_csv({})
+
+    assert weather_csv is not None and weather_csv.exists()
+    df = pd.read_csv(weather_csv)
+    # 1e-4 kg/m2/s * 86400 s = 8.64 mm per step (old *3600 gave 0.36)
+    assert df["PRECIP"].mean() == pytest.approx(8.64, rel=1e-3)
+    assert df["TEMP"].mean() == pytest.approx(10.0, abs=1e-3)

--- a/tests/unit/models/wflow/test_forcing_canonical.py
+++ b/tests/unit/models/wflow/test_forcing_canonical.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Canonical-forcing-reader behaviour for the Wflow preprocessor.
+
+Wflow previously hardcoded ``precip * 3600`` (an hourly assumption) regardless of
+the actual forcing timestep, undercounting precipitation on daily/3-hourly data.
+With the canonical reader, precipitation comes from CF ``precipitation_flux``
+(kg m-2 s-1) scaled by the *declared* timestep, and temperature from
+``air_temperature`` (K).
+"""
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from symfluence.core.config.models import SymfluenceConfig
+from symfluence.models.wflow.preprocessor import WflowPreProcessor
+
+_PROPS = {"lat": 51.0, "lon": -115.0, "area_m2": 2.0e9, "elev": 1500.0}
+
+
+@pytest.fixture
+def wflow_config(tmp_path):
+    return SymfluenceConfig(**{
+        "SYMFLUENCE_DATA_DIR": str(tmp_path / "data"),
+        "SYMFLUENCE_CODE_DIR": str(tmp_path / "code"),
+        "DOMAIN_NAME": "test_domain",
+        "EXPERIMENT_ID": "test_run",
+        "EXPERIMENT_TIME_START": "2005-01-01 00:00",
+        "EXPERIMENT_TIME_END": "2005-03-01 23:00",
+        "DOMAIN_DEFINITION_METHOD": "lumped",
+        "SUB_GRID_DISCRETIZATION": "GRUs",
+        "HYDROLOGICAL_MODEL": "WFLOW",
+        "FORCING_DATASET": "ERA5",
+        "FORCING_TIME_STEP_SIZE": 86400,
+    })
+
+
+@pytest.fixture
+def mock_logger():
+    return Mock()
+
+
+def _write_cf_forcing(forcing_dir, pptrate_value, *, n=10):
+    forcing_dir.mkdir(parents=True, exist_ok=True)
+    times = pd.date_range("2005-01-02", periods=n, freq="D")
+    xr.Dataset(
+        {
+            "precipitation_flux": ("time", np.full(n, pptrate_value, dtype="f8")),  # kg m-2 s-1
+            "air_temperature": ("time", np.full(n, 283.15, dtype="f8")),            # K -> 10 degC
+        },
+        coords={"time": times},
+    ).to_netcdf(forcing_dir / "forcing.nc")
+
+
+def test_precip_uses_declared_timestep_not_hardcoded_hour(wflow_config, mock_logger):
+    """Daily forcing must scale by 86400 s, not the old hardcoded 3600."""
+    pp = WflowPreProcessor(wflow_config, mock_logger)
+    pp._create_directory_structure()
+    _write_cf_forcing(pp.forcing_basin_path, 1e-4)  # daily, 1e-4 kg/m2/s
+
+    with patch.object(pp, "_get_catchment_properties", return_value=_PROPS):
+        pp._generate_forcing()
+
+    ds = xr.open_dataset(pp.forcing_out_dir / "forcing.nc")
+    try:
+        # 1e-4 kg/m2/s * 86400 s = 8.64 mm/day  (old *3600 gave 0.36)
+        assert float(ds["precip"].isel(y=0, x=0).mean()) == pytest.approx(8.64, rel=1e-3)
+        assert float(ds["temp"].isel(y=0, x=0).mean()) == pytest.approx(10.0, abs=1e-3)
+    finally:
+        ds.close()


### PR DESCRIPTION
## Summary
Makes **CFIF** — CF standard names with underscores (`precipitation_flux`, `air_temperature`, …) — the canonical forcing vocabulary of the model-ready store, matching the existing `data.preprocessing.cfif` vocabulary the acquisition layer already normalises to. PR #197's `open_canonical_forcing` had renamed source variables *to* the SUMMA shorthand (`pptrate`/`airtemp`), against CFIF; this corrects the direction and retrofits every consumer.

**Stacks on #201.** Review order: #200 → #201 → this.

## Foundation (commit 1)
- `cf_conventions.CANONICAL_FORCING` re-keyed by CF name; each entry keeps its native `summa` name for model-native layers. `open_canonical_forcing` now emits CF names; `resolve_forcing_var` resolves any alias (SUMMA/ERA5/CMIP) under the CF key.
- Only model-native files keep the shorthand (SUMMA's Fortran inputs translate via `cfif.CFIF_TO_SUMMA_MAPPING`); `forcings_builder` only *stamps* CF `standard_name` attributes.
- Adapters retrofitted to CF names: `prms`, `mhm`, `gsflow` (#197) and `lisflood`, `cwatm`, `pcrglobwb` (#201). `swat` already CF-first.
- New `test_forcing_reader.py` locks the CF-emission contract.

## Timestep fixes (commits 2–3, test-first)
- **wflow** hardcoded `precip*3600` (hourly) regardless of timestep — undercounting daily precip **24×**. Now scales by the declared `forcing_timestep_seconds`. New `tests/unit/models/wflow`: daily `1e-4 kg/m²/s` → `8.64 mm/day` (old `0.36`).
- **ignacio** had the same `*3600` in its weather-CSV conversion → fixed identically, test-first.

## CF vocabulary status: COMPLETE
Every forcing-parsing model now reads CF/CFIF names. The remaining models (`lstm`, `pihm`, `parflow`, `clmparflow`, `rhessys`) were verified to already read CF names — no shorthand reads remain.

## Out of scope (separate follow-up)
`parflow`/`clmparflow`/`rhessys` still hardcode `*3600`. For parflow/clmparflow this is baked into an hourly-by-design Snow-17 pipeline (`ppt_mm_hr` → hourly cache), so a correct fix must thread the timestep through Snow-17 — a deeper change tracked separately, test-first.

## Tests
Full models/data/core suites: **5888 passed**, all guards green.

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).