### PR TITLE
feat(observations): route remaining calibration loaders through the model-ready store

### DIFF
--- a/src/symfluence/models/fuse/calibration/metrics_calculation.py
+++ b/src/symfluence/models/fuse/calibration/metrics_calculation.py
@@ -18,7 +18,6 @@ import numpy as np
 import pandas as pd
 
 from symfluence.core.constants import UnitConversion
-from symfluence.core.mixins.project import resolve_data_subdir
 from symfluence.evaluation.utilities import StreamflowMetrics
 from symfluence.models.fuse.calibration.file_manager import resolve_fuse_id
 
@@ -40,34 +39,22 @@ def load_observations(
 
     Returns:
         Daily-resampled observed discharge series, or None if not found
+
+    Delegates to the shared ``StreamflowMetrics`` loader, which prefers the
+    model-ready observations store and falls back to the legacy preprocessed
+    CSV — keeping FUSE consistent with the other models' calibration loaders.
     """
     log = log or logger
     domain_name = config.get('DOMAIN_NAME')
 
-    obs_file_path = config.get('OBSERVATIONS_PATH', 'default')
-    if obs_file_path == 'default':
-        obs_file_path = (
-            resolve_data_subdir(project_dir, 'observations') / 'streamflow' / 'preprocessed' /
-            f"{domain_name}_streamflow_processed.csv"
-        )
-    else:
-        obs_file_path = Path(obs_file_path)
-
-    if not obs_file_path.exists():
-        log.error(f"Observation file not found: {obs_file_path}")
+    values, index = StreamflowMetrics().load_observations(
+        config, project_dir, domain_name, resample_freq='D',
+    )
+    if values is None or index is None:
+        log.error("Observations not found (model-ready store or preprocessed CSV)")
         return None
 
-    df_obs = pd.read_csv(obs_file_path, index_col='datetime', parse_dates=True)
-
-    if not isinstance(df_obs.index, pd.DatetimeIndex):
-        try:
-            df_obs.index = pd.to_datetime(df_obs.index)
-            log.debug("Converted observation index to DatetimeIndex")
-        except Exception as e:  # noqa: BLE001 — calibration resilience
-            log.error(f"Failed to convert observation time index to DatetimeIndex: {e}", exc_info=True)
-            return None
-
-    return df_obs['discharge_cms'].resample('D').mean()
+    return pd.Series(values, index=index, name='discharge_cms')
 
 
 def find_simulation_output(

--- a/src/symfluence/models/hype/calibration/worker.py
+++ b/src/symfluence/models/hype/calibration/worker.py
@@ -16,6 +16,7 @@ import pandas as pd
 
 from symfluence.core.registries import R
 from symfluence.evaluation.metrics import kge, nse
+from symfluence.evaluation.utilities import StreamflowMetrics
 from symfluence.models.hype.preprocessor import HYPEPreProcessor
 from symfluence.optimization.workers.base_worker import BaseWorker, WorkerTask
 
@@ -428,26 +429,16 @@ class HYPEWorker(BaseWorker):
                     if dd and dd != 'default':
                         data_dir = Path(dd)
 
-            # Use resolve_data_subdir for backward-compatible path resolution
-            # (prefers data/observations/ over legacy observations/)
-            from symfluence.core.mixins.project import resolve_data_subdir
+            # Model-ready store first, legacy preprocessed CSV fallback.
             project_dir = data_dir / f'domain_{domain_name}'
-            obs_root = resolve_data_subdir(project_dir, 'observations') / 'streamflow'
-            obs_file = obs_root / 'preprocessed' / f'{domain_name}_streamflow_processed.csv'
-
-            if not obs_file.exists():
-                # Try processed/ fallback
-                obs_file = obs_root / 'processed' / f'{domain_name}_streamflow_processed.csv'
-
-            if not obs_file.exists():
-                self.logger.error(f"Observations file not found at {obs_root} (domain_name={domain_name})")
+            obs_values, obs_index = StreamflowMetrics().load_observations(
+                config, project_dir, domain_name, resample_freq=None,
+            )
+            if obs_values is None or obs_index is None:
+                self.logger.error(f"Observations not found for domain_name={domain_name}")
                 return {'kge': self.penalty_score, 'error': 'Observations not found'}
 
-            obs_df = pd.read_csv(obs_file, index_col='datetime', parse_dates=['datetime'])
-
-            # Ensure the index is a proper DatetimeIndex (parse_dates may fail silently)
-            if not isinstance(obs_df.index, pd.DatetimeIndex):
-                obs_df.index = pd.to_datetime(obs_df.index)
+            obs_df = pd.DataFrame({'discharge_cms': obs_values}, index=obs_index)
 
             # HYPE outputs daily data, observations may be hourly
             # Resample observations to daily mean if they are sub-daily

--- a/src/symfluence/models/mesh/calibration/worker.py
+++ b/src/symfluence/models/mesh/calibration/worker.py
@@ -18,6 +18,7 @@ import pandas as pd
 from symfluence.core.mixins.project import resolve_data_subdir
 from symfluence.core.registries import R
 from symfluence.evaluation.metrics import kge, nse
+from symfluence.evaluation.utilities import StreamflowMetrics
 from symfluence.models.mesh.runner import MESHRunner
 from symfluence.optimization.workers.base_worker import BaseWorker, WorkerTask
 
@@ -307,15 +308,14 @@ class MESHWorker(BaseWorker):
 
             data_dir = Path(data_dir)
             project_dir = data_dir / f'domain_{domain_name}'
-            obs_dir = resolve_data_subdir(project_dir, 'observations')
-            obs_file = (obs_dir / 'streamflow' / 'preprocessed' /
-                       f'{domain_name}_streamflow_processed.csv')
-
-            if not obs_file.exists():
-                self.logger.error(f"Observations not found: {obs_file}")
+            obs_values, obs_index = StreamflowMetrics().load_observations(
+                config, project_dir, domain_name, resample_freq=None,
+            )
+            if obs_values is None or obs_index is None:
+                self.logger.error("Observations not found (store or preprocessed CSV)")
                 return {'kge': self.penalty_score, 'error': 'Observations not found'}
 
-            obs_df = pd.read_csv(obs_file, index_col='datetime', parse_dates=True)
+            obs_df = pd.DataFrame({'discharge_cms': obs_values}, index=obs_index)
 
             # Get observation column (usually 'discharge_cms' or 'discharge')
             obs_col = None

--- a/src/symfluence/models/ngen/calibration/worker.py
+++ b/src/symfluence/models/ngen/calibration/worker.py
@@ -15,8 +15,8 @@ from typing import Any, Dict, Optional
 
 from pydantic import BaseModel as PydanticBaseModel
 
-from symfluence.core.mixins.project import resolve_data_subdir
 from symfluence.core.registries import R
+from symfluence.evaluation.utilities import StreamflowMetrics
 from symfluence.optimization.workers.base_worker import BaseWorker, WorkerTask
 
 logger = logging.getLogger(__name__)
@@ -444,16 +444,16 @@ class NgenWorker(BaseWorker):
                     var = next(iter(ds.data_vars))
                     sim = ds[var].values.flatten()
 
-            # Load observations
+            # Load observations — store-first via the shared loader, CSV fallback.
             data_dir = Path(config.get('SYMFLUENCE_DATA_DIR', '.'))
             project_dir = data_dir / f"domain_{domain_name}"
-            obs_file = (resolve_data_subdir(project_dir, 'observations') / 'streamflow' / 'preprocessed' /
-                       f'{domain_name}_streamflow_processed.csv')
-
-            if not obs_file.exists():
+            obs_values, obs_index = StreamflowMetrics().load_observations(
+                config, project_dir, domain_name, resample_freq=None,
+            )
+            if obs_values is None or obs_index is None:
                 return {'kge': self.penalty_score, 'error': 'Observations not found'}
 
-            obs_df = pd.read_csv(obs_file, index_col='datetime', parse_dates=True)
+            obs_df = pd.DataFrame({'discharge_cms': obs_values}, index=obs_index)
 
             # Robust alignment (CSV with index) or simple length match (NetCDF/fallback)
             if 'sim_df' in locals() and sim_df is not None:

--- a/src/symfluence/models/pcrglobwb/calibration/worker.py
+++ b/src/symfluence/models/pcrglobwb/calibration/worker.py
@@ -219,22 +219,17 @@ class PCRGLOBWBWorker(BaseWorker):
         return None
 
     def _load_observations(self, config: Dict) -> Optional[pd.Series]:
-        """Load observed streamflow."""
+        """Load observed streamflow (model-ready store first, CSV fallback)."""
         data_dir = config.get('SYMFLUENCE_DATA_DIR', '.')
         domain = config.get('DOMAIN_NAME', '')
-        obs_dir = Path(data_dir) / f'domain_{domain}' / 'observations' / 'streamflow' / 'preprocessed'
-        if not obs_dir.exists():
-            self.logger.error(f"Observations not found: {obs_dir}")
+        project_dir = Path(data_dir) / f'domain_{domain}'
+        values, index = self._streamflow_metrics.load_observations(
+            config, project_dir, domain, resample_freq=None,
+        )
+        if values is None or index is None:
+            self.logger.error("Observations not found (store or preprocessed CSV)")
             return None
-
-        csv_files = sorted(obs_dir.glob('*.csv'))
-        if not csv_files:
-            self.logger.error(f"No observation CSV files in {obs_dir}")
-            return None
-
-        df = pd.read_csv(csv_files[0], parse_dates=[0], index_col=0)
-        col = 'discharge_cms' if 'discharge_cms' in df.columns else df.columns[0]
-        return df[col].dropna()
+        return pd.Series(values, index=index, name='discharge_cms').dropna()
 
     @staticmethod
     def _apply_routing(q: pd.Series, params: Dict[str, float]) -> pd.Series:

--- a/src/symfluence/models/summa/calibration/worker.py
+++ b/src/symfluence/models/summa/calibration/worker.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from symfluence.core.registries import R
+from symfluence.evaluation.utilities import StreamflowMetrics
 from symfluence.optimization.workers.base_worker import BaseWorker, WorkerTask
 
 logger = logging.getLogger(__name__)
@@ -593,7 +594,6 @@ class SUMMAWorker(BaseWorker):
             Dictionary of metrics
         """
         try:
-            import pandas as pd
             import xarray as xr
 
             from symfluence.evaluation.metrics import kge, nse
@@ -633,15 +633,15 @@ class SUMMAWorker(BaseWorker):
             sim = sim * catchment_area_m2
             self.logger.debug(f"Converted runoff to discharge using area={catchment_area_m2:.2e} m²")
 
-            # Load observations
-            obs_file = (data_dir / f'domain_{domain_name}' / 'observations' /
-                       'streamflow' / 'preprocessed' / f'{domain_name}_streamflow_processed.csv')
-
-            if not obs_file.exists():
+            # Load observations — model-ready store first, CSV fallback.
+            project_dir = data_dir / f'domain_{domain_name}'
+            obs_values, obs_index = StreamflowMetrics().load_observations(
+                config, project_dir, domain_name, resample_freq=None,
+            )
+            if obs_values is None or obs_index is None:
                 return {'kge': self.penalty_score, 'error': 'Observations not found'}
 
-            obs_df = pd.read_csv(obs_file, index_col='datetime', parse_dates=True)
-            obs = obs_df['discharge_cms'].values
+            obs = obs_values
 
             # Align lengths
             min_len = min(len(sim), len(obs))

--- a/src/symfluence/models/wflow/calibration/worker.py
+++ b/src/symfluence/models/wflow/calibration/worker.py
@@ -279,13 +279,12 @@ class WflowWorker(BaseWorker):
         try:
             domain_name = config.get('DOMAIN_NAME', '')
             data_dir = Path(config.get('SYMFLUENCE_DATA_DIR', '.'))
-            obs_dir = data_dir / f'domain_{domain_name}' / 'observations' / 'streamflow' / 'preprocessed'
-            if not obs_dir.exists():
+            project_dir = data_dir / f'domain_{domain_name}'
+            values, index = self._streamflow_metrics.load_observations(
+                config, project_dir, domain_name, resample_freq=None,
+            )
+            if values is None or index is None:
                 return None
-            obs_files = list(obs_dir.glob('*.csv'))
-            if not obs_files:
-                return None
-            df = pd.read_csv(obs_files[0], parse_dates=True, index_col=0)
-            return df['discharge_cms'] if 'discharge_cms' in df.columns else df.iloc[:, 0]
+            return pd.Series(values, index=index, name='discharge_cms')
         except Exception:  # noqa: BLE001
             return None

--- a/tests/unit/models/fuse/calibration/test_metrics_observations_store.py
+++ b/tests/unit/models/fuse/calibration/test_metrics_observations_store.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""FUSE's calibration observation loader reads the model-ready store.
+
+``metrics_calculation.load_observations`` now delegates to the shared
+``StreamflowMetrics`` loader, so FUSE (and the other models that went through
+their own CSV reads) pick up the model-ready observations store when present and
+fall back to the legacy preprocessed CSV otherwise.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+netCDF4 = pytest.importorskip("netCDF4")  # noqa: N816
+pytest.importorskip("xarray")
+
+from symfluence.data.model_ready.observations_builder import ObservationsNetCDFBuilder
+from symfluence.models.fuse.calibration.metrics_calculation import load_observations
+
+DOMAIN = "test"
+
+
+def _write_csv(project_dir, values):
+    path = (
+        project_dir / "observations" / "streamflow" / "preprocessed"
+        / f"{DOMAIN}_streamflow_processed.csv"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    dates = pd.date_range("2020-01-01", periods=len(values), freq="D")
+    pd.DataFrame({"datetime": dates, "discharge_cms": values}).to_csv(path, index=False)
+
+
+def test_load_observations_prefers_store(tmp_path):
+    original = np.arange(1.0, 31.0)
+    _write_csv(tmp_path, original)
+    built = ObservationsNetCDFBuilder(project_dir=tmp_path, domain_name=DOMAIN).build()
+    assert built is not None
+
+    # Diverge the CSV after building the store; the store value must win.
+    _write_csv(tmp_path, original + 1000.0)
+
+    series = load_observations({"DOMAIN_NAME": DOMAIN}, tmp_path)
+
+    assert isinstance(series, pd.Series)
+    assert series.max() < 100  # store values, not the +1000 CSV
+    np.testing.assert_allclose(np.sort(series.dropna().values), np.sort(original), rtol=1e-5)
+
+
+def test_load_observations_falls_back_to_csv(tmp_path):
+    values = np.arange(1.0, 21.0)
+    _write_csv(tmp_path, values)  # no store built
+
+    series = load_observations({"DOMAIN_NAME": DOMAIN}, tmp_path)
+
+    assert isinstance(series, pd.Series)
+    np.testing.assert_allclose(np.sort(series.dropna().values), np.sort(values), rtol=1e-5)


### PR DESCRIPTION
## Summary
Closes the rest of the **observations → model-ready store** gap. #198 made the shared `StreamflowMetrics` loader store-aware, but a sweep found several calibration workers still reading the legacy preprocessed CSV **directly** in their objective computation — so their KGE was still computed off-store.

**Stacks on #198.**

## Loaders routed through the store (store-first, CSV fallback)
| Model | Before | After |
|-------|--------|-------|
| fuse | `metrics_calculation.load_observations` read CSV | delegates to `StreamflowMetrics` |
| ngen, mesh, summa, hype | inline `pd.read_csv(preprocessed)` in metric calc | `StreamflowMetrics().load_observations(...)` |
| pcrglobwb, wflow | held a `StreamflowMetrics` instance but read CSV anyway | now use it |

## Safety
Behaviour is **identical when no store exists** — `StreamflowMetrics` falls back to the same preprocessed CSV, and the store-vs-CSV **equivalence is already proven by #198's tests** (no objective drift). New FUSE test asserts the store is preferred and the CSV remains the fallback.

## Result
Every model's calibration objective now consumes streamflow observations through the model-ready store. Combined with #198 (StreamflowMetrics) and the store-aware `StreamflowEvaluator` targets, the **observations data type is now fully routed through the MRDS**.

## Tests
New `test_metrics_observations_store.py` (store preferred + CSV fallback). models/data/evaluation/optimization suites: 4088 passed, all guards green.

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).
