### PR TITLE
feat(attributes): SUMMA soil/land class from the model-ready store

### DIFF
--- a/src/symfluence/models/summa/attributes_manager.py
+++ b/src/symfluence/models/summa/attributes_manager.py
@@ -642,36 +642,53 @@ class SummaAttributesManager(ConfigurableMixin):
         intersect_hruId_var = self._get_config_value(lambda: self.config.paths.catchment_hruid)
 
         try:
-            shp = gpd.read_file(intersect_path / intersect_name)
-
-            # Check and create missing USGS_X columns
-            for i in range(13):
-                col_name = f'USGS_{i}'
-                if col_name not in shp.columns:
-                    shp[col_name] = 0  # Add the missing column and initialize with 0
+            # Prefer the model-ready attributes store (/soil/ fractions keyed by
+            # hru_id); fall back to the SoilGrids intersection shapefile.
+            store_frac = self._load_store_class_fractions(
+                'soil', 'soil_fraction', 'soil_class_name')
+            shp = None
+            if store_frac is None:
+                shp = gpd.read_file(intersect_path / intersect_name)
+                # Check and create missing USGS_X columns
+                for i in range(13):
+                    col_name = f'USGS_{i}'
+                    if col_name not in shp.columns:
+                        shp[col_name] = 0  # Add the missing column and initialize with 0
 
             with nc4.Dataset(attribute_file, "r+") as att:
                 for idx in range(len(att['hruId'])):
                     attribute_hru = att['hruId'][idx]
-                    shp_mask = (shp[intersect_hruId_var].astype(int) == attribute_hru)
 
-                    # Check if there are any matching rows for this HRU
-                    if not any(shp_mask):
-                        self.logger.warning(f"No soil class data found for HRU {attribute_hru}, using default class")
-                        att['soilTypeIndex'][idx] = 6  # Use a default value (6 = loam)
-                        continue
+                    if store_frac is not None:
+                        hist = store_frac.get(int(attribute_hru))
+                        if hist is None:
+                            self.logger.warning(f"No soil class data found for HRU {attribute_hru}, using default class")
+                            att['soilTypeIndex'][idx] = 6  # Use a default value (6 = loam)
+                            continue
+                        tmp_hist = [hist.get(j, 0.0) for j in range(13)]
+                        tmp_hist[0] = -1  # Set USGS_0 to -1 to avoid selecting it
+                        tmp_sc = int(np.argmax(np.asarray(tmp_hist)))
+                    else:
+                        assert shp is not None  # read above when the store is unused
+                        shp_mask = (shp[intersect_hruId_var].astype(int) == attribute_hru)
 
-                    tmp_hist = []
-                    for j in range(13):
-                        col_name = f'USGS_{j}'
-                        tmp_hist.append(shp[col_name][shp_mask].values[0])
+                        # Check if there are any matching rows for this HRU
+                        if not any(shp_mask):
+                            self.logger.warning(f"No soil class data found for HRU {attribute_hru}, using default class")
+                            att['soilTypeIndex'][idx] = 6  # Use a default value (6 = loam)
+                            continue
 
-                    tmp_hist[0] = -1  # Set USGS_0 to -1 to avoid selecting it
-                    tmp_sc = np.argmax(np.asarray(tmp_hist))
+                        tmp_hist = []
+                        for j in range(13):
+                            col_name = f'USGS_{j}'
+                            tmp_hist.append(shp[col_name][shp_mask].values[0])
 
-                    if shp[f'USGS_{tmp_sc}'][shp_mask].values[0] != tmp_hist[tmp_sc]:
-                        self.logger.warning(f'Index and mode soil class do not match at hru_id {attribute_hru}')
-                        tmp_sc = 6  # Use a default value (6 = loam) instead of -999
+                        tmp_hist[0] = -1  # Set USGS_0 to -1 to avoid selecting it
+                        tmp_sc = np.argmax(np.asarray(tmp_hist))
+
+                        if shp[f'USGS_{tmp_sc}'][shp_mask].values[0] != tmp_hist[tmp_sc]:
+                            self.logger.warning(f'Index and mode soil class do not match at hru_id {attribute_hru}')
+                            tmp_sc = 6  # Use a default value (6 = loam) instead of -999
 
                     # Ensure soil type index is positive (SUMMA requires this)
                     if tmp_sc <= 0:
@@ -700,37 +717,53 @@ class SummaAttributesManager(ConfigurableMixin):
         intersect_hruId_var = self._get_config_value(lambda: self.config.paths.catchment_hruid)
 
         try:
-            shp = gpd.read_file(intersect_path / intersect_name)
-
-            # Check and create missing IGBP_X columns
-            for i in range(1, 18):
-                col_name = f'IGBP_{i}'
-                if col_name not in shp.columns:
-                    shp[col_name] = 0  # Add the missing column and initialize with 0
+            # Prefer the model-ready attributes store (/landcover/ fractions
+            # keyed by hru_id); fall back to the land-class intersection shapefile.
+            store_frac = self._load_store_class_fractions(
+                'landcover', 'land_fraction', 'land_class_name')
+            shp = None
+            if store_frac is None:
+                shp = gpd.read_file(intersect_path / intersect_name)
+                # Check and create missing IGBP_X columns
+                for i in range(1, 18):
+                    col_name = f'IGBP_{i}'
+                    if col_name not in shp.columns:
+                        shp[col_name] = 0  # Add the missing column and initialize with 0
 
             is_water = 0
 
             with nc4.Dataset(attribute_file, "r+") as att:
                 for idx in range(len(att['hruId'])):
                     attribute_hru = att['hruId'][idx]
-                    shp_mask = (shp[intersect_hruId_var].astype(int) == attribute_hru)
 
-                    # Check if there are any matching rows for this HRU
-                    if not any(shp_mask):
-                        self.logger.warning(f"No land class data found for HRU {attribute_hru}, using default class")
-                        att['vegTypeIndex'][idx] = 1  # Use a default value (1 = Evergreen Needleleaf)
-                        continue
+                    if store_frac is not None:
+                        hist = store_frac.get(int(attribute_hru))
+                        if hist is None:
+                            self.logger.warning(f"No land class data found for HRU {attribute_hru}, using default class")
+                            att['vegTypeIndex'][idx] = 1  # Use a default value (1 = Evergreen Needleleaf)
+                            continue
+                        tmp_hist = [hist.get(j, 0.0) for j in range(1, 18)]
+                        tmp_lc = int(np.argmax(np.asarray(tmp_hist))) + 1
+                    else:
+                        assert shp is not None  # read above when the store is unused
+                        shp_mask = (shp[intersect_hruId_var].astype(int) == attribute_hru)
 
-                    tmp_hist = []
-                    for j in range(1, 18):
-                        col_name = f'IGBP_{j}'
-                        tmp_hist.append(shp[col_name][shp_mask].values[0])
+                        # Check if there are any matching rows for this HRU
+                        if not any(shp_mask):
+                            self.logger.warning(f"No land class data found for HRU {attribute_hru}, using default class")
+                            att['vegTypeIndex'][idx] = 1  # Use a default value (1 = Evergreen Needleleaf)
+                            continue
 
-                    tmp_lc = np.argmax(np.asarray(tmp_hist)) + 1
+                        tmp_hist = []
+                        for j in range(1, 18):
+                            col_name = f'IGBP_{j}'
+                            tmp_hist.append(shp[col_name][shp_mask].values[0])
 
-                    if shp[f'IGBP_{tmp_lc}'][shp_mask].values[0] != tmp_hist[tmp_lc - 1]:
-                        self.logger.warning(f'Index and mode land class do not match at hru_id {attribute_hru}')
-                        tmp_lc = 1  # Use a default value (1 = Evergreen Needleleaf) instead of -999
+                        tmp_lc = np.argmax(np.asarray(tmp_hist)) + 1
+
+                        if shp[f'IGBP_{tmp_lc}'][shp_mask].values[0] != tmp_hist[tmp_lc - 1]:
+                            self.logger.warning(f'Index and mode land class do not match at hru_id {attribute_hru}')
+                            tmp_lc = 1  # Use a default value (1 = Evergreen Needleleaf) instead of -999
 
                     if tmp_lc == 17:
                         if any(val > 0 for val in tmp_hist[0:-1]):  # HRU is mostly water but other land classes are present
@@ -836,6 +869,66 @@ class SummaAttributesManager(ConfigurableMixin):
         except Exception as e:  # noqa: BLE001 — model execution resilience
             self.logger.debug(
                 f"Could not read elevation from attributes store: {e}", exc_info=True
+            )
+            return None
+
+    def _load_store_class_fractions(
+        self, group: str, frac_var: str, name_var: str
+    ) -> Optional[Dict[int, Dict[int, float]]]:
+        """Load per-HRU class fractions from a model-ready attributes group.
+
+        Returns ``{hru_id: {class_index: fraction}}`` for a soil/landcover group
+        (e.g. ``group='soil'``, ``frac_var='soil_fraction'``,
+        ``name_var='soil_class_name'`` whose names are ``USGS_0``/``USGS_1``/…),
+        keyed by integer HRU id. Returns ``None`` when the store/group is
+        unavailable so the caller falls back to the intersection shapefile.
+
+        No drift: the store fractions originate from the same intersection
+        shapefile, so the dominant-class selection is identical.
+        """
+        try:
+            from symfluence.data.model_ready import open_canonical_attributes
+
+            domain_name = self.project_dir.name.replace('domain_', '', 1)
+            reader = open_canonical_attributes(self.project_dir, domain_name)
+            if reader is None or not reader.has_group(group):
+                return None
+            ids = reader.hru_ids(group)
+            if not ids:
+                return None
+            with reader.group(group) as ds:
+                if frac_var not in ds.variables or name_var not in ds.variables:
+                    return None
+                frac = np.asarray(ds[frac_var].values)
+                names = [str(x) for x in np.atleast_1d(ds[name_var].values)]
+            if frac.ndim != 2 or frac.shape[0] != len(ids):
+                return None
+            class_idx: List[Optional[int]] = []
+            for nm in names:
+                try:
+                    class_idx.append(int(nm.split('_')[-1]))
+                except ValueError:
+                    class_idx.append(None)
+            mapping: Dict[int, Dict[int, float]] = {}
+            for h, hid in enumerate(ids):
+                try:
+                    key = int(float(hid))
+                except (ValueError, TypeError):
+                    continue
+                mapping[key] = {
+                    ci: float(frac[h, c])
+                    for c, ci in enumerate(class_idx) if ci is not None
+                }
+            if mapping:
+                self.logger.info(
+                    f"Using {group} class fractions from model-ready attributes "
+                    f"store ({len(mapping)} HRUs)"
+                )
+                return mapping
+            return None
+        except Exception as e:  # noqa: BLE001 — model execution resilience
+            self.logger.debug(
+                f"Could not read {group} fractions from store: {e}", exc_info=True
             )
             return None
 

--- a/tests/unit/models/test_summa_attributes_store.py
+++ b/tests/unit/models/test_summa_attributes_store.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""SUMMA attributes manager reads soil/land class fractions from the MRDS.
+
+Covers the per-HRU class-fraction reconstruction used by insert_soil_class /
+insert_land_class. The store's /soil/ and /landcover/ fraction matrices come
+from the same intersection shapefiles, so the dominant-class selection is
+unchanged — this verifies the mapping is keyed and ordered correctly.
+"""
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import pytest
+
+netCDF4 = pytest.importorskip("netCDF4")  # noqa: N816
+gpd = pytest.importorskip("geopandas")
+pytest.importorskip("xarray")
+
+from shapely.geometry import box
+
+from symfluence.data.model_ready.attributes_builder import AttributesNetCDFBuilder
+from symfluence.models.summa.attributes_manager import SummaAttributesManager
+
+HRU_IDS = [1, 2, 3]
+
+
+def _catchment_shp(tmp_path):
+    path = tmp_path / "shapefiles" / "catchment" / "test_HRUs_lumped.shp"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    gpd.GeoDataFrame({
+        "HRU_ID": HRU_IDS,
+        "HRU_area": np.full(3, 2.0e6),
+        "geometry": [box(i, 50, i + 1, 51) for i in range(3)],
+    }, crs="EPSG:4326").to_file(path)
+
+
+def _soil_shp(tmp_path):
+    path = (tmp_path / "shapefiles" / "catchment_intersection"
+            / "with_soilgrids" / "catchment_with_soilclass.shp")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # USGS_0..4 fractions; per HRU the dominant non-zero class differs.
+    data = {"HRU_ID": HRU_IDS}
+    fracs = {
+        "USGS_0": [0.1, 0.1, 0.1],
+        "USGS_1": [0.7, 0.0, 0.0],
+        "USGS_2": [0.2, 0.8, 0.1],
+        "USGS_3": [0.0, 0.1, 0.8],
+        "USGS_4": [0.0, 0.0, 0.0],
+    }
+    data.update(fracs)
+    data["geometry"] = [box(i, 50, i + 1, 51) for i in range(3)]
+    gpd.GeoDataFrame(data, crs="EPSG:4326").to_file(path)
+
+
+def _land_shp(tmp_path):
+    path = (tmp_path / "shapefiles" / "catchment_intersection"
+            / "with_landclass" / "catchment_with_landclass.shp")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {"HRU_ID": HRU_IDS}
+    for i in range(1, 6):
+        data[f"IGBP_{i}"] = [0.0, 0.0, 0.0]
+    data["IGBP_2"] = [0.9, 0.1, 0.1]
+    data["IGBP_4"] = [0.1, 0.9, 0.2]
+    data["geometry"] = [box(i, 50, i + 1, 51) for i in range(3)]
+    gpd.GeoDataFrame(data, crs="EPSG:4326").to_file(path)
+
+
+def _manager(tmp_path):
+    # Bypass the heavy constructor — the reader helper only needs project_dir/logger.
+    mgr = SummaAttributesManager.__new__(SummaAttributesManager)
+    mgr.project_dir = tmp_path
+    mgr.logger = logging.getLogger("test_summa_attrs")
+    return mgr
+
+
+def test_soil_fractions_from_store(tmp_path):
+    _catchment_shp(tmp_path)
+    _soil_shp(tmp_path)
+    assert AttributesNetCDFBuilder(project_dir=tmp_path, domain_name="test").build() is not None
+
+    frac = _manager(tmp_path)._load_store_class_fractions(
+        "soil", "soil_fraction", "soil_class_name")
+
+    assert frac is not None
+    assert set(frac) == {1, 2, 3}
+    # HRU 1 fractions match the shapefile, keyed by USGS index.
+    assert frac[1][1] == pytest.approx(0.7)
+    assert frac[1][2] == pytest.approx(0.2)
+    # Dominant class (USGS_0 set to -1 in the caller) is USGS_1 for HRU 1,
+    # USGS_2 for HRU 2, USGS_3 for HRU 3 — i.e. argmax of the non-zero classes.
+    def dominant(h):
+        hist = [frac[h].get(j, 0.0) for j in range(5)]
+        hist[0] = -1
+        return int(np.argmax(hist))
+    assert dominant(1) == 1
+    assert dominant(2) == 2
+    assert dominant(3) == 3
+
+
+def test_land_fractions_from_store(tmp_path):
+    _catchment_shp(tmp_path)
+    _land_shp(tmp_path)
+    assert AttributesNetCDFBuilder(project_dir=tmp_path, domain_name="test").build() is not None
+
+    frac = _manager(tmp_path)._load_store_class_fractions(
+        "landcover", "land_fraction", "land_class_name")
+
+    assert frac is not None
+    assert set(frac) == {1, 2, 3}
+    # vegTypeIndex = argmax(IGBP_1..17) + 1 ; HRU 1 dominant IGBP_2, HRU 2 IGBP_4.
+    def veg(h):
+        hist = [frac[h].get(j, 0.0) for j in range(1, 18)]
+        return int(np.argmax(hist)) + 1
+    assert veg(1) == 2
+    assert veg(2) == 4
+
+
+def test_returns_none_when_store_absent(tmp_path):
+    assert _manager(tmp_path)._load_store_class_fractions(
+        "soil", "soil_fraction", "soil_class_name") is None

--- a/tools/quality/broad_exception_allowlist.txt
+++ b/tools/quality/broad_exception_allowlist.txt
@@ -1072,6 +1072,7 @@ src/symfluence/models/rhessys/worldfile_generator.py:RHESSysWorldfileGenerator.g
 src/symfluence/models/state/manager.py:StateManager.export_to_fews:except Exception as e:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/summa/attributes_manager.py:SummaAttributesManager._calculate_aspect_from_dem:except Exception as e:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/summa/attributes_manager.py:SummaAttributesManager._calculate_tan_slope_from_dem:except Exception as e:  # noqa: BLE001 — model execution resilience
+src/symfluence/models/summa/attributes_manager.py:SummaAttributesManager._load_store_class_fractions:except Exception as e:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/summa/attributes_manager.py:SummaAttributesManager._load_store_elevation:except Exception as e:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/summa/attributes_manager.py:SummaAttributesManager.insert_aspect:except Exception as e:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/summa/attributes_manager.py:SummaAttributesManager.insert_land_class:except Exception as e:  # noqa: BLE001 — model execution resilience


### PR DESCRIPTION
## Summary
Starts the **attributes → model-ready store** rollout by completing the **SUMMA** pilot. #199 added the `open_canonical_attributes` reader and wired SUMMA elevation; this adds **soil and land class**, so SUMMA now consumes the attributes store for all three (elevation, soil, landcover).

**Stacks on #199.**

## Change
- New shared helper `_load_store_class_fractions(group, frac_var, name_var)` → `{hru_id: {class_index: fraction}}`, reconstructed from the store's `/soil/` (`soil_fraction`/`soil_class_name`) and `/landcover/` (`land_fraction`/`land_class_name`) groups, joined by the `hru_id` coordinate added in #199.
- `insert_soil_class` / `insert_land_class` use it as a store-first fast path and feed the **identical** dominant-class logic; the shapefile path is byte-for-byte unchanged and remains the fallback when the store is absent.

## No drift
The store's fraction matrices originate from the same SoilGrids / land-class intersection shapefiles, so the dominant-class selection (`argmax`) is identical. Behaviour is unchanged when no store exists.

## Tests
`tests/unit/models/test_summa_attributes_store.py` — store reconstruction keyed by HRU, correct dominant soil/veg index, `None` when the store is absent. summa + data/model_ready suites green (67 passed).

## Remaining (task #8, follow-up)
`HYPE` (complex SLC soil×landcover pipeline), `glacier_manager`, `SWAT`, `VIC`, `CRHM` still read attributes from shapefiles — each a separate per-model wiring, HYPE being the substantial one.

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).
