### PR TITLE
feat(attributes): HYPE GeoData soil/land/elevation from the model-ready store

### DIFF
--- a/src/symfluence/models/hype/geodata_manager.py
+++ b/src/symfluence/models/hype/geodata_manager.py
@@ -380,7 +380,12 @@ class HYPEGeoDataManager:
         intersect_base_path: Optional[Path],
         basin_id_col: str
     ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
-        """Robustly load GIS statistics from CSV or shapefile fallbacks."""
+        """Robustly load GIS statistics from the model-ready attributes store,
+        falling back to gistool CSVs or intersection shapefiles."""
+        store_stats = self._load_gis_stats_from_store(basin_id_col)
+        if store_stats is not None:
+            return store_stats
+
         def find_data(pattern: str, fallback_shp_path: Optional[str] = None) -> Optional[pd.DataFrame]:
             files = list(gistool_output.glob(pattern))
             if files:
@@ -408,6 +413,89 @@ class HYPEGeoDataManager:
             )
 
         return soil, land, elev
+
+    @staticmethod
+    def _coerce_basin_ids(ids: list) -> list:
+        """Coerce store HRU ids to integers where possible (basin ids are ints)."""
+        out = []
+        for hid in ids:
+            try:
+                out.append(int(float(hid)))
+            except (ValueError, TypeError):
+                out.append(hid)
+        return out
+
+    def _store_class_frame(
+        self, reader, group: str, frac_var: str, name_var: str, index_name: str
+    ) -> Optional[pd.DataFrame]:
+        """Build a per-basin class-fraction DataFrame from an attributes group.
+
+        Columns are the class names (``USGS_<id>`` / ``IGBP_<id>``) and the index
+        is the basin id, matching the gistool/shapefile layout ``_process_slc``
+        consumes. Returns ``None`` when the group is unavailable.
+        """
+        if not reader.has_group(group):
+            return None
+        ids = reader.hru_ids(group)
+        if not ids:
+            return None
+        with reader.group(group) as ds:
+            if frac_var not in ds.variables or name_var not in ds.variables:
+                return None
+            frac = np.asarray(ds[frac_var].values)
+            names = [str(x) for x in np.atleast_1d(ds[name_var].values)]
+        if frac.ndim != 2 or frac.shape[0] != len(ids):
+            return None
+        df = pd.DataFrame(frac, columns=names, index=self._coerce_basin_ids(ids))
+        df.index.name = index_name
+        return df
+
+    def _load_gis_stats_from_store(
+        self, basin_id_col: str
+    ) -> Optional[Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]]:
+        """Build (soil, landcover, elevation) stats from the model-ready
+        attributes store, or ``None`` when unavailable.
+
+        No drift: the store's soil/landcover/terrain values originate from the
+        same intersection shapefiles the CSV/shapefile fallback reads.
+        """
+        try:
+            from symfluence.data.model_ready import open_canonical_attributes
+
+            data_dir = self.config.get('SYMFLUENCE_DATA_DIR')
+            domain = self.config.get('DOMAIN_NAME')
+            if not data_dir or not domain:
+                return None
+            project_dir = Path(data_dir) / f'domain_{domain}'
+            reader = open_canonical_attributes(project_dir, domain)
+            if reader is None:
+                return None
+
+            soil = self._store_class_frame(
+                reader, 'soil', 'soil_fraction', 'soil_class_name', basin_id_col)
+            land = self._store_class_frame(
+                reader, 'landcover', 'land_fraction', 'land_class_name', basin_id_col)
+
+            elev = None
+            if reader.has_group('terrain'):
+                ids = reader.hru_ids('terrain')
+                elev_vals = reader.variable('terrain', 'elev_mean')
+                if ids and elev_vals is not None and len(elev_vals) == len(ids):
+                    elev = pd.DataFrame(
+                        {'elev_mean': np.asarray(elev_vals)},
+                        index=self._coerce_basin_ids(ids),
+                    )
+                    elev.index.name = basin_id_col
+
+            if soil is None or land is None or elev is None:
+                return None
+            self.logger.info(
+                "Loaded HYPE GIS statistics from the model-ready attributes store")
+            return soil, land, elev
+        except Exception as e:  # noqa: BLE001 — model execution resilience
+            self.logger.debug(
+                f"Could not load GIS stats from attributes store: {e}", exc_info=True)
+            return None
 
     def _process_slc(
         self,

--- a/tests/unit/models/hype/test_geodata_store.py
+++ b/tests/unit/models/hype/test_geodata_store.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""HYPE GeoData manager reads soil/land/elevation stats from the MRDS.
+
+``_load_gis_stats`` now prefers the model-ready attributes store, reconstructing
+the per-basin soil (USGS_*), landcover (IGBP_*) and elevation frames that the SLC
+pipeline consumes, and falling back to gistool CSVs / intersection shapefiles.
+The store values originate from the same intersection shapefiles, so SLC output
+is unchanged.
+"""
+from __future__ import annotations
+
+import logging
+from unittest.mock import Mock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+netCDF4 = pytest.importorskip("netCDF4")  # noqa: N816
+gpd = pytest.importorskip("geopandas")
+pytest.importorskip("xarray")
+
+from shapely.geometry import box
+
+from symfluence.data.model_ready.attributes_builder import AttributesNetCDFBuilder
+from symfluence.models.hype.geodata_manager import HYPEGeoDataManager
+
+HRU_IDS = [1, 2, 3]
+
+
+def _catchment_shp(tmp_path):
+    path = tmp_path / "shapefiles" / "catchment" / "test_HRUs_lumped.shp"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    gpd.GeoDataFrame({
+        "HRU_ID": HRU_IDS,
+        "HRU_area": np.full(3, 2.0e6),
+        "geometry": [box(i, 50, i + 1, 51) for i in range(3)],
+    }, crs="EPSG:4326").to_file(path)
+
+
+def _soil_shp(tmp_path):
+    path = (tmp_path / "shapefiles" / "catchment_intersection"
+            / "with_soilgrids" / "catchment_with_soilclass.shp")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {"HRU_ID": HRU_IDS,
+            "USGS_0": [0.1, 0.1, 0.1], "USGS_1": [0.7, 0.0, 0.0],
+            "USGS_2": [0.2, 0.8, 0.1], "USGS_3": [0.0, 0.1, 0.8]}
+    data["geometry"] = [box(i, 50, i + 1, 51) for i in range(3)]
+    gpd.GeoDataFrame(data, crs="EPSG:4326").to_file(path)
+
+
+def _land_shp(tmp_path):
+    path = (tmp_path / "shapefiles" / "catchment_intersection"
+            / "with_landclass" / "catchment_with_landclass.shp")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {"HRU_ID": HRU_IDS}
+    for i in range(1, 6):
+        data[f"IGBP_{i}"] = [0.0, 0.0, 0.0]
+    data["IGBP_2"] = [0.9, 0.1, 0.1]
+    data["IGBP_4"] = [0.1, 0.9, 0.9]
+    data["geometry"] = [box(i, 50, i + 1, 51) for i in range(3)]
+    gpd.GeoDataFrame(data, crs="EPSG:4326").to_file(path)
+
+
+def _dem_shp(tmp_path):
+    path = (tmp_path / "shapefiles" / "catchment_intersection"
+            / "with_dem" / "catchment_with_dem.shp")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    gpd.GeoDataFrame({
+        "HRU_ID": HRU_IDS, "elev_mean": [800.0, 1200.0, 2000.0],
+        "geometry": [box(i, 50, i + 1, 51) for i in range(3)],
+    }, crs="EPSG:4326").to_file(path)
+
+
+def _manager(tmp_path):
+    mgr = HYPEGeoDataManager.__new__(HYPEGeoDataManager)
+    mgr.config = {
+        "SYMFLUENCE_DATA_DIR": str(tmp_path.parent),
+        "DOMAIN_NAME": "test",
+    }
+    mgr.logger = logging.getLogger("test_hype_geodata")
+    return mgr
+
+
+def _build(tmp_path):
+    # project_dir = <data_dir>/domain_test ; store lives under it.
+    assert AttributesNetCDFBuilder(project_dir=tmp_path, domain_name="test").build() is not None
+
+
+def test_load_gis_stats_from_store(tmp_path):
+    project_dir = tmp_path / "domain_test"
+    _catchment_shp(project_dir)
+    _soil_shp(project_dir)
+    _land_shp(project_dir)
+    _dem_shp(project_dir)
+    _build(project_dir)
+
+    soil, land, elev = _manager(project_dir)._load_gis_stats_from_store("HRU_ID")
+
+    assert list(soil.index) == HRU_IDS
+    assert "USGS_1" in soil.columns and soil.loc[1, "USGS_1"] == pytest.approx(0.7)
+    assert "IGBP_2" in land.columns and land.loc[1, "IGBP_2"] == pytest.approx(0.9)
+    assert elev.loc[3, "elev_mean"] == pytest.approx(2000.0)
+
+
+def test_store_frames_drive_slc_processing(tmp_path):
+    project_dir = tmp_path / "domain_test"
+    _catchment_shp(project_dir)
+    _soil_shp(project_dir)
+    _land_shp(project_dir)
+    _dem_shp(project_dir)
+    _build(project_dir)
+
+    mgr = _manager(project_dir)
+    soil, land, elev = mgr._load_gis_stats_from_store("HRU_ID")
+    base_df = pd.DataFrame({"subid": HRU_IDS})
+
+    slc_df, _ = mgr._process_slc(base_df, land, soil, threshold=0.05)
+
+    # Dominant soil: USGS_1 (hru1), USGS_2 (hru2), USGS_3 (hru3).
+    # Active land (>0.05): IGBP_2 and/or IGBP_4. SLC = (landcover, soil) combos.
+    combos = set(zip(slc_df["landcover"], slc_df["soil"]))
+    assert (2, 1) in combos   # hru1: IGBP_2 x USGS_1
+    assert (4, 2) in combos   # hru2: IGBP_4 x USGS_2
+    assert (4, 3) in combos   # hru3: IGBP_4 x USGS_3
+    assert all(slc_df["soil"] >= 1)  # HYPE requires soil >= 1
+
+
+def test_returns_none_when_store_absent(tmp_path):
+    assert _manager(tmp_path / "domain_test")._load_gis_stats_from_store("HRU_ID") is None

--- a/tools/quality/broad_exception_allowlist.txt
+++ b/tools/quality/broad_exception_allowlist.txt
@@ -661,7 +661,6 @@ src/symfluence/models/execution/spatial_orchestrator.py:SpatialOrchestrator.rout
 src/symfluence/models/fuse/calibration/file_manager.py:_resolve_simulation_dates:except Exception as e:  # noqa: BLE001 — calibration resilience
 src/symfluence/models/fuse/calibration/file_manager.py:update_fuse_file_manager:except Exception as e:  # noqa: BLE001 — calibration resilience
 src/symfluence/models/fuse/calibration/metrics_calculation.py:align_and_filter:except Exception as e:  # noqa: BLE001 — calibration resilience
-src/symfluence/models/fuse/calibration/metrics_calculation.py:load_observations:except Exception as e:  # noqa: BLE001 — calibration resilience
 src/symfluence/models/fuse/calibration/metrics_calculation.py:read_fuse_streamflow:except Exception as e:  # noqa: BLE001 — calibration resilience
 src/symfluence/models/fuse/calibration/metrics_calculation.py:read_fuse_streamflow:except Exception as e:  # noqa: BLE001 — calibration resilience
 src/symfluence/models/fuse/calibration/metrics_calculation.py:read_routed_streamflow:except Exception as e:  # noqa: BLE001 — calibration resilience
@@ -780,6 +779,7 @@ src/symfluence/models/hype/config_manager.py:HYPEConfigManager.write_par_file:ex
 src/symfluence/models/hype/extractor.py:HYPEResultExtractor._extract_from_text:except Exception as e:  # noqa: BLE001 — wrap-and-raise to domain error
 src/symfluence/models/hype/forcing_processor.py:HYPEForcingProcessor._merge_forcing_files:except Exception as xe:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/hype/geodata_manager.py:HYPEGeoDataManager._calculate_geometry_area:except Exception as e:  # noqa: BLE001 — model execution resilience
+src/symfluence/models/hype/geodata_manager.py:HYPEGeoDataManager._load_gis_stats_from_store:except Exception as e:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/hype/geodata_manager.py:HYPEGeoDataManager.create_geofiles:except Exception as e:  # noqa: BLE001
 src/symfluence/models/hype/geodata_manager.py:HYPEGeoDataManager.sort_geodata:except Exception as e:  # noqa: BLE001 — model execution resilience
 src/symfluence/models/hype/geodata_manager.py:HYPEGeoDataManager.sort_geodata:except Exception as e:  # noqa: BLE001 — model execution resilience


### PR DESCRIPTION
## Summary
Continues the attributes → model-ready store rollout. **HYPE** now sources its GIS statistics (soil, landcover, elevation) from the attributes store instead of gistool CSVs / intersection shapefiles.

Base: `develop` (after the SUMMA rollout #205 merged).

## Change
- `HYPEGeoDataManager._load_gis_stats` prefers the store: it reconstructs the per-basin **soil (`USGS_*`)**, **landcover (`IGBP_*`)** and **elevation** DataFrames that `_process_slc` consumes from the store's `/soil/`, `/landcover/` and `/terrain/` groups (keyed by `hru_id`), and falls back to the existing CSV / shapefile logic when the store is absent.
- New helpers `_load_gis_stats_from_store` / `_store_class_frame`.

## No drift
The store's soil/landcover/terrain values originate from the same SoilGrids / land-class / DEM intersection shapefiles the fallback reads, so the SLC definitions are unchanged.

## Tests
`tests/unit/models/hype/test_geodata_store.py` — frame reconstruction (columns/index/values) and an **end-to-end `_process_slc` run** proving the store frames yield the correct SLC `(landcover, soil)` combinations, plus `None` when the store is absent. hype + model_ready + summa-attrs suites: 93 passed.

## Attributes rollout status
Store-consuming now: SUMMA (elevation/soil/land), CLM (soil), **HYPE (soil/land/elev)**. The remaining models read sources the store does not carry — VIC/SWAT read catchment **polygon geometry** (centroid/bounds), CRHM reads **DEM rasters** (elevation bands), and `glacier_manager` needs the per-`domType` breakdown (the store keeps only a summed glacier fraction) — so they legitimately keep reading shapefiles/rasters.

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).
