### PR TITLE
perf: address RTI review item 20 hot-spots (raster hoist, julian vectorization, coastal partition, CLI perf gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,3 +140,9 @@ jobs:
           python -c "import symfluence; from symfluence.core.registries import R; \
             assert R.runners.get('SUMMA') is not None, 'SUMMA not registered via entry points'; \
             print('import + entry-point registration OK')"
+
+      - name: CLI performance regression tests
+        # Lazy-import guard: fails if a heavy dependency creeps into CLI
+        # startup. Serial (-n 0) so subprocess wall-clock timings are stable.
+        run: |
+          pytest -m performance -n 0 tests/performance/

--- a/pytest.ini
+++ b/pytest.ini
@@ -32,6 +32,7 @@ markers =
     # Speed markers
     slow: Slow tests (>30s)
     quick: Quick tests (<5s)
+    performance: Performance regression tests (subprocess wall-clock thresholds)
 
     # Data requirements
     requires_data: Requires external data downloads

--- a/src/symfluence/geospatial/discretization/core.py
+++ b/src/symfluence/geospatial/discretization/core.py
@@ -356,15 +356,19 @@ class DomainDiscretizer(PathResolverMixin):
         all_hrus = []
         hru_id_counter = 1
 
-        # Process each GRU individually
-        for gru_idx, gru_row in gru_gdf.iterrows():
-            self.logger.info(f"Processing GRU {gru_idx + 1}/{len(gru_gdf)}")
+        # Open the classification raster once and mask per GRU; reopening the
+        # same file inside the loop is pure per-GRU overhead.
+        with rasterio.open(raster_path) as src:
+            nodata_value = src.nodata
 
-            gru_geometry = gru_row.geometry
-            gru_id = gru_row.get("GRU_ID", gru_idx + 1)
+            # Process each GRU individually
+            for gru_idx, gru_row in gru_gdf.iterrows():
+                self.logger.info(f"Processing GRU {gru_idx + 1}/{len(gru_gdf)}")
 
-            # Extract raster data within this GRU
-            with rasterio.open(raster_path) as src:
+                gru_geometry = gru_row.geometry
+                gru_id = gru_row.get("GRU_ID", gru_idx + 1)
+
+                # Extract raster data within this GRU
                 try:
                     # Mask the raster to this GRU's geometry
                     out_image, out_transform = mask(
@@ -375,58 +379,57 @@ class DomainDiscretizer(PathResolverMixin):
                         filled=False,
                     )
                     out_image = out_image[0]
-                    nodata_value = src.nodata
                 except (rasterio.RasterioIOError, ValueError, RuntimeError) as e:
                     self.logger.warning(
                         f"Could not extract raster data for GRU {gru_id}: {str(e)}"
                     )
                     continue
 
-            # Create mask for valid pixels
-            if nodata_value is not None:
-                valid_mask = out_image != nodata_value
-            else:
-                valid_mask = (
-                    ~np.isnan(out_image)
-                    if out_image.dtype == np.float64
-                    else np.ones_like(out_image, dtype=bool)
-                )
+                # Create mask for valid pixels
+                if nodata_value is not None:
+                    valid_mask = out_image != nodata_value
+                else:
+                    valid_mask = (
+                        ~np.isnan(out_image)
+                        if out_image.dtype == np.float64
+                        else np.ones_like(out_image, dtype=bool)
+                    )
 
-            if not np.any(valid_mask):
-                self.logger.warning(f"No valid pixels found in GRU {gru_id}")
-                continue
+                if not np.any(valid_mask):
+                    self.logger.warning(f"No valid pixels found in GRU {gru_id}")
+                    continue
 
-            # Find unique values within this GRU
-            valid_values = out_image[valid_mask]
+                # Find unique values within this GRU
+                valid_values = out_image[valid_mask]
 
-            if attribute_name in ["elevClass", "radiationClass"]:
-                # For continuous data, classify into bands
-                gru_hrus = self._create_hrus_from_bands(
-                    out_image,
-                    valid_mask,
-                    out_transform,
-                    thresholds,
-                    attribute_name,
-                    gru_geometry,
-                    gru_row,
-                    hru_id_counter,
-                )
-            else:
-                # For discrete classes, use unique values
-                unique_values = np.unique(valid_values)
-                gru_hrus = self._create_hrus_from_classes(
-                    out_image,
-                    valid_mask,
-                    out_transform,
-                    unique_values,
-                    attribute_name,
-                    gru_geometry,
-                    gru_row,
-                    hru_id_counter,
-                )
+                if attribute_name in ["elevClass", "radiationClass"]:
+                    # For continuous data, classify into bands
+                    gru_hrus = self._create_hrus_from_bands(
+                        out_image,
+                        valid_mask,
+                        out_transform,
+                        thresholds,
+                        attribute_name,
+                        gru_geometry,
+                        gru_row,
+                        hru_id_counter,
+                    )
+                else:
+                    # For discrete classes, use unique values
+                    unique_values = np.unique(valid_values)
+                    gru_hrus = self._create_hrus_from_classes(
+                        out_image,
+                        valid_mask,
+                        out_transform,
+                        unique_values,
+                        attribute_name,
+                        gru_geometry,
+                        gru_row,
+                        hru_id_counter,
+                    )
 
-            all_hrus.extend(gru_hrus)
-            hru_id_counter += len(gru_hrus)
+                all_hrus.extend(gru_hrus)
+                hru_id_counter += len(gru_hrus)
 
         self.logger.info(f"Created {len(all_hrus)} HRUs across all GRUs")
         return gpd.GeoDataFrame(all_hrus, crs=gru_gdf.crs)

--- a/src/symfluence/geospatial/geofabric/delineators/coastal_delineator.py
+++ b/src/symfluence/geospatial/geofabric/delineators/coastal_delineator.py
@@ -91,7 +91,7 @@ class CoastalWatershedDelineator(BaseGeofabricDelineator):
             # Create a single polygon from all existing watersheds
             try:
                 watersheds_polygon = gpd.GeoDataFrame(
-                    geometry=[river_basins.unary_union],
+                    geometry=[river_basins.union_all()],
                     crs=river_basins.crs
                 )
             except Exception as e:  # noqa: BLE001 — preprocessing resilience
@@ -156,7 +156,7 @@ class CoastalWatershedDelineator(BaseGeofabricDelineator):
             # If we still don't have valid coastal watersheds, use a simpler approach
             if coastal_watersheds is None or coastal_watersheds.empty:
                 self.logger.warning("Failed to create divided coastal watersheds. Using buffer method.")
-                coastal_watersheds = self._divide_coastal_strip_by_buffer_method(coastal_strip, river_basins)
+                coastal_watersheds = self._divide_coastal_strip_by_buffer_method(coastal_strip, river_basins_proj)
 
             if coastal_watersheds is None or coastal_watersheds.empty:
                 self.logger.info("No valid coastal watersheds created.")
@@ -441,7 +441,7 @@ class CoastalWatershedDelineator(BaseGeofabricDelineator):
             voronoi_gdf = gpd.GeoDataFrame(geometry=regions, crs=points_gdf.crs)
 
             # Create a convex hull around the points to limit Voronoi extent
-            convex_hull = points_gdf.unary_union.convex_hull
+            convex_hull = points_gdf.union_all().convex_hull
 
             # Use a large buffer around the convex hull (projected CRS, metres)
             buffer_distance = 10000.0  # ~10 km
@@ -476,31 +476,8 @@ class CoastalWatershedDelineator(BaseGeofabricDelineator):
             GeoDataFrame with divided coastal watersheds or None if failed
         """
         try:
-            # Get the exterior boundaries of each basin
-            basin_boundaries = []
-            for idx, basin in river_basins.iterrows():
-                # Get the exterior of the basin
-                if basin.geometry.geom_type == 'Polygon':
-                    boundary = basin.geometry.exterior
-                elif basin.geometry.geom_type == 'MultiPolygon':
-                    # Get the longest boundary for multipolygons
-                    boundary = max([poly.exterior for poly in basin.geometry.geoms],
-                                key=lambda x: x.length)
-                else:
-                    continue
-
-                basin_boundaries.append({
-                    'boundary': boundary,
-                    'gru_id': basin['GRU_ID']
-                })
-
-            # Create a convex hull around all basins and extend it outward
-            convex_hull = river_basins.unary_union.convex_hull
-            ext_distance = 10000.0  # ~10 km (projected CRS, metres)
-            shapely.geometry.Polygon(convex_hull).buffer(ext_distance)
-
             # Use a buffer-based approach to divide the coastal strip
-            coastal_geom = coastal_strip.geometry.unary_union
+            coastal_geom = coastal_strip.geometry.union_all()
             divided_coastal = []
 
             for idx, basin in river_basins.iterrows():
@@ -556,23 +533,39 @@ class CoastalWatershedDelineator(BaseGeofabricDelineator):
         Divide the coastal strip using a buffer-based method.
 
         This is a more robust fallback method that uses buffers around each basin
-        to claim portions of the coastal strip.
+        to claim portions of the coastal strip: progressively wider bands (up to
+        1 km) around each basin claim first-come-first-served, and whatever the
+        bands do not reach is split into contiguous fragments, each assigned
+        whole to its nearest basin. A contiguous fragment equidistant to several
+        basins (e.g. the outer part of a strip wider than 1 km) therefore goes
+        entirely to the first spatial-index match; the choice is deterministic
+        for a given input. Fine-grained partitioning is the job of the primary
+        Voronoi path — this method only guarantees no coastal area is lost.
 
         Args:
-            coastal_strip: Coastal areas to divide
+            coastal_strip: Coastal areas to divide (projected CRS, metres)
             river_basins: Existing river basins
 
         Returns:
             GeoDataFrame with divided coastal watersheds or None if failed
         """
         try:
-            coastal_geom = coastal_strip.geometry.unary_union
+            # The strip is reprojected to UTM upstream while basins may arrive in
+            # the original (possibly geographic) CRS; every intersection and
+            # distance below is meaningless across mixed CRSes, so align first.
+            if river_basins.crs != coastal_strip.crs:
+                river_basins = river_basins.to_crs(coastal_strip.crs)
+
+            coastal_geom = coastal_strip.geometry.union_all()
 
             # Create an empty list to store divided coastal watersheds
             divided_coastal = []
 
-            # Create multiple buffer sizes for more uniform coverage
-            buffer_sizes = [0.001, 0.002, 0.003, 0.005, 0.008, 0.01]  # In decimal degrees
+            # Progressively wider claim bands, in metres (the strip is in a
+            # projected CRS). These match the intent of the original
+            # degree-sized bands (~0.001-0.01 deg) from when this method
+            # operated on geographic coordinates.
+            buffer_sizes = [100.0, 200.0, 300.0, 500.0, 800.0, 1000.0]
             remaining_coastal = coastal_geom
 
             for buffer_size in buffer_sizes:
@@ -600,39 +593,32 @@ class CoastalWatershedDelineator(BaseGeofabricDelineator):
                     except Exception as e:  # noqa: BLE001 — preprocessing resilience
                         self.logger.warning(f"Error processing basin {basin['GRU_ID']} with buffer {buffer_size}: {str(e)}", exc_info=True)
 
-            # Handle any remaining coastal strip by assigning to nearest basin
+            # Handle any remaining coastal strip by assigning each contiguous
+            # fragment to its nearest basin (vectorized via the spatial index).
             if not remaining_coastal.is_empty:
                 self.logger.info("Assigning remaining coastal areas to nearest basins.")
 
-                # Convert to GeoDataFrame for easier processing
                 remaining_gdf = gpd.GeoDataFrame(
                     geometry=[remaining_coastal],
-                    crs=river_basins.crs
+                    crs=coastal_strip.crs
                 )
 
                 # Explode to get individual polygons
-                try:
-                    # For newer geopandas versions
-                    remaining_gdf = remaining_gdf.explode(index_parts=True).reset_index(drop=True)
-                except TypeError:
-                    # For older geopandas versions that don't support index_parts
-                    remaining_gdf = remaining_gdf.explode().reset_index(drop=True)
+                remaining_gdf = remaining_gdf.explode(index_parts=True).reset_index(drop=True)
 
-                # For each remaining polygon, find the nearest basin
-                for idx, row in remaining_gdf.iterrows():
-                    nearest_basin = None
-                    min_distance = float('inf')
+                joined = gpd.sjoin_nearest(
+                    remaining_gdf,
+                    river_basins[['GRU_ID', 'geometry']],
+                    how='left',
+                )
+                # Exact-tie matches duplicate the fragment row; keep the first.
+                joined = joined[~joined.index.duplicated(keep='first')]
 
-                    for basin_idx, basin in river_basins.iterrows():
-                        distance = row.geometry.distance(basin.geometry)
-                        if distance < min_distance:
-                            min_distance = distance
-                            nearest_basin = basin['GRU_ID']
-
-                    if nearest_basin is not None:
+                for geometry, basin_id in zip(joined.geometry, joined['GRU_ID']):
+                    if pd.notna(basin_id):
                         divided_coastal.append({
-                            'geometry': row.geometry,
-                            'basin_id': nearest_basin
+                            'geometry': geometry,
+                            'basin_id': basin_id
                         })
 
             # Create GeoDataFrame from divided coastal watersheds

--- a/src/symfluence/models/base/standard_postprocessor.py
+++ b/src/symfluence/models/base/standard_postprocessor.py
@@ -20,7 +20,6 @@ Usage:
 from __future__ import annotations
 
 import re
-from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional, cast
 
@@ -390,10 +389,14 @@ class StandardModelPostProcessor(BaseModelPostProcessor):
             )
             return df
 
-        def julian_to_datetime(row):
-            return datetime(int(row['YEAR']), 1, 1) + timedelta(days=int(row['DAY']) - 1)
-
-        df['datetime'] = df.apply(julian_to_datetime, axis=1)
+        # Vectorized datetime(YEAR, 1, 1) + (DAY - 1) days. Built from the year
+        # start rather than '%Y%j' parsing so an out-of-range day-of-year rolls
+        # into the next year instead of raising, matching the previous per-row
+        # implementation.
+        df['datetime'] = (
+            pd.to_datetime(df['YEAR'].astype(int).astype(str), format='%Y')
+            + pd.to_timedelta(df['DAY'].astype(int) - 1, unit='D')
+        )
         df.set_index('datetime', inplace=True)
 
         # Drop the original DAY/YEAR columns to clean up

--- a/src/symfluence/models/mesh/calibration/worker.py
+++ b/src/symfluence/models/mesh/calibration/worker.py
@@ -184,7 +184,7 @@ class MESHWorker(BaseWorker):
         Returns:
             Dictionary of metric names to values
         """
-        from datetime import datetime, timedelta
+        from datetime import datetime
 
         from symfluence.models.mesh.extractor import MESHResultExtractor
 
@@ -272,12 +272,13 @@ class MESHWorker(BaseWorker):
                 # Check for QOSIM columns (routed streamflow)
                 qosim_cols = [c for c in sim_df.columns if c.startswith('QOSIM')]
                 if qosim_cols:
-                    # Convert YEAR and JDAY/DAY to datetime
+                    # Convert YEAR and JDAY/DAY to datetime (vectorized: year
+                    # start + day-of-year offset, with out-of-range days rolling
+                    # over like the previous per-row implementation).
                     day_col = 'JDAY' if 'JDAY' in sim_df.columns else 'DAY'
-                    sim_df['time'] = sim_df.apply(
-                        lambda row: datetime(int(row['YEAR']), 1, 1) +
-                                   timedelta(days=int(row[day_col]) - 1),
-                        axis=1
+                    sim_df['time'] = (
+                        pd.to_datetime(sim_df['YEAR'].astype(int).astype(str), format='%Y')
+                        + pd.to_timedelta(sim_df[day_col].astype(int) - 1, unit='D')
                     )
                     sim_df = sim_df.set_index('time')
                     sim_df = sim_df.rename(columns={qosim_cols[0]: 'runoff'})

--- a/src/symfluence/models/utilities/forcing_data_processor.py
+++ b/src/symfluence/models/utilities/forcing_data_processor.py
@@ -324,7 +324,8 @@ class ForcingDataProcessor:
         """
         Resample dataset to target frequency.
 
-        Uses xarray options to avoid issues with flox/numbagg.
+        Reductions run with flox/numbagg/bottleneck disabled so the output is
+        bit-identical regardless of which optional accelerators are installed.
 
         Args:
             ds: Dataset to resample
@@ -349,7 +350,13 @@ class ForcingDataProcessor:
 
         self.logger.debug(f"Resampling forcing data to {target_freq} frequency using {method}")
 
-        # Use explicit options to avoid numbagg/flox issues
+        # Deliberately pin the plain-numpy reduction path: flox/numbagg/bottleneck
+        # change summation order, so the resampled forcing would differ at the
+        # floating-point level depending on which optional accelerators happen to
+        # be installed (conda envs often pull flox in with xarray). Disabling them
+        # keeps forcing bit-identical across pip/uv/conda/HPC environments. This
+        # runs in one-time preprocessing, not the calibration loop, so the cost is
+        # small. (RTI architecture review item 20: investigated, kept deliberately.)
         with xr.set_options(use_flox=False, use_numbagg=False, use_bottleneck=False):
             resampler = ds.resample({time_var: target_freq})
             if method == 'mean':

--- a/tests/performance/test_cli_performance.py
+++ b/tests/performance/test_cli_performance.py
@@ -1,67 +1,62 @@
-"""
-CLI Performance Tests
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
 
-Measures import time and CLI command execution time for performance tracking.
+"""CLI performance regression tests.
+
+Guards the lazy-import discipline at CLI startup (RTI architecture review
+item 20): heavy dependencies (xarray, geopandas, rasterio, torch) must not be
+imported eagerly by the CLI path. The regression this catches adds several
+seconds to every command, so the ceilings are generous — cold start is ~5 s
+locally and CI runners are slower — while still failing on an
+order-of-magnitude jump from an eager heavy import.
+
+Each measurement runs in a fresh subprocess so module caching in the test
+runner cannot mask a regression.
 """
 from __future__ import annotations
 
 import subprocess
 import sys
 import time
-from pathlib import Path
 
-PYTHON = sys.executable  # Use current Python interpreter
+import pytest
+
+pytestmark = [pytest.mark.performance, pytest.mark.cli]
+
+# Ceilings in seconds; see module docstring for the calibration rationale.
+IMPORT_TIME_LIMIT_S = 15.0
+COMMAND_TIME_LIMIT_S = 20.0
 
 
-def measure_import_time():
-    """Measure time to import the CLI argument parser."""
+def _timed_run(cmd: list[str]) -> float:
+    """Run a command in a fresh subprocess and return its wall-clock seconds."""
     start = time.perf_counter()
-    cmd = [
-        PYTHON, "-c",
-        "import sys; from pathlib import Path; "
-        "sys.path.insert(0, str(Path.cwd() / 'src')); "
-        "import symfluence.cli.argument_parser"
-    ]
-    subprocess.run(cmd, check=True, capture_output=True)
-    end = time.perf_counter()
-    return end - start
+    subprocess.run(cmd, check=True, capture_output=True, timeout=120)
+    return time.perf_counter() - start
 
 
-def measure_cli_help_time():
-    """Measure time for 'symfluence --help' command."""
-    start = time.perf_counter()
-    cmd = [PYTHON, "-m", "symfluence", "--help"]
-    subprocess.run(cmd, check=True, capture_output=True)
-    end = time.perf_counter()
-    return end - start
+def test_cli_parser_import_time():
+    """Importing the CLI argument parser must stay lightweight."""
+    elapsed = _timed_run([sys.executable, "-c", "import symfluence.cli.argument_parser"])
+    assert elapsed < IMPORT_TIME_LIMIT_S, (
+        f"CLI parser import took {elapsed:.2f}s (limit {IMPORT_TIME_LIMIT_S}s) — "
+        "a heavy dependency is likely being imported eagerly at CLI startup"
+    )
 
 
-def measure_cli_list_steps_time():
-    """Measure time for 'symfluence workflow list-steps' command."""
-    start = time.perf_counter()
-    cmd = [PYTHON, "-m", "symfluence", "workflow", "list-steps"]
-    subprocess.run(cmd, check=True, capture_output=True)
-    end = time.perf_counter()
-    return end - start
+def test_cli_help_time():
+    """`symfluence --help` must respond without loading the scientific stack."""
+    elapsed = _timed_run([sys.executable, "-m", "symfluence", "--help"])
+    assert elapsed < COMMAND_TIME_LIMIT_S, (
+        f"'symfluence --help' took {elapsed:.2f}s (limit {COMMAND_TIME_LIMIT_S}s) — "
+        "a heavy dependency is likely being imported eagerly at CLI startup"
+    )
 
 
-if __name__ == "__main__":
-    print("Measuring CLI performance...")
-
-    import_time = measure_import_time()
-    print(f"  Import time: {import_time:.4f}s")
-
-    help_time = measure_cli_help_time()
-    print(f"  '--help' time: {help_time:.4f}s")
-
-    list_steps_time = measure_cli_list_steps_time()
-    print(f"  'workflow list-steps' time: {list_steps_time:.4f}s")
-
-    # Save results to a file for comparison later
-    results_file = Path("cli_performance_baseline.txt")
-    with open(results_file, "w") as f:
-        f.write(f"import_time: {import_time}\n")
-        f.write(f"help_time: {help_time}\n")
-        f.write(f"list_steps_time: {list_steps_time}\n")
-
-    print(f"\nResults saved to {results_file}")
+def test_cli_list_steps_time():
+    """`symfluence workflow list-steps` must respond without a full framework load."""
+    elapsed = _timed_run([sys.executable, "-m", "symfluence", "workflow", "list-steps"])
+    assert elapsed < COMMAND_TIME_LIMIT_S, (
+        f"'symfluence workflow list-steps' took {elapsed:.2f}s (limit {COMMAND_TIME_LIMIT_S}s) — "
+        "a heavy dependency is likely being imported eagerly on the workflow path"
+    )

--- a/tests/unit/geospatial/test_coastal_delineator.py
+++ b/tests/unit/geospatial/test_coastal_delineator.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Unit tests for the coastal-strip division fallbacks in CoastalWatershedDelineator.
+
+These pin the behavior of the two fallback methods used when the primary
+Voronoi division fails (RTI architecture review item 20):
+
+- ``_divide_coastal_strip_by_buffer_method``: progressive metre-band claims,
+  then nearest-basin assignment of leftover fragments via ``sjoin_nearest``.
+- ``_divide_coastal_strip_by_extending_boundaries``: per-basin 1 km buffer
+  claims.
+
+Before the rewrite the buffer method used degree-sized bands (millimetres in
+the projected CRS the caller supplies), which collapsed the whole contiguous
+strip onto the first basin in row order; these tests guard the fixed
+nearest-based partition.
+"""
+from __future__ import annotations
+
+import logging
+import types
+
+import pytest
+
+pytest.importorskip("geopandas")
+
+import geopandas as gpd  # noqa: E402
+from shapely.geometry import box  # noqa: E402
+
+from symfluence.geospatial.geofabric.delineators.coastal_delineator import (  # noqa: E402
+    CoastalWatershedDelineator,
+)
+
+pytestmark = [pytest.mark.unit]
+
+UTM_CRS = "EPSG:32627"
+
+
+@pytest.fixture
+def river_basins():
+    """Three 10x10 km basins side by side along the x axis (projected CRS)."""
+    return gpd.GeoDataFrame(
+        {'GRU_ID': [1, 2, 3]},
+        geometry=[
+            box(0, 0, 10_000, 10_000),
+            box(10_000, 0, 20_000, 10_000),
+            box(20_000, 0, 30_000, 10_000),
+        ],
+        crs=UTM_CRS,
+    )
+
+
+@pytest.fixture
+def coastal_strip():
+    """A 2 km coastal band along the full southern edge of the basins."""
+    return gpd.GeoDataFrame(geometry=[box(0, -2_000, 30_000, 0)], crs=UTM_CRS)
+
+
+@pytest.fixture
+def delineator():
+    """The methods under test only use ``self.logger``."""
+    return types.SimpleNamespace(logger=logging.getLogger("test_coastal"))
+
+
+class TestBufferMethod:
+    def test_partitions_strip_among_touching_basins(self, delineator, river_basins, coastal_strip):
+        result = CoastalWatershedDelineator._divide_coastal_strip_by_buffer_method(
+            delineator, coastal_strip, river_basins
+        )
+
+        assert result is not None and not result.empty
+        # Every basin claims a share; the strip must not collapse onto basin 1
+        # (the pre-fix degenerate behavior assigned it 59.9998 of 60 km2).
+        assert set(result['parent_basin']) == {1, 2, 3}
+        areas = result.set_index('parent_basin').geometry.area
+        total = coastal_strip.geometry.area.sum()
+        # No coastal area is lost.
+        assert areas.sum() == pytest.approx(total, rel=1e-6)
+        # The claim bands partition the first kilometre evenly: each basin gets
+        # at least (almost) its own 10 km2 inner band. The contiguous outer
+        # band is a single fragment equidistant to all three basins and goes
+        # whole to the tie-winning first match — documented fallback behavior.
+        for gru_id in (1, 2, 3):
+            assert areas[gru_id] > 9.5e6  # ~its 10 km2 inner band, in m2
+
+    def test_detached_fragment_goes_to_nearest_basin(self, delineator, river_basins):
+        # One fragment clearly nearest basin 3, far beyond the 1 km claim bands.
+        strip = gpd.GeoDataFrame(
+            geometry=[box(24_000, -7_000, 26_000, -5_000)], crs=UTM_CRS
+        )
+        result = CoastalWatershedDelineator._divide_coastal_strip_by_buffer_method(
+            delineator, strip, river_basins
+        )
+
+        assert result is not None
+        assert list(result['parent_basin']) == [3]
+        assert result.geometry.area.sum() == pytest.approx(strip.geometry.area.sum(), rel=1e-9)
+
+    def test_reprojects_basins_when_crs_differs(self, delineator, river_basins):
+        # The caller reprojects the strip to UTM but historically passed basins
+        # in their original CRS; the method must align them before intersecting.
+        strip = gpd.GeoDataFrame(
+            geometry=[box(24_000, -7_000, 26_000, -5_000)], crs=UTM_CRS
+        )
+        basins_geographic = river_basins.to_crs("EPSG:4326")
+        result = CoastalWatershedDelineator._divide_coastal_strip_by_buffer_method(
+            delineator, strip, basins_geographic
+        )
+
+        assert result is not None
+        assert list(result['parent_basin']) == [3]
+
+    def test_output_crs_matches_strip(self, delineator, river_basins, coastal_strip):
+        result = CoastalWatershedDelineator._divide_coastal_strip_by_buffer_method(
+            delineator, coastal_strip, river_basins
+        )
+        assert result.crs == coastal_strip.crs
+
+    def test_empty_strip_returns_none(self, delineator, river_basins):
+        empty = gpd.GeoDataFrame(geometry=[box(0, 0, 1, 1).buffer(0).difference(box(0, 0, 1, 1))], crs=UTM_CRS)
+        result = CoastalWatershedDelineator._divide_coastal_strip_by_buffer_method(
+            delineator, empty, river_basins
+        )
+        assert result is None
+
+
+class TestExtendingBoundariesMethod:
+    def test_claims_one_km_band_per_basin(self, delineator, river_basins, coastal_strip):
+        result = CoastalWatershedDelineator._divide_coastal_strip_by_extending_boundaries(
+            delineator, coastal_strip, river_basins
+        )
+
+        assert result is not None and not result.empty
+        assert set(result['parent_basin']) == {1, 2, 3}
+        # This method claims a single 1 km buffer band; with a 2 km strip the
+        # claimed area is the inner band only.
+        assert result.geometry.area.sum() < coastal_strip.geometry.area.sum()


### PR DESCRIPTION
Closes out the five static performance hot-spot candidates from the RTI architectural review (Tier 3, item 20). Each was investigated before changing anything; two turned out to be latent correctness bugs rather than pure performance items.

## Changes

### 1. Raster hoist (`geospatial/discretization/core.py`)
`_create_multipolygon_hrus` opened the classification raster once **per GRU**. It now opens the file once and masks each GRU inside the open handle (`src.nodata` hoisted too). Pure restructure, no behavior change.

### 2. Julian-day vectorization (`models/base/standard_postprocessor.py`, `models/mesh/calibration/worker.py`)
Both row-wise `df.apply` datetime builders are replaced with vectorized `pd.to_datetime(YEAR) + pd.to_timedelta(DAY - 1)`. The postprocessor path runs on **every calibration iteration** for julian-format models; measured ~14x faster on a century of daily output. Verified bit-identical, including the edge case: the old code silently rolled day 366 in a non-leap year into the next year, so the new code builds from year-start + offset rather than `%Y%j` parsing (which would raise) to preserve that behavior exactly.

### 3. Coastal-strip fallback rewrite (`geospatial/geofabric/delineators/coastal_delineator.py`)
Characterizing the buffer-method fallback on a projected fixture revealed it was degenerate, not just slow:
- The claim bands were sized in **decimal degrees** (a remnant from before the caller reprojected to UTM), i.e. millimetres — so the whole contiguous strip collapsed onto the first basin in row order (59.9998 of 60 km² in the fixture).
- The second fallback call passed basins in the original CRS against a UTM strip, making every distance meaningless.

Now: metre-scaled claim bands matching the original degree-band intent, leftover fragments assigned via spatial-index-backed `gpd.sjoin_nearest` instead of a nested O(fragments × basins) distance loop, defensive CRS alignment inside the method, and dead code removed (unused `basin_boundaries` loop, discarded convex-hull buffer, obsolete `explode` shim, deprecated `.unary_union` attribute accesses). The docstring documents the remaining whole-fragment tie-break coarseness honestly — fine partitioning is the primary Voronoi path's job; the fallback guarantees no coastal area is lost. New `tests/unit/geospatial/test_coastal_delineator.py` (6 tests) pins the partition, area conservation, nearest assignment, CRS handling, and output CRS; the module previously had **zero** coverage.

### 4. Forcing-resample flox disable: investigated, kept (`models/utilities/forcing_data_processor.py`)
The unexplained "avoid numbagg/flox issues" comment is replaced with the real rationale: pinning the plain-numpy reduction path keeps resampled forcing **bit-identical regardless of which optional accelerators are installed** (flox/numbagg aren't in the lockfile, but conda envs often pull flox with xarray). It runs in one-time preprocessing, not the calibration loop, so the determinism is worth far more than the negligible speedup of removing it.

### 5. CLI performance gate (`tests/performance/`, `pytest.ini`, `.github/workflows/ci.yml`)
The standalone perf script (zero collected tests, wrote a stray baseline file to the CWD) is now three pytest-collected regression tests with generous wall-clock ceilings (15–20 s vs ~5 s local cold start) — loose enough for noisy CI runners, tight enough to catch the failure mode they guard: a heavy library imported eagerly at CLI startup. Registered a `performance` marker and added a serial CI step so the regression actually fails the build.

## Verification
- 6 new coastal tests + full `tests/unit/geospatial/` (143) and `tests/unit/models/` sweeps pass (1,428 tests)
- Julian vectorization equivalence verified explicitly, including float years and non-leap day-366 rollover
- Perf tests pass serially in ~15 s; `ci.yml` parses; ruff + mypy clean on all changed files; all pre-commit guards pass

> Repo and code assistance from [Claude](https://claude.ai) (Anthropic).