### PR TITLE
docs: architecture at-a-glance, ADR practice, and threat model (review item 25)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,89 @@
+# SYMFLUENCE Architecture — at a glance
+
+SYMFLUENCE is a framework for reproducible multi-model hydrological science:
+define a study area once, run many hydrological models against it, calibrate
+them, and compare the results through one consistent workflow. This document
+is the one-page orientation; the full architecture guide lives in the Sphinx
+documentation ([`docs/source/architecture.rst`](docs/source/architecture.rst),
+rendered on the docs site), and the decisions behind the design are recorded
+as ADRs under [`docs/adr/`](docs/adr/).
+
+## The workflow
+
+Everything is organized around a single end-to-end modeling workflow, driven
+by one typed YAML configuration file:
+
+1. **Domain setup** — define the geographic area and discretize it into
+   modeling units (GRUs/HRUs).
+2. **Data preprocessing** — acquire and prepare meteorological forcing and
+   physical attributes.
+3. **Model instantiation** — configure and stage one or more hydrological
+   models against the domain.
+4. **Calibration and optimization** — tune parameters against observations
+   (DDS, PSO, SCE-UA, DE, …).
+5. **Evaluation** — score model output against observations and compare
+   models.
+
+The pipeline executes named steps tracked by stage markers, so completed steps
+are skipped on re-run; the `symfluence workflow` CLI drives it.
+
+## The layered structure
+
+The source tree under `src/symfluence/` divides into three layers:
+
+- **`core/`** is the foundation: the Pydantic configuration models, the
+  component registry, the path resolver, shared mixins, the exception
+  hierarchy, and profiling hooks. Everything depends on it; **it depends on
+  nothing above it.** That rule is enforced, not aspirational — see
+  `scripts/check_core_layering.py` (CI + pre-commit).
+- **Capability packages** implement the workflow steps: `geospatial/` (domain
+  setup), `data/` (acquisition and preprocessing), `models/` (one adapter
+  package per hydrological model), `optimization/` (calibration algorithms),
+  and `evaluation/` (scoring and benchmarking). `project/` orchestrates a full
+  run across them.
+- **Interface packages** are the ways a user drives the framework: `cli/`,
+  `gui/` (Panel web UI), `tui/` (terminal UI), `agent/` (bundled AI
+  assistant), `reporting/`, `coupling/`, and `fews/` (Delft-FEWS integration).
+
+## The six decisions everything builds on
+
+Recorded in full, with their costs, in
+[ADR-0000](docs/adr/0000-initial-architecture-decisions.md):
+
+1. **Typed configuration is the contract.** A run is valid iff its YAML
+   validates against the Pydantic tree. Unknown keys are warned about at
+   ingestion ([ADR-0006](docs/adr/0006-config-unknown-keys-warn-by-default.md)).
+2. **The manager pattern orchestrates work** — orchestration lives in
+   managers, not in model adapters.
+3. **Mixins carry cross-cutting concerns** (logging, config access, path
+   resolution) instead of a deep inheritance tree.
+4. **The component registry is the extensibility substrate.** Components are
+   looked up by name through the `R` facade; third-party packages register via
+   entry points and `model_manifest()` — including their typed configuration
+   ([ADR-0002](docs/adr/0002-plugins-may-ship-typed-config.md)). Contribution
+   is plugins-first (GOVERNANCE.md §3).
+5. **External model engines are compiled separately and run as
+   subprocesses.** The canonical SUMMA/FUSE/NGEN/… binaries are used directly;
+   no Python re-implementations.
+6. **Multiple installation methods are deliberate** — four maintained
+   families (pip, conda, npm prebuilt, source/bootstrap), each exercised by
+   its own CI workflow; pip is the primary documented path.
+
+## Extending the framework
+
+New models, data handlers, and optimizers are independent Python packages that
+register through entry points — no edits to `core/`. Start with
+[GOVERNANCE.md](GOVERNANCE.md) §3 (the contribution model), the developer
+guide in the Sphinx docs, and the JAX model packages (jHBV, jSACSMA, …) as
+reference plugin implementations.
+
+## Related documents
+
+| Document | What it covers |
+|----------|----------------|
+| [`docs/source/architecture.rst`](docs/source/architecture.rst) | Full architecture guide (diagrams, data flow, patterns) |
+| [`docs/adr/`](docs/adr/) | Architecture Decision Records |
+| [`docs/security.md`](docs/security.md) | Threat model and security posture |
+| [`GOVERNANCE.md`](GOVERNANCE.md) | Contribution model, interface stewardship, decision-making |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | Practical contributor guide |
+| [`.github/SECURITY.md`](.github/SECURITY.md) | How to report a vulnerability |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,11 @@ Pull requests that add new models or algorithms directly to the core will be
 redirected to the plugin path unless there is a compelling reason for core
 inclusion.
 
+A plugin can supply its own **typed configuration schema** via
+`model_manifest(config_schema=...)`; it participates in the validated config
+tree just like an in-tree model. See
+[ADR-0002](docs/adr/0002-plugins-may-ship-typed-config.md).
+
 ---
 
 ## 4. Branching Strategy
@@ -161,6 +166,13 @@ git push origin develop
 - Keep functions focused and testable.
 - Prefer explicit over implicit; avoid magic numbers.
 
+### Logging Levels
+A failed operation that the framework recovers from (a model run crashes, a data
+step fails) is logged at `ERROR`, not `CRITICAL`. `CRITICAL` is reserved for the
+single orchestrator-boundary case where the *whole run* is aborting. See
+[ADR-0005](docs/adr/0005-logging-level-policy.md) for the full level policy. Use
+`--debug` to surface `DEBUG`-level detail when diagnosing a run.
+
 ### Type Checking Notes
 
 SYMFLUENCE uses mypy for static type checking. Some files contain `# type: ignore` comments due to limitations in third-party type stubs:
@@ -221,6 +233,12 @@ pytest tests/unit/          # Unit tests only
 pytest tests/integration/   # Integration tests
 pytest tests/e2e/ --run-full-examples  # End-to-end tests (slow)
 ```
+
+CI enforces a coverage floor that only ratchets upward — a change may not lower
+total coverage. See [ADR-0008](docs/adr/0008-coverage-gate-raise-and-ratchet.md)
+for the policy. When testing config handling, set `SYMFLUENCE_STRICT_CONFIG=1`
+(or `STRICT_CONFIG: true` in the config) to turn unrecognized-key warnings into
+hard errors — see [ADR-0006](docs/adr/0006-config-unknown-keys-warn-by-default.md).
 
 See `tests/TESTING.md` for detailed testing documentation.
 
@@ -363,6 +381,12 @@ While SYMFLUENCE is pre-1.0 (currently 0.x.x):
 - MINOR versions may include breaking changes (documented in CHANGELOG)
 - PATCH versions are always backward compatible
 - Deprecation warnings will be issued at least one MINOR version before removal
+- The legacy `*Registry.register` decorator shims are removed before 1.0;
+  register through `model_manifest()` and the unified `R.*` facade. See
+  [ADR-0001](docs/adr/0001-remove-legacy-registry-shims.md).
+
+Significant interface and policy decisions are recorded as Architecture
+Decision Records under [`docs/adr/`](docs/adr/).
 
 ### Deprecation Policy
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -78,8 +78,11 @@ package that registers with SYMFLUENCE at install time. This includes:
 
 - **New model integrations.** Implement the four component interfaces
   (preprocessor, runner, postprocessor, extractor) and register via
-  `model_manifest()`. See the six JAX-native packages (jHBV, jSACSMA, etc.)
-  as reference implementations.
+  `model_manifest()`. A plugin may also ship its own **typed Pydantic
+  configuration schema** (`model_manifest(config_schema=...)`), which the core
+  validation pipeline consumes on equal footing with in-tree models — see
+  [ADR-0002](docs/adr/0002-plugins-may-ship-typed-config.md). See the six
+  JAX-native packages (jHBV, jSACSMA, etc.) as reference implementations.
 - **New data handlers.** Implement the acquisition handler interface and
   register via decorator.
 - **New optimization algorithms.** Implement the optimizer interface and
@@ -218,6 +221,19 @@ The CI suite includes interface compliance tests that verify:
 Plugin authors are encouraged to run these tests against their packages.
 Instructions are provided in the plugin development guide.
 
+### 4.5 Architecture Decision Records
+
+Decisions that affect a stable interface or set a project-wide policy are
+recorded as **Architecture Decision Records** under [`docs/adr/`](docs/adr/).
+An ADR captures the context, the decision, and its consequences, and is
+immutable once accepted — a decision is changed by adding a superseding ADR,
+not by editing the old one. This keeps the record of *why* a contract was set
+the way it is legible as the contributor base grows. Several of the decisions
+behind the contracts in this document are recorded there, including the removal
+of legacy registry shims ([ADR-0001](docs/adr/0001-remove-legacy-registry-shims.md))
+and the opening of typed plugin configuration
+([ADR-0002](docs/adr/0002-plugins-may-ship-typed-config.md)).
+
 ---
 
 ## 5. Decision-Making
@@ -338,3 +354,4 @@ series:
 |---------|------------|------------------|-------------------------------------------------------------------------|
 | 1.0     | 2026-03-13 | Darri Eythorsson | Initial governance document                                             |
 | 1.1     | 2026-04-20 | Darri Eythorsson | Cross-reference [LICENSING.md](LICENSING.md) (initial licensing policy) |
+| 1.2     | 2026-06-10 | Darri Eythorsson | Add §4.5 (Architecture Decision Records); link ADR-0001/0002 from §3.1 and §4.5 |

--- a/docs/adr/0000-initial-architecture-decisions.md
+++ b/docs/adr/0000-initial-architecture-decisions.md
@@ -1,0 +1,98 @@
+# ADR-0000: Initial architecture decisions
+
+- **Status:** Accepted (recorded retroactively)
+- **Date:** 2026-06-10
+
+## Context
+
+SYMFLUENCE grew to roughly 1,100 source files before the project adopted an
+ADR practice, so the decisions that shape the codebase were made — and proved
+out — without being written down as decisions. This record captures the six
+of them that everything else builds on, so they are legible to contributors
+without reverse-engineering the source. Each is stated with its upside and
+the cost it knowingly carries.
+
+## Decisions
+
+### 1. Typed configuration is the contract
+
+A Pydantic model hierarchy under `core/config/models/` is the single
+agreement between the user and the framework: a run is valid if and only if
+its configuration validates. Typos and type mismatches are caught by the
+validator before any code runs; the configuration is self-documenting through
+its schema; the contract is testable in isolation. The cost is that the
+schema must be kept open to plugins rather than hardcoded — addressed by
+[ADR-0002](0002-plugins-may-ship-typed-config.md) — and that unknown keys
+need their own validation layer
+([ADR-0006](0006-config-unknown-keys-warn-by-default.md)).
+
+### 2. The manager pattern orchestrates work
+
+A base manager class and a set of domain-specific managers carry each
+workflow step from configuration to result, keeping orchestration logic out
+of the model adapters. Orchestration lives in one tier instead of being
+duplicated across adapters, and a new model gets a working workflow as long
+as it fits the existing manager contracts. The cost is that the base manager
+is load-bearing for every model at once, so its contract changes demand test
+coverage commensurate with that blast radius.
+
+### 3. Mixins carry cross-cutting concerns
+
+Logging, timing, validation, configuration access, path resolution, shapefile
+handling, and file utilities are supplied through `core/mixins/` rather than
+a deep inheritance tree. Each concern stays small and reusable, and the
+framework avoids diamond-inheritance pathologies. The cost is a cognitive
+surface of roughly three dozen mixin classes a contributor learns before
+changing one safely; trimming that surface is future work, not a current
+defect.
+
+### 4. The component registry is the extensibility substrate
+
+Models, optimizers, data handlers, and other components are looked up by name
+through a single generic `Registry[T]` exposed via the `R` facade
+(`core/registries.py`), and third-party code extends the framework by
+registering against it through Python entry points
+(`model_manifest()` being the model-facing form). The framework grows new
+capabilities without `core/` changing, and the plugin contract is uniform
+across component types. The contribution model is plugins-first
+(GOVERNANCE.md §3): new model integrations default to independent packages,
+including their typed configuration
+([ADR-0002](0002-plugins-may-ship-typed-config.md)).
+
+### 5. External model engines are compiled separately and run as subprocesses
+
+SUMMA, FUSE, NGEN, MESH, and the other compiled engines are not Python; the
+framework builds them through a binary install step and invokes them as
+external processes. The canonical, peer-reviewed implementation of each
+hydrological model is used directly, with no Python re-implementation that
+would itself need re-validation against the original. The accepted costs are
+that the compile step is build engineering in its own right (own CI
+workflows, system-dependency registry, multi-platform packaging), and that
+subprocess failures must surface clearly — a silent model crash is the
+worst-case failure mode of this decision, which is why non-zero exits are
+logged at WARNING/ERROR with the log path rather than swallowed.
+
+### 6. Multiple installation methods are offered deliberately
+
+The seven offered install commands collapse into four maintained families —
+the pip family (pip, pipx, uv, uv tool), conda, npm prebuilt binaries, and a
+source/bootstrap build — to meet users where they already are, on both HPC
+systems and laptops. pip is the primary documented path. The cost is that
+every family must keep working, which is why each is exercised by its own CI
+workflow (`install-methods.yml`, `install-validate.yml`,
+`install-validate-arm.yml`, `npm-multidistro.yml`) rather than validated by
+hand.
+
+## Consequences
+
+- These six decisions are the baseline; later ADRs record refinements on top
+  of them rather than re-deciding them.
+- They are not immutable physics — any of them can be superseded by a future
+  ADR — but a change to one of them is a major architectural event and should
+  be treated as such.
+
+## References
+
+- `docs/source/architecture.rst` — the full architecture guide
+- `ARCHITECTURE.md` — the at-a-glance summary at the repository root
+- GOVERNANCE.md §3 (plugins-first), §4 (interface stewardship)

--- a/docs/adr/0001-remove-legacy-registry-shims.md
+++ b/docs/adr/0001-remove-legacy-registry-shims.md
@@ -34,10 +34,17 @@ two categories that this decision does **not** remove:
    (e.g. `ParameterBoundsRegistry`, `ObjectiveRegistry`, `ForcingAdapterRegistry`,
    the `data/` `BaseRegistry` hierarchy). These were never compatibility shims.
 2. **Thin documented facades over `R`** that exist for ergonomics, not
-   backward compatibility — e.g. `BuildInstructionsRegistry.register(...)` is
-   the supported public spelling of `R.build_instructions.add(...)` and is used
-   by infrastructure tooling. These forward to the unified registry by design
-   and remain supported.
+   backward compatibility — e.g. `BuildInstructionsRegistry` forwards to
+   `R.build_instructions` by design and remains supported.
+
+For both categories the supported surface is split by direction: the
+**lookup/factory API** (`get_adapter`, `get_handler`, `get_strategy`,
+`get_all_instructions`, …) is first-class and stays; **registration** happens
+only through `R.*.add()` / `model_manifest()`. The residual `register*`
+methods on these classes therefore emit `DeprecationWarning` and exist solely
+so out-of-tree plugins written against the old spelling keep working — all
+in-tree registration was moved to the `R` facade (PR #211). They may be
+deleted in any pre-1.0 release.
 
 ## Consequences
 
@@ -53,4 +60,5 @@ two categories that this decision does **not** remove:
 ## References
 
 - PR #138 — registry migration Phase A (shim deletion)
+- PR #211 — migration of all remaining in-tree registrations to the `R` facade
 - GOVERNANCE.md §4 — Interface Stewardship

--- a/docs/adr/0001-remove-legacy-registry-shims.md
+++ b/docs/adr/0001-remove-legacy-registry-shims.md
@@ -1,0 +1,56 @@
+# ADR-0001: Legacy registry shim classes are removed before 1.0
+
+- **Status:** Accepted
+- **Date:** 2026-06-05
+- **Related:** GOVERNANCE.md §4
+
+## Context
+
+SYMFLUENCE historically exposed per-domain registry classes
+(`ModelRegistry`, `OptimizerRegistry`, `ComponentRegistry`, `ConfigRegistry`,
+`ResultExtractorRegistry`, `PlotterRegistry`) and registration decorators such
+as `@ModelRegistry.register(...)`. These were superseded by a single unified
+registry facade, `R` (e.g. `R.runners.add(...)`, `R.config_schemas.get(...)`).
+
+During the migration the old class names were briefly retained as thin
+forwarding shims so that in-tree and external code could be ported
+incrementally. Before 1.0 the project had to commit one way or the other: are
+these shims removed in a named release, or kept indefinitely? The concern is
+that "indefinitely" promotes the legacy class names to permanent public API,
+after which semantic versioning forbids removing them without a major-version
+break.
+
+## Decision
+
+The legacy forwarding shims are **removed before the 1.0 release**, not kept.
+The unified `R` facade and the `model_manifest()` entry point are the only
+supported registration surface at 1.0.
+
+This decision is already implemented: the forwarding shim classes were deleted
+in PR #138. Names that still end in `*Registry` in the source tree fall into
+two categories that this decision does **not** remove:
+
+1. **First-class domain registries** with their own purpose-built API
+   (e.g. `ParameterBoundsRegistry`, `ObjectiveRegistry`, `ForcingAdapterRegistry`,
+   the `data/` `BaseRegistry` hierarchy). These were never compatibility shims.
+2. **Thin documented facades over `R`** that exist for ergonomics, not
+   backward compatibility — e.g. `BuildInstructionsRegistry.register(...)` is
+   the supported public spelling of `R.build_instructions.add(...)` and is used
+   by infrastructure tooling. These forward to the unified registry by design
+   and remain supported.
+
+## Consequences
+
+- The 1.0 public API does not include the legacy `*Registry.register`
+  decorators. Plugins and core code register through `model_manifest()` and
+  `R.*`. Removing the shims pre-1.0 keeps them out of the SemVer surface.
+- Any remaining external code using the old decorators must migrate before
+  upgrading to 1.0. The migration is mechanical (decorator rename); the JAX
+  plugin packages were ported as reference examples.
+- This is consistent with GOVERNANCE.md §4.2: a breaking interface change made
+  *before* 1.0 is permitted under pre-1.0 SemVer without a deprecation cycle.
+
+## References
+
+- PR #138 — registry migration Phase A (shim deletion)
+- GOVERNANCE.md §4 — Interface Stewardship

--- a/docs/adr/0001-remove-legacy-registry-shims.md
+++ b/docs/adr/0001-remove-legacy-registry-shims.md
@@ -41,10 +41,10 @@ For both categories the supported surface is split by direction: the
 **lookup/factory API** (`get_adapter`, `get_handler`, `get_strategy`,
 `get_all_instructions`, …) is first-class and stays; **registration** happens
 only through `R.*.add()` / `model_manifest()`. The residual `register*`
-methods on these classes therefore emit `DeprecationWarning` and exist solely
-so out-of-tree plugins written against the old spelling keep working — all
-in-tree registration was moved to the `R` facade (PR #211). They may be
-deleted in any pre-1.0 release.
+methods on these classes briefly survived as `DeprecationWarning` shims for
+out-of-tree plugins written against the old spelling — all in-tree
+registration was moved to the `R` facade (PR #211) — and were then removed
+entirely (commit `3aa52291`). No deprecated registration spelling remains.
 
 ## Consequences
 

--- a/docs/adr/0002-plugins-may-ship-typed-config.md
+++ b/docs/adr/0002-plugins-may-ship-typed-config.md
@@ -1,0 +1,63 @@
+# ADR-0002: Plugins may ship their own typed configuration schema
+
+- **Status:** Accepted
+- **Date:** 2026-06-05
+- **Related:** [ADR-0000](0000-initial-architecture-decisions.md) (decisions 1 and 4), GOVERNANCE.md §3
+
+## Context
+
+Until mid-2026, runners and post-processors were pluggable but typed
+configuration was not. The top-level configuration model named only the models
+the framework already knew about, and `R.config_schemas` — where a plugin would
+register a typed Pydantic schema — was not read by the core validation
+pipeline. A third-party plugin could therefore register a runner but could not
+supply a typed config schema that participated in the validated config tree; it
+had to fall back on untyped pass-through keys.
+
+That asymmetry contradicted the project's own plugins-first contribution model
+(GOVERNANCE.md §3): the documentation promised that a first-class model could
+live in an independent package, but a first-class model includes its typed
+configuration. The question for 1.0 was whether to open the typed-config path
+or to document the closed shape honestly.
+
+## Decision
+
+Typed plugin configuration is **opened before 1.0**. A plugin may register its
+own typed configuration schema and have it participate in the validated config
+tree on equal footing with in-tree models.
+
+This is already implemented in PR #139. A plugin declares its schema through
+`model_manifest(config_schema=...)`; the schema is registered into
+`R.config_schemas`, and the core resolution path
+(`core/config/config_resolution.get_config_schema`) reads it during
+validation. The top-level `ModelConfig` no longer carries a hardcoded
+`Optional[*Config]` field per model — model-specific configuration is resolved
+generically from the registry and re-flattened on serialization so that
+stage-marker hashing stays byte-stable.
+
+Plugins that register only a `config_adapter` (rather than an explicit
+`config_schema`) are bridged automatically: `model_manifest()` registers the
+adapter's `get_config_schema()` into `R.config_schemas`, and adapters whose
+schemas use bare field names plus a `CONFIG_PREFIX` get their flat-key
+transformers derived from the prefix (PR #178). The JAX model plugins work
+through this path with zero plugin-side changes.
+
+## Consequences
+
+- The plugin contract at 1.0 is: **runners, post-processors, and typed
+  configuration schemas are all pluggable.** Plugin documentation should
+  describe typed config as supported.
+- Adding a new in-tree model no longer requires editing the top-level config
+  model — it requires registering a schema, the same path a plugin uses. This
+  removes a class of "registered but unvalidated" drift.
+- `R.config_schemas` is now a consumed registry. A CI guard
+  (`tests/unit/config/test_config_schema_consumed.py`) verifies registered
+  schemas are actually read, so the path cannot silently regress to the closed
+  shape.
+
+## References
+
+- PR #139 — typed-config plumbing; PR #178 — adapter bridging
+- `core/config/config_resolution.py` — `get_config_schema`
+  (re-exported at `models/config_resolution.py`)
+- GOVERNANCE.md §3 (Plugins First), §4.1 (configuration schema keys)

--- a/docs/adr/0003-config-dict-override-is-supported.md
+++ b/docs/adr/0003-config-dict-override-is-supported.md
@@ -1,0 +1,60 @@
+# ADR-0003: `_config_dict_override` is a supported escape hatch
+
+- **Status:** Accepted
+- **Date:** 2026-06-05
+- **Related:** [ADR-0006](0006-config-unknown-keys-warn-by-default.md) (works within the same `extra='allow'` constraint)
+
+## Context
+
+The `ConfigMixin` (`core/mixins/config.py`) provides a setter,
+`_config_dict_override`, that lets code replace configuration values *after*
+the configuration has been validated and frozen. On its face this looks like
+an accidental bypass of the "configuration is immutable once validated"
+guarantee, and the question arose whether it should be closed.
+
+On inspection the hook has real production callers that depend on it to inject
+model-derived values that are only known after preprocessing:
+
+- `models/fuse/subcatchment_processor.py`
+- `models/summa/config_manager.py`
+
+These are not tests reaching past the validation boundary; they are legitimate
+model-specific steps that compute configuration from data (subcatchment
+structure, SUMMA file manager paths) that cannot exist at initial validation
+time.
+
+## Decision
+
+`_config_dict_override` is a **supported, intentional escape hatch**, not a bug
+to be closed. It is the sanctioned mechanism for injecting values that are only
+knowable after a model-specific preprocessing step has run.
+
+Its contract — and the limits of the commitment this ADR makes:
+
+- It is **internal API** (leading underscore): used by core and in-tree model
+  code, not part of the plugin-facing surface. It may be renamed, narrowed, or
+  replaced by a structured mechanism in a future release without a deprecation
+  cycle, provided the in-tree callers move with it.
+- It applies *after* validation deliberately. Callers are responsible for the
+  validity of values they inject; the immutability guarantee covers the
+  *initial* validated tree, not post-preprocessing derived values.
+- New uses should be rare and model-specific. Prefer expressing configuration
+  in the YAML schema where the value is knowable up front. A growing caller
+  count is the signal to revisit this ADR and design a first-class
+  derived-values mechanism.
+
+## Consequences
+
+- The "immutable once validated" property is scoped precisely: it describes the
+  validated config tree as loaded, not a prohibition on derived-value injection
+  during the pipeline.
+- Because in-tree code and plugins rely on extra/derived keys flowing through
+  the config object, the frozen base config cannot be tightened to reject
+  unrecognized fields wholesale. Unknown-key safety is therefore provided by
+  ingestion-time validation instead — see
+  [ADR-0006](0006-config-unknown-keys-warn-by-default.md).
+
+## References
+
+- `core/mixins/config.py` — `_config_dict_override`
+- Callers: `models/fuse/subcatchment_processor.py`, `models/summa/config_manager.py`

--- a/docs/adr/0004-bundled-agent-human-in-the-loop.md
+++ b/docs/adr/0004-bundled-agent-human-in-the-loop.md
@@ -1,0 +1,43 @@
+# ADR-0004: The bundled AI agent does not push without a human
+
+- **Status:** Accepted
+- **Date:** 2026-06-05
+- **Related:** `docs/security.md` (threat model)
+
+## Context
+
+SYMFLUENCE bundles an AI agent (`agent/`) that can create commits and open pull
+requests. Its push-and-PR path originally defaulted to acting automatically.
+That default is an exploitable surface: an agent that processes repository or
+issue content is exposed to prompt injection, and under that threat an injected
+instruction could trigger a push to a remote with no human in the loop.
+Switching to a human-confirmed default costs essentially nothing in usability.
+
+## Decision
+
+The bundled agent is **human-in-the-loop by default.** Pushing to a remote and
+opening a pull request require an explicit opt-in from the caller; they do not
+happen automatically.
+
+This is implemented in `agent/pr_manager.py`: the push/PR entry point takes
+`auto_push: bool = False`. Autonomous push is available only when a caller
+explicitly passes `auto_push=True`, which is a deliberate, auditable choice
+rather than the default behavior.
+
+## Consequences
+
+- The default-safe posture closes the highest-likelihood prompt-injection
+  path: an injected instruction cannot cause an unattended push because the
+  default does not push.
+- Workflows that genuinely want autonomous PR creation (e.g. a trusted CI
+  context) opt in explicitly at the call site, where the decision is visible in
+  code review.
+- This is a policy commitment, not only a current default: the human-in-the-loop
+  default for outward-facing actions (push, PR) is the intended behavior at 1.0
+  and should not be flipped to autonomous-by-default without a corresponding
+  security review (and a superseding ADR).
+
+## References
+
+- `agent/pr_manager.py` — `auto_push: bool = False`
+- `docs/security.md` — agent trust boundary

--- a/docs/adr/0005-logging-level-policy.md
+++ b/docs/adr/0005-logging-level-policy.md
@@ -1,0 +1,55 @@
+# ADR-0005: Logging-level policy — ERROR is the operational ceiling
+
+- **Status:** Accepted
+- **Date:** 2026-06-05
+
+## Context
+
+Across the source tree, nothing is logged at the `CRITICAL` level. Without a
+written policy, a contributor cannot tell whether that is deliberate — the
+project has no events it considers critical — or whether the level has simply
+not been adopted, and therefore cannot know whether to reach for it. Either
+position is fine; what was missing is the written rule.
+
+## Decision
+
+`ERROR` is the **operational ceiling** for routine logging. It is the level used
+when an operation fails — a model run crashes, a data acquisition fails, a
+metric cannot be computed — and the framework recovers, skips, or surfaces the
+failure while continuing. This is consistent with the framework's resilience
+posture (`except Exception as e: # noqa: BLE001`), where individual failures are
+logged at `ERROR` and the pipeline continues.
+
+`CRITICAL` is **reserved** for the single orchestrator-boundary case where the
+*entire run* is being aborted — i.e. the framework cannot continue at all. It is
+deliberately rare; there are zero `.critical()` calls in the tree today, and a
+contributor should reach for it only at that top-level abort boundary, not for
+an individual component failure (which is `ERROR`).
+
+Level guidance, summarized:
+
+| Level | Use for |
+|-------|---------|
+| `DEBUG` | Diagnostic detail; off by default, surfaced with `--debug` |
+| `INFO` | Normal pipeline progress and milestones |
+| `WARNING` | Recoverable anomaly; degraded but functioning |
+| `ERROR` | An operation failed; framework recovers/skips and continues |
+| `CRITICAL` | The whole run is aborting; framework cannot continue (rare) |
+
+## Consequences
+
+- Contributors have an explicit rule: a failed model run or data step is
+  `ERROR`, not `CRITICAL`. `CRITICAL` is not "a bad ERROR"; it marks total
+  abort.
+- The current absence of `.critical()` calls is correct under this policy, not
+  an oversight — the codebase's failure modes are designed to be recoverable
+  and logged at `ERROR`.
+- If a genuine whole-run abort boundary is added later (e.g. a top-level
+  orchestrator catch that re-raises after cleanup), that is the appropriate and
+  expected place for a single `CRITICAL` line.
+
+## References
+
+- CLAUDE.md — resilience logging convention (`# noqa: BLE001`)
+- `--debug` flag — surfaces `DEBUG`-level detail when diagnosing a run
+- CONTRIBUTING.md §5 — logging-levels guidance for contributors

--- a/docs/adr/0006-config-unknown-keys-warn-by-default.md
+++ b/docs/adr/0006-config-unknown-keys-warn-by-default.md
@@ -1,0 +1,77 @@
+# ADR-0006: Unknown configuration keys — warn by default, strict opt-in
+
+- **Status:** Accepted
+- **Date:** 2026-06-05 (status updated 2026-06-10)
+- **Related:** [ADR-0003](0003-config-dict-override-is-supported.md) (the `extra='allow'` constraint this works within)
+
+## Context
+
+SYMFLUENCE configs are flat, uppercase YAML (`DOMAIN_NAME: ...`). The base
+configuration models accept unrecognized fields (`extra='allow'`), so a typo
+such as `HYDROLOGICAL_MDOEL` is accepted rather than flagged, which can let a
+setting silently take no effect — the most common class of configuration
+mistake a user encounters.
+
+The obvious fix — flipping the Pydantic models to `extra='forbid'` — is the
+wrong tool here for two reasons:
+
+1. It acts at the **post flat→nested layer**, after key transformation, so it
+   reports confusing internal names rather than the user's flat key.
+2. It would reject **legitimate plugin keys** and the post-validation
+   `_config_dict_override` path ([ADR-0003](0003-config-dict-override-is-supported.md)),
+   both of which deliberately rely on extra keys flowing through.
+
+## Decision
+
+Keep the base config `extra='allow'`, and instead **validate raw flat keys at
+ingestion** against an allowlist that unions every core alias, every registered
+plugin schema (`R.config_schemas`), and every legacy alias. The *response* is
+tiered, not the allowlist:
+
+- **Warn by default** — each unknown key is logged with a "did you mean?"
+  suggestion (`difflib`), so existing configs keep loading unchanged. This is
+  the 1.0 default for user configs.
+- **Strict mode** — raise `ConfigValidationError` instead, enabled per-config
+  via a `STRICT_CONFIG` key or globally via `SYMFLUENCE_STRICT_CONFIG`.
+- **Escape hatch** — genuinely freeform keys are listed under
+  `ALLOW_UNKNOWN_KEYS` to suppress the warning/error without registering a
+  schema.
+
+This is implemented in `core/config/key_validation.py` and wired into the load
+path at `core/config/factories.from_file_factory` (warns by default, escalates
+under strict). The decision for 1.0 is to **keep warn-by-default for user
+configs** rather than make strict the global default, because strict-by-default
+could break configs and plugins in the wild that currently rely on silent
+extras.
+
+## Consequences
+
+- The silent-typo concern is addressed: a misspelled key is surfaced with a
+  suggestion at load time, at the correct (flat) layer, without breaking
+  plugins or the `_config_dict_override` hook.
+- `extra='forbid'` is **explicitly not adopted** for the base config; the
+  ingestion validator is the mechanism.
+- One known limitation: the validator runs on **flat** configs only — nested
+  configs bypass it (`from_file_factory` validates in the flat branch). Nested
+  configs get their safety from the typed tree itself; extending key validation
+  to the nested path is possible future work.
+- **The project dogfoods strict mode on its own shipped configs.** After an
+  allowlist-completion pass (125 directly-read flat keys registered as
+  `RECOGNIZED_FLAT_KEYS`; the widespread legacy spelling `TARGET_METRIC`
+  normalized to `OPTIMIZATION_METRIC`; plugin-adapter keys bridged via the
+  `CONFIG_PREFIX` fallback; verified-dead keys stripped from shipped templates
+  and examples), strict validation is **enforced in CI and pre-commit** for the
+  maintained shipped configs (`scripts/check_shipped_configs_strict.py`,
+  `tests/unit/config/test_shipped_configs_strict.py`). Kitchen-sink
+  documentation templates and the research-archive example configs are
+  explicitly exempted.
+- Whether `STRICT_CONFIG` becomes the **user-facing default** in a later
+  release is an open follow-on; flipping it is a behavior change for existing
+  user configs and warrants its own (superseding) ADR.
+
+## References
+
+- `core/config/key_validation.py`; caller `core/config/factories.py:from_file_factory`
+- `core/config/legacy_aliases.py` — `RECOGNIZED_FLAT_KEYS`, `NORMALIZATION_ALIASES`
+- `scripts/check_shipped_configs_strict.py`; `tests/unit/config/test_shipped_configs_strict.py`
+- `tests/unit/config/test_key_validation.py`

--- a/docs/adr/0007-gui-single-user-localhost.md
+++ b/docs/adr/0007-gui-single-user-localhost.md
@@ -1,0 +1,52 @@
+# ADR-0007: The web GUI is a single-user localhost tool
+
+- **Status:** Accepted
+- **Date:** 2026-06-05
+
+## Context
+
+SYMFLUENCE ships a Panel/Param web GUI (`gui/`). Its intended deployment
+context was unstated: is it meant to run only on a single user's own machine
+(localhost), or might it run on a shared HPC login node where other users are
+present? The answer determines whether authentication is a 1.0 requirement or
+a later enhancement.
+
+The code already encodes a localhost-first stance: `gui/server.py` binds
+`127.0.0.1` by default; binding to a non-loopback address (e.g. `0.0.0.0`) is an
+explicit opt-in that emits a loud warning and restricts the websocket origin to
+the bound host:port (`is_loopback_address` helper). There is no authentication
+layer.
+
+## Decision
+
+The web GUI is a **single-user, localhost tool** at 1.0. This is the stated,
+supported deployment context.
+
+- The default and supported configuration is loopback (`127.0.0.1`).
+- Binding to a non-loopback interface remains an **advanced, opt-in** action,
+  unauthenticated and at the operator's own risk, surfaced by the existing
+  warning. It is not a supported multi-tenant deployment.
+- **Authentication is not a 1.0 requirement.** Multi-user / shared-node
+  deployment with real auth is deferred past 1.0 (it would be net-new feature
+  work, and the single-user model covers the framework's intended use).
+
+The deferral is scoped, not permanent: if the GUI's role grows (e.g. a hosted
+or shared deployment becomes a real use case), authentication becomes a
+prerequisite for that work, recorded in a superseding ADR — not an optional
+add-on.
+
+## Consequences
+
+- Documentation should state plainly that the GUI is for local single-user use
+  and that exposing it on a network is unsupported and unauthenticated. Users
+  who need shared access are responsible for fronting it with their own
+  authenticating proxy.
+- The loopback default plus opt-in warning is the enforced boundary; changes
+  that weaken it (e.g. defaulting to `0.0.0.0`) are security regressions, not
+  configuration choices.
+
+## References
+
+- `gui/server.py` — `127.0.0.1` default, opt-in non-loopback with warning
+- `is_loopback_address` helper; `tests/unit/gui/test_server_bind.py`
+- `docs/security.md` — network surface

--- a/docs/adr/0008-coverage-gate-raise-and-ratchet.md
+++ b/docs/adr/0008-coverage-gate-raise-and-ratchet.md
@@ -1,0 +1,55 @@
+# ADR-0008: Test-coverage policy — ratcheted global gate plus a core-spine gate
+
+- **Status:** Accepted
+- **Date:** 2026-06-05 (updated 2026-06-10: core-spine gate landed)
+
+## Context
+
+The project enforces a flat coverage floor in CI. A single project-wide number
+lets strong coverage in one area average out weak coverage elsewhere, which can
+hide a regression in the part of the codebase that matters most (`core/`). The
+floor also sat at 15% while measured unit-test coverage was ~29%, so the gate
+was not doing real work.
+
+Roughly 700 modules (model adapters, data handlers, geospatial processors)
+need external model binaries or live services to exercise and cannot run in CI
+at all, which is why a project-wide number is structurally low and why the
+testable core deserves its own bar.
+
+## Decision
+
+Coverage is enforced by **two gates, both one-way ratchets by policy** (raise
+as coverage improves, never lower):
+
+1. **Global gate:** `--cov-fail-under` / `fail_under` raised from 15 to **25**
+   in `ci.yml`, `cross-platform.yml`, and `pyproject.toml` together, set ~4
+   points below measured reality (~29%) so the gate binds without flaking on
+   parallel-run variance.
+2. **Core-spine gate:** the CI-testable core (config parsing, registry, path
+   resolution, mixins) gets its own stricter bar — `coverage report
+   --include='src/symfluence/core/*' --fail-under=80`, with
+   instrumentation-only modules (profiling, npm packaging) omitted. This is
+   the per-package target that prevents weak coverage elsewhere from being
+   masked by, or masking, the core.
+
+Whether to additionally *enforce* the ratchet mechanically (a CI step diffing
+`coverage.json` against a committed baseline) remains deferred; the manual
+floors are the 1.0 mechanism.
+
+## Consequences
+
+- Contributions cannot lower either floor, which is the property that matters
+  (preventing silent regression), and the part of the codebase every model
+  depends on is held to a meaningfully higher bar than the binary-gated long
+  tail.
+- Both gates start at today's reality, not an aspiration, and are tightened
+  over time as coverage grows. Raising a floor is a routine change; lowering
+  one requires revisiting this ADR.
+- Extending per-package gates beyond `core/` (e.g. `optimization/`,
+  `data/`) is available follow-on work using the same pattern.
+
+## References
+
+- `pyproject.toml` (`fail_under = 25`)
+- `.github/workflows/ci.yml`, `.github/workflows/cross-platform.yml` —
+  `--cov-fail-under=25` and the "Core coverage gate" step (`--fail-under=80`)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,44 @@
+# Architecture Decision Records
+
+This directory records significant architecture and policy decisions for
+SYMFLUENCE as short, dated documents. An ADR captures the *context* a decision
+was made in, the *decision* itself, and its *consequences*, so that a choice
+which is easy to make once and easy to forget later remains legible to future
+contributors.
+
+ADRs are immutable once accepted. A decision is changed not by editing its ADR
+but by adding a new ADR that supersedes it; the old record stays in place with
+its status updated to `Superseded by ADR-XXXX`. This keeps the history of *why*
+intact rather than overwriting it.
+
+## When to write one
+
+Write an ADR when a decision (a) affects a stable interface or public contract
+(see [GOVERNANCE.md](../../GOVERNANCE.md) §4), (b) sets a project-wide policy a
+contributor could otherwise reasonably guess wrong, or (c) resolves a question
+that has surfaced more than once. Routine bug fixes and local implementation
+choices do not need one.
+
+## Format
+
+Each ADR follows a light [MADR](https://adr.github.io/madr/)-style template:
+a status line, **Context**, **Decision**, **Consequences**, and **References**.
+Keep them short — an ADR is a record, not a design document.
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0000](0000-initial-architecture-decisions.md) | Initial architecture decisions (recorded retroactively) | Accepted |
+| [0001](0001-remove-legacy-registry-shims.md) | Legacy registry shim classes are removed before 1.0 | Accepted |
+| [0002](0002-plugins-may-ship-typed-config.md) | Plugins may ship their own typed configuration schema | Accepted |
+| [0003](0003-config-dict-override-is-supported.md) | `_config_dict_override` is a supported escape hatch | Accepted |
+| [0004](0004-bundled-agent-human-in-the-loop.md) | The bundled AI agent does not push without a human | Accepted |
+| [0005](0005-logging-level-policy.md) | Logging-level policy: ERROR is the operational ceiling | Accepted |
+| [0006](0006-config-unknown-keys-warn-by-default.md) | Unknown config keys: warn by default, strict opt-in | Accepted |
+| [0007](0007-gui-single-user-localhost.md) | The web GUI is a single-user localhost tool | Accepted |
+| [0008](0008-coverage-gate-raise-and-ratchet.md) | Coverage policy: ratcheted global gate plus core-spine gate | Accepted |
+
+ADR-0000 records the baseline decisions the codebase was built on, written
+down retroactively when the ADR practice was adopted; ADR-0001 onward record
+decisions made (or made explicit) ahead of the 1.0 release.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,119 @@
+# SYMFLUENCE security posture and threat model
+
+This document describes what SYMFLUENCE trusts, where the trust boundaries
+are, and what protects each one. It complements
+[`.github/SECURITY.md`](../.github/SECURITY.md), which covers how to report a
+vulnerability privately.
+
+## Deployment context
+
+SYMFLUENCE is a research framework run by a single user on their own machine
+or HPC account, against data directories they own. It is not a network
+service: nothing listens on a socket by default except the optional web GUI,
+which binds loopback only
+([ADR-0007](adr/0007-gui-single-user-localhost.md)). Multi-tenant or hosted
+deployment is out of scope and unsupported.
+
+## The most important boundary: configuration is trusted input
+
+A SYMFLUENCE configuration file controls which executables the framework
+builds and runs and where it reads and writes data. **A configuration from an
+untrusted source must be treated as code**, exactly like a Makefile or a CI
+workflow file: review it before running it. The framework validates configs
+for *correctness* (typed Pydantic tree, unknown-key warnings — see
+[ADR-0006](adr/0006-config-unknown-keys-warn-by-default.md)), not for
+*malice*; that is by design, because the user running a config and the author
+of that config are normally the same person.
+
+## Trust boundaries and mitigations
+
+### 1. Configuration files (YAML)
+
+- Every YAML parse site uses `yaml.safe_load`; `yaml.load` (which can
+  instantiate arbitrary Python objects) does not appear in the tree.
+- The dynamic-execution builtins `eval`, `exec`, and `os.system` do not appear
+  anywhere in the source tree.
+- Configs are validated into a typed Pydantic tree; unrecognized keys are
+  warned about at ingestion with a "did you mean?" suggestion, with an
+  opt-in strict mode (`STRICT_CONFIG` / `SYMFLUENCE_STRICT_CONFIG`) that the
+  project's own shipped configs are held to in CI.
+
+### 2. Downloaded scientific data
+
+Forcing, attribute, and observation data are fetched from remote services
+(ERA5, SoilGrids, USGS, …) over HTTPS through configured `requests.Session`
+objects with retry logic. Credentials are read from environment variables
+only; there are no hardcoded secrets, and the logging layer masks sensitive
+fields.
+
+Downloaded archives are extracted through the hardened helpers in
+`core/archive_extraction.py` (path-traversal-safe tar and zip extraction);
+no raw `extractall` call sites remain. Residual risk: scientific file formats
+(netCDF/HDF5/GeoTIFF) are parsed by compiled third-party libraries, so a
+malicious data file could target a parser vulnerability — mitigated by
+pinning those libraries via lockfiles (below) and by the deployment context
+(users fetch from the canonical scientific providers).
+
+### 3. Compiled model engines
+
+Hydrological model binaries (SUMMA, FUSE, NGEN, …) are built from pinned
+upstream sources by the framework's binary install step and invoked as
+subprocesses with framework-constructed argument lists. `shell=True` is
+confined to a small number of audited sites where shell semantics are
+genuinely required (notably HPC `module load`, which is a shell function);
+those sites quote tokens and are documented inline. Model engines read and
+write inside the user's domain directory; they run with the user's own
+privileges, as any locally built scientific code does.
+
+### 4. Machine-learning checkpoints
+
+All `torch.load` call sites pass `weights_only=True`, closing the
+arbitrary-object-deserialization path (CVE-2025-32434 lineage) for model
+checkpoints. Treat third-party checkpoint files with the same caution as any
+downloaded binary regardless.
+
+### 5. The bundled AI agent
+
+The agent (`agent/`) processes repository content, which makes prompt
+injection part of its threat model: text in a repo could try to instruct the
+agent to take outward-facing actions. Mitigations: pushing and opening pull
+requests are **off by default** and require explicit caller opt-in
+([ADR-0004](adr/0004-bundled-agent-human-in-the-loop.md)), and file reads are
+checked against a deny-list (`.git/`, `.env`, key material) with
+directory-prefix and glob matching. Anyone wiring the agent into automation
+should keep a human review between agent output and anything that publishes.
+
+### 6. Network surface
+
+- The web GUI binds `127.0.0.1` by default; a non-loopback bind is an
+  explicit, warned, unauthenticated opt-in and is not a supported deployment
+  ([ADR-0007](adr/0007-gui-single-user-localhost.md)).
+- No other component listens on the network. The Delft-FEWS adapter is
+  file-based (PI XML exchange).
+
+### 7. Supply chain
+
+- `uv.lock` pins the full PyPI dependency tree with SHA-256 hashes;
+  `pixi.lock` does the same for the conda ecosystem. A substituted upstream
+  package fails at install time rather than being silently pulled in.
+- Every source file carries an SPDX license header; `bandit` runs in
+  pre-commit and CI alongside ruff/mypy, and a broad-exception guard keeps
+  error handling auditable.
+
+## Residual risks and non-goals
+
+- **Untrusted configs are not sandboxed** (see above) — running one is
+  equivalent to running a script.
+- **Parser vulnerabilities in scientific libraries** are mitigated by
+  pinning, not eliminated.
+- **No SBOM or artifact-provenance attestation is published yet**; the
+  lockfiles are the current supply-chain record. Publishing provenance for
+  the prebuilt binary distributions is future work.
+- **The GUI has no authentication** because shared deployment is out of
+  scope; that boundary is revisited (with a superseding ADR) if the scope
+  changes.
+
+## Reporting
+
+Found something? Please follow the private reporting process in
+[`.github/SECURITY.md`](../.github/SECURITY.md) — do not open a public issue.


### PR DESCRIPTION
Closes the last substantive item from the RTI architectural review (Tier 3, item 25): the missing top-level architecture documentation, an ADR practice, and a published threat model. This is consolidation of existing material plus the decision records — not new design.

## What's in here

### `ARCHITECTURE.md` (new, repo root)
One-page orientation: the five-step workflow, the three-layer source structure with the enforced core-layering rule (`scripts/check_core_layering.py`), the six baseline architectural decisions, extension points, and a related-documents table linking the Sphinx architecture guide, the ADRs, the threat model, and governance docs.

### `docs/adr/` (new)
MADR-lite Architecture Decision Records — immutable once accepted, superseded rather than edited:

- **ADR-0000** — the six baseline decisions the codebase was built on (typed config as the contract, manager orchestration, mixins, registry substrate, subprocess model engines, deliberate multi-method installation), recorded retroactively with their costs stated.
- **ADR-0001..0008** — the pre-1.0 policy decisions: legacy registry shims removed; plugins may ship typed config; `_config_dict_override` is a supported (internal, revisitable) escape hatch; the bundled agent never pushes without a human; ERROR is the logging ceiling with CRITICAL reserved for whole-run abort; unknown config keys warn by default with strict opt-in; the GUI is a single-user localhost tool; coverage policy is a ratcheted 25% global gate plus the 80% core-spine gate.

Every factual claim was re-verified against the current tree before landing (zero `.critical()` calls, override callers, shim absence, consumed-schema guard, gate values in all three synced locations). ADR-0006 and ADR-0008 were updated from their original drafts to reflect work that has since merged: strict-config validation is now dogfooded and enforced on the maintained shipped configs, and the core-spine coverage gate exists in both CI workflows. The records are written self-contained — each states its own context rather than referencing external review material.

### `docs/security.md` (new)
The threat model: deployment context (single-user research tool, nothing listening by default), the headline boundary stated plainly — **a configuration file is trusted input; an untrusted config must be treated as code** — and seven trust boundaries with their verified mitigations (safe_load-only YAML and no eval/exec/os.system in the tree, hardened archive extraction with no raw `extractall` remaining, `weights_only=True` on all `torch.load` sites, agent push off-by-default with a read deny-list, loopback-only GUI, SHA-256-pinned lockfiles). Residual risks and non-goals are listed rather than implied, including the absence of SBOM/provenance publication.

### `GOVERNANCE.md` / `CONTRIBUTING.md` (pointer edits)
GOVERNANCE gains §4.5 introducing the ADR register; CONTRIBUTING gains short pointers where contributors actually look — plugin typed config in §3, logging levels in §5, coverage ratchet and strict-config testing in §5, shim removal in the versioning section.

## Verification
All relative links across the 14 touched files resolve (scripted check); section references verified against the actual headings; pre-commit hooks pass. Docs-only — no source changes.

> Repo and code assistance from [Claude](https://claude.ai) (Anthropic).