### PR TITLE
refactor(registry): finish item-9 tail — migrate all remaining legacy decorators to R facade

### DIFF
--- a/src/symfluence/cli/external_tools_config.py
+++ b/src/symfluence/cli/external_tools_config.py
@@ -10,10 +10,10 @@ This module provides build configurations for external tools required by SYMFLUE
 
 Architecture:
     - Infrastructure tools (sundials, taudem, gistool, datatool, ngiab) are defined
-      directly in this file and registered via BuildInstructionsRegistry.register_instructions()
+      directly in this file and registered via R.build_instructions.add()
     - Model-specific tools (summa, fuse, mizuroute, etc.) are defined in their
       respective model directories (e.g., src/symfluence/models/summa/build_instructions.py)
-      and registered via @BuildInstructionsRegistry.register() decorator
+      and registered via the @R.build_instructions.add() decorator
 
 Public API:
     get_external_tools_definitions() -> Dict[str, Dict[str, Any]]
@@ -42,6 +42,8 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
+from symfluence.core.registries import R
+
 from .external_tools_build_commands import (
     ENZYME_BUILD_COMMAND,
     OPENFEWS_BUILD_COMMAND,
@@ -59,7 +61,7 @@ def _register_sundials(common_env: str) -> None:
     # ================================================================
     # SUNDIALS - Solver Library (Install First - Required by SUMMA)
     # ================================================================
-    BuildInstructionsRegistry.register_instructions('sundials', {
+    R.build_instructions.add('sundials', {
         'description': 'SUNDIALS - SUite of Nonlinear and DIfferential/ALgebraic equation Solvers',
         'config_path_key': 'SUNDIALS_INSTALL_PATH',
         'config_exe_key': 'SUNDIALS_DIR',
@@ -91,7 +93,7 @@ def _register_taudem(common_env: str) -> None:
     # ================================================================
     # TauDEM - Terrain Analysis
     # ================================================================
-    BuildInstructionsRegistry.register_instructions('taudem', {
+    R.build_instructions.add('taudem', {
         'description': 'Terrain Analysis Using Digital Elevation Models',
         'config_path_key': 'TAUDEM_INSTALL_PATH',
         'config_exe_key': 'TAUDEM_EXE',
@@ -121,7 +123,7 @@ def _register_gistool() -> None:
     # ================================================================
     # GIStool - Geospatial Data Extraction
     # ================================================================
-    BuildInstructionsRegistry.register_instructions('gistool', {
+    R.build_instructions.add('gistool', {
         'description': 'Geospatial data extraction and processing tool',
         'config_path_key': 'INSTALL_PATH_GISTOOL',
         'config_exe_key': 'EXE_NAME_GISTOOL',
@@ -150,7 +152,7 @@ def _register_datatool() -> None:
     # ================================================================
     # Datatool - Meteorological Data Processing
     # ================================================================
-    BuildInstructionsRegistry.register_instructions('datatool', {
+    R.build_instructions.add('datatool', {
         'description': 'Meteorological data extraction and processing tool',
         'config_path_key': 'DATATOOL_PATH',
         'config_exe_key': 'DATATOOL_SCRIPT',
@@ -179,7 +181,7 @@ def _register_openfews() -> None:
     # ================================================================
     # openFEWS - Delft-FEWS Flood Early Warning System
     # ================================================================
-    BuildInstructionsRegistry.register_instructions('openfews', {
+    R.build_instructions.add('openfews', {
         'description': 'openFEWS - Delft Flood Early Warning System (open-source distribution)',
         'config_path_key': 'OPENFEWS_INSTALL_PATH',
         'config_exe_key': 'OPENFEWS_EXE',
@@ -206,7 +208,7 @@ def _register_ngiab() -> None:
     # ================================================================
     # NGIAB - NextGen In A Box
     # ================================================================
-    BuildInstructionsRegistry.register_instructions('ngiab', {
+    R.build_instructions.add('ngiab', {
         'description': 'NextGen In A Box - Container-based ngen deployment',
         'config_path_key': 'NGIAB_INSTALL_PATH',
         'config_exe_key': 'NGIAB_SCRIPT',
@@ -268,7 +270,7 @@ def _register_enzyme() -> None:
     # ================================================================
     # Enzyme AD - Automatic Differentiation (used by cFUSE)
     # ================================================================
-    BuildInstructionsRegistry.register_instructions('enzyme', {
+    R.build_instructions.add('enzyme', {
         'description': 'Enzyme AD - Automatic Differentiation via LLVM',
         'config_path_key': None,
         'config_exe_key': None,
@@ -361,7 +363,7 @@ def _load_build_module_directly(module_name: str, pkg_root: object) -> None:
         mod = importlib.util.module_from_spec(spec)
         sys.modules[module_name] = mod
         spec.loader.exec_module(mod)
-        # The @BuildInstructionsRegistry.register decorator has now fired.
+        # The @R.build_instructions.add decorator has now fired.
 
     finally:
         # Restore original sys.modules state for parent packages so that

--- a/src/symfluence/cli/preset_registry.py
+++ b/src/symfluence/cli/preset_registry.py
@@ -26,11 +26,12 @@ class PresetRegistry:
     """
     Registry for model-specific initialization presets.
 
-    Models register their presets using the @register_preset decorator,
-    enabling dynamic discovery without hardcoding preset definitions centrally.
+    Deprecated delegation shim: presets now register via the unified
+    registry (``@R.presets.add('fuse-basic')``); lookups here read from
+    ``R.presets``.
 
     Example:
-        >>> @PresetRegistry.register_preset('fuse-basic')
+        >>> @R.presets.add('fuse-basic')
         >>> def fuse_basic_preset():
         ...     return {
         ...         'description': 'Basic FUSE setup',

--- a/src/symfluence/data/acquisition/handlers/aorc.py
+++ b/src/symfluence/data/acquisition/handlers/aorc.py
@@ -29,8 +29,9 @@ import pandas as pd
 import s3fs
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 # NWM Lambert Conformal Conic projection string (from Zarr metadata)
 _NWM_PROJ4 = (
@@ -62,7 +63,7 @@ _NWM_ZARR_VARNAMES = {
 _NWM_MAX_YEAR = 2023
 
 
-@AcquisitionRegistry.register('AORC')
+@R.acquisition_handlers.add('AORC')
 class AORCAcquirer(BaseAcquisitionHandler):
     """
     Download and process NOAA AORC forcing data from cloud storage.

--- a/src/symfluence/data/acquisition/handlers/aridity_index.py
+++ b/src/symfluence/data/acquisition/handlers/aridity_index.py
@@ -33,9 +33,10 @@ import numpy as np
 import rasterio
 from rasterio.windows import from_bounds
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
 from ..mixins import RetryMixin
-from ..registry import AcquisitionRegistry
 from ..utils import create_robust_session, download_file_streaming
 
 # Figshare direct file download URLs (v3.1)
@@ -61,9 +62,9 @@ _VARIABLES = {
 _DEFAULT_VARIABLES = ['ai', 'et0']
 
 
-@AcquisitionRegistry.register('ARIDITY_INDEX')
-@AcquisitionRegistry.register('GLOBAL_ARIDITY')
-@AcquisitionRegistry.register('CGIAR_ARIDITY')
+@R.acquisition_handlers.add('ARIDITY_INDEX')
+@R.acquisition_handlers.add('GLOBAL_ARIDITY')
+@R.acquisition_handlers.add('CGIAR_ARIDITY')
 class AridityIndexAcquirer(BaseAcquisitionHandler, RetryMixin):
     """
     CGIAR-CSI Global Aridity Index and PET acquisition.

--- a/src/symfluence/data/acquisition/handlers/ascat_sm.py
+++ b/src/symfluence/data/acquisition/handlers/ascat_sm.py
@@ -34,6 +34,8 @@ import shutil
 from pathlib import Path
 from typing import Optional
 
+from symfluence.core.registries import R
+
 try:
     import cdsapi
     HAS_CDSAPI = True
@@ -41,11 +43,10 @@ except ImportError:
     HAS_CDSAPI = False
 
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 
-@AcquisitionRegistry.register('ASCAT')
-@AcquisitionRegistry.register('ASCAT_SM')
+@R.acquisition_handlers.add('ASCAT')
+@R.acquisition_handlers.add('ASCAT_SM')
 class ASCATSMAcquirer(BaseAcquisitionHandler):
     """
     Acquires ASCAT Soil Moisture data via Copernicus CDS.

--- a/src/symfluence/data/acquisition/handlers/bedrock_depth.py
+++ b/src/symfluence/data/acquisition/handlers/bedrock_depth.py
@@ -32,9 +32,10 @@ import numpy as np
 import rasterio
 from rasterio.windows import from_bounds
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
 from ..mixins import RetryMixin
-from ..registry import AcquisitionRegistry
 from ..utils import create_robust_session
 
 # Global GeoTIFF URL (supports HTTP range requests for remote subsetting)
@@ -44,9 +45,9 @@ _GLOBAL_URL = (
 _VSICURL_URL = f"/vsicurl/{_GLOBAL_URL}"
 
 
-@AcquisitionRegistry.register('BEDROCK_DEPTH')
-@AcquisitionRegistry.register('BDTICM')
-@AcquisitionRegistry.register('DEPTH_TO_BEDROCK')
+@R.acquisition_handlers.add('BEDROCK_DEPTH')
+@R.acquisition_handlers.add('BDTICM')
+@R.acquisition_handlers.add('DEPTH_TO_BEDROCK')
 class BedrockDepthAcquirer(BaseAcquisitionHandler, RetryMixin):
     """
     SoilGrids 2017 depth to bedrock acquisition.

--- a/src/symfluence/data/acquisition/handlers/canopy_height.py
+++ b/src/symfluence/data/acquisition/handlers/canopy_height.py
@@ -36,9 +36,10 @@ import rasterio
 import requests
 from rasterio.merge import merge as rio_merge
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
 from ..mixins import RetryMixin
-from ..registry import AcquisitionRegistry
 from ..utils import create_robust_session
 
 # =============================================================================
@@ -48,8 +49,8 @@ from ..utils import create_robust_session
 APPEEARS_BASE = "https://appeears.earthdatacloud.nasa.gov/api"
 
 
-@AcquisitionRegistry.register('GEDI_CANOPY_HEIGHT')
-@AcquisitionRegistry.register('GEDI_L2A')
+@R.acquisition_handlers.add('GEDI_CANOPY_HEIGHT')
+@R.acquisition_handlers.add('GEDI_L2A')
 class GEDICanopyHeightAcquirer(BaseAcquisitionHandler):
     """
     GEDI L2A canopy height acquisition via NASA AppEEARS.
@@ -382,9 +383,9 @@ class GEDICanopyHeightAcquirer(BaseAcquisitionHandler):
 # Meta/WRI Global Canopy Height (Planetary Computer)
 # =============================================================================
 
-@AcquisitionRegistry.register('META_CANOPY_HEIGHT')
-@AcquisitionRegistry.register('WRI_CANOPY_HEIGHT')
-@AcquisitionRegistry.register('META_WRI_CANOPY')
+@R.acquisition_handlers.add('META_CANOPY_HEIGHT')
+@R.acquisition_handlers.add('WRI_CANOPY_HEIGHT')
+@R.acquisition_handlers.add('META_WRI_CANOPY')
 class MetaCanopyHeightAcquirer(BaseAcquisitionHandler, RetryMixin):
     """
     Meta/WRI Global Canopy Height acquisition via Microsoft Planetary Computer.
@@ -604,9 +605,9 @@ class MetaCanopyHeightAcquirer(BaseAcquisitionHandler, RetryMixin):
 # GLAD/UMD Tree Height
 # =============================================================================
 
-@AcquisitionRegistry.register('GLAD_TREE_HEIGHT')
-@AcquisitionRegistry.register('UMD_TREE_HEIGHT')
-@AcquisitionRegistry.register('GLAD_CANOPY')
+@R.acquisition_handlers.add('GLAD_TREE_HEIGHT')
+@R.acquisition_handlers.add('UMD_TREE_HEIGHT')
+@R.acquisition_handlers.add('GLAD_CANOPY')
 class GLADTreeHeightAcquirer(BaseAcquisitionHandler, RetryMixin):
     """
     GLAD/UMD tree height acquisition from University of Maryland.

--- a/src/symfluence/data/acquisition/handlers/cds_datasets.py
+++ b/src/symfluence/data/acquisition/handlers/cds_datasets.py
@@ -24,6 +24,8 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from symfluence.core.registries import R
+
 try:
     import cdsapi
     HAS_CDSAPI = True
@@ -32,7 +34,6 @@ except ImportError:
 
 from ...utils import VariableStandardizer
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 from .era5 import diagnose_cds_credentials
 
 
@@ -1032,7 +1033,7 @@ class CDSRegionalReanalysisHandler(BaseAcquisitionHandler, ABC):
         return T_celsius + 243.5
 
 
-@AcquisitionRegistry.register('CARRA')
+@R.acquisition_handlers.add('CARRA')
 class CARRAAcquirer(CDSRegionalReanalysisHandler):
     """CARRA (Copernicus Arctic Regional Reanalysis) data acquisition handler.
 
@@ -1182,7 +1183,7 @@ class CARRAAcquirer(CDSRegionalReanalysisHandler):
         return T_celsius + 243.5  # Standard Magnus formula
 
 
-@AcquisitionRegistry.register('CERRA')
+@R.acquisition_handlers.add('CERRA')
 class CERRAAcquirer(CDSRegionalReanalysisHandler):
     """CERRA (Copernicus European Regional Reanalysis) data acquisition handler.
 

--- a/src/symfluence/data/acquisition/handlers/chirps.py
+++ b/src/symfluence/data/acquisition/handlers/chirps.py
@@ -30,11 +30,12 @@ from typing import List
 import requests
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 
-@AcquisitionRegistry.register('CHIRPS')
+@R.acquisition_handlers.add('CHIRPS')
 class CHIRPSAcquirer(BaseAcquisitionHandler):
     """
     Acquires CHIRPS precipitation data from UCSB CHG data server.

--- a/src/symfluence/data/acquisition/handlers/cmc_snow.py
+++ b/src/symfluence/data/acquisition/handlers/cmc_snow.py
@@ -37,8 +37,9 @@ from typing import Dict, Optional
 
 import requests
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 # NSIDC data endpoint
 CMC_BASE_URL = (
@@ -50,8 +51,8 @@ CMC_BASE_URL = (
 DEFAULT_SNOW_DENSITY = 200.0
 
 
-@AcquisitionRegistry.register('CMC_SNOW')
-@AcquisitionRegistry.register('CMC')
+@R.acquisition_handlers.add('CMC_SNOW')
+@R.acquisition_handlers.add('CMC')
 class CMCSnowAcquirer(BaseAcquisitionHandler):
     """
     Acquires CMC Daily Snow Depth Analysis data from NSIDC.

--- a/src/symfluence/data/acquisition/handlers/cnes_grgs_tws.py
+++ b/src/symfluence/data/acquisition/handlers/cnes_grgs_tws.py
@@ -20,12 +20,13 @@ import numpy as np
 import pandas as pd
 import requests
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 
-@AcquisitionRegistry.register('CNES_GRGS')
-@AcquisitionRegistry.register('CNES_GRGS_TWS')
+@R.acquisition_handlers.add('CNES_GRGS')
+@R.acquisition_handlers.add('CNES_GRGS_TWS')
 class CNESGRGSAcquirer(BaseAcquisitionHandler):
     """
     Handles CNES/GRGS RL05 GRACE TWS data acquisition.

--- a/src/symfluence/data/acquisition/handlers/conus404.py
+++ b/src/symfluence/data/acquisition/handlers/conus404.py
@@ -16,9 +16,10 @@ import intake
 import numpy as np
 from aiohttp.client_exceptions import ClientError, ClientPayloadError
 
+from symfluence.core.registries import R
+
 from ...utils import VariableStandardizer, create_spatial_mask, find_nearest_grid_point, get_bbox_center
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 
 def _load_with_retry(dataset, logger, max_retries=5, initial_delay=5):
@@ -54,7 +55,7 @@ def _load_with_retry(dataset, logger, max_retries=5, initial_delay=5):
                 raise
 
 
-@AcquisitionRegistry.register('CONUS404')
+@R.acquisition_handlers.add('CONUS404')
 class CONUS404Acquirer(BaseAcquisitionHandler):
     """
     Acquirer for CONUS404 high-resolution regional climate data.

--- a/src/symfluence/data/acquisition/handlers/daymet.py
+++ b/src/symfluence/data/acquisition/handlers/daymet.py
@@ -29,8 +29,9 @@ from urllib.parse import urlparse
 import pandas as pd
 import requests
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 
 class _EarthdataSession(requests.Session):
@@ -74,7 +75,7 @@ class _EarthdataTokenSession(requests.Session):
             prepared_request.headers['Authorization'] = f'Bearer {self._token}'
 
 
-@AcquisitionRegistry.register('DAYMET')
+@R.acquisition_handlers.add('DAYMET')
 class DaymetAcquirer(BaseAcquisitionHandler):
     """
     Handles Daymet climate data acquisition from ORNL DAAC.

--- a/src/symfluence/data/acquisition/handlers/dem.py
+++ b/src/symfluence/data/acquisition/handlers/dem.py
@@ -46,9 +46,10 @@ from rasterio.merge import merge as rio_merge
 from rasterio.transform import from_bounds as rio_from_bounds
 from rasterio.windows import Window, from_bounds
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
 from ..mixins import RetryMixin
-from ..registry import AcquisitionRegistry
 from ..utils import create_robust_session
 
 # =============================================================================
@@ -209,7 +210,7 @@ class _TileDownloadMixin:
 # Copernicus DEM Acquirers (GLO-30 and GLO-90)
 # =============================================================================
 
-@AcquisitionRegistry.register('COPDEM30')
+@R.acquisition_handlers.add('COPDEM30')
 class CopDEM30Acquirer(BaseAcquisitionHandler, RetryMixin, _TileDownloadMixin):
     """Copernicus DEM GLO-30 acquisition via AWS S3 with tile management.
 
@@ -321,7 +322,7 @@ class CopDEM30Acquirer(BaseAcquisitionHandler, RetryMixin, _TileDownloadMixin):
         return out_path
 
 
-@AcquisitionRegistry.register('COPDEM90')
+@R.acquisition_handlers.add('COPDEM90')
 class CopDEM90Acquirer(CopDEM30Acquirer):
     """Copernicus DEM GLO-90 acquisition via AWS S3.
 
@@ -350,7 +351,7 @@ class CopDEM90Acquirer(CopDEM30Acquirer):
 # FABDEM (unchanged)
 # =============================================================================
 
-@AcquisitionRegistry.register('FABDEM')
+@R.acquisition_handlers.add('FABDEM')
 class FABDEMAcquirer(BaseAcquisitionHandler):
     """FABDEM acquisition handler for forest/building-removed elevation data.
 
@@ -454,7 +455,7 @@ class FABDEMAcquirer(BaseAcquisitionHandler):
 # NASADEM Local (unchanged)
 # =============================================================================
 
-@AcquisitionRegistry.register('NASADEM_LOCAL')
+@R.acquisition_handlers.add('NASADEM_LOCAL')
 class NASADEMLocalAcquirer(BaseAcquisitionHandler):
     """NASADEM local tile acquisition for pre-downloaded elevation data.
 
@@ -542,7 +543,7 @@ class NASADEMLocalAcquirer(BaseAcquisitionHandler):
 # SRTM GL1 (30m) via OpenTopography S3
 # =============================================================================
 
-@AcquisitionRegistry.register('SRTM')
+@R.acquisition_handlers.add('SRTM')
 class SRTMAcquirer(BaseAcquisitionHandler, RetryMixin, _TileDownloadMixin):
     """SRTM GL1 (30m) DEM acquisition via OpenTopography S3.
 
@@ -652,7 +653,7 @@ class SRTMAcquirer(BaseAcquisitionHandler, RetryMixin, _TileDownloadMixin):
 # ETOPO 2022 via NOAA OPeNDAP
 # =============================================================================
 
-@AcquisitionRegistry.register('ETOPO2022')
+@R.acquisition_handlers.add('ETOPO2022')
 class ETOPO2022Acquirer(BaseAcquisitionHandler):
     """ETOPO 2022 global relief model acquisition via NOAA OPeNDAP.
 
@@ -784,7 +785,7 @@ class ETOPO2022Acquirer(BaseAcquisitionHandler):
 # Mapzen Terrain Tiles via AWS S3
 # =============================================================================
 
-@AcquisitionRegistry.register('MAPZEN')
+@R.acquisition_handlers.add('MAPZEN')
 class MapzenAcquirer(BaseAcquisitionHandler, RetryMixin, _TileDownloadMixin):
     """Mapzen terrain tile acquisition from AWS S3 Skadi dataset.
 
@@ -906,7 +907,7 @@ class MapzenAcquirer(BaseAcquisitionHandler, RetryMixin, _TileDownloadMixin):
 # ALOS AW3D30 via Microsoft Planetary Computer STAC
 # =============================================================================
 
-@AcquisitionRegistry.register('ALOS')
+@R.acquisition_handlers.add('ALOS')
 class ALOSAcquirer(BaseAcquisitionHandler, RetryMixin, _TileDownloadMixin):
     """ALOS AW3D30 DEM acquisition via Microsoft Planetary Computer STAC API.
 

--- a/src/symfluence/data/acquisition/handlers/em_earth.py
+++ b/src/symfluence/data/acquisition/handlers/em_earth.py
@@ -15,12 +15,13 @@ import pandas as pd
 import s3fs
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 
-@AcquisitionRegistry.register('EM-EARTH')
-@AcquisitionRegistry.register('EM_EARTH')
+@R.acquisition_handlers.add('EM-EARTH')
+@R.acquisition_handlers.add('EM_EARTH')
 class EMEarthAcquirer(BaseAcquisitionHandler):
     """
     Acquires EM-Earth global climate reanalysis data from AWS S3.

--- a/src/symfluence/data/acquisition/handlers/era5.py
+++ b/src/symfluence/data/acquisition/handlers/era5.py
@@ -19,11 +19,11 @@ import pandas as pd
 import xarray as xr
 
 from symfluence.core.exceptions import DataAcquisitionError
+from symfluence.core.registries import R
 from symfluence.core.validation import validate_bounding_box, validate_numeric_range
 from symfluence.geospatial.coordinate_utils import BoundingBox, get_bbox_extent
 
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 from .era5_cds import ERA5CDSAcquirer
 from .era5_processing import era5_to_summa_schema
 
@@ -265,7 +265,7 @@ def diagnose_cds_credentials() -> Optional[str]:
     return None
 
 
-@AcquisitionRegistry.register('ERA5')
+@R.acquisition_handlers.add('ERA5')
 class ERA5Acquirer(BaseAcquisitionHandler):
     """
     Dispatcher for ERA5 reanalysis data acquisition.

--- a/src/symfluence/data/acquisition/handlers/era5_cds.py
+++ b/src/symfluence/data/acquisition/handlers/era5_cds.py
@@ -17,6 +17,8 @@ from typing import Optional
 import pandas as pd
 import xarray as xr
 
+from symfluence.core.registries import R
+
 try:
     import cdsapi
     HAS_CDSAPI = True
@@ -25,11 +27,10 @@ except ImportError:
 
 from ..base import BaseAcquisitionHandler
 from ..mixins import ChunkedDownloadMixin, RetryMixin, SpatialSubsetMixin
-from ..registry import AcquisitionRegistry
 from .era5_processing import era5_to_summa_schema
 
 
-@AcquisitionRegistry.register('ERA5_CDS')
+@R.acquisition_handlers.add('ERA5_CDS')
 class ERA5CDSAcquirer(BaseAcquisitionHandler, RetryMixin, ChunkedDownloadMixin, SpatialSubsetMixin):
     """
     ERA5 data acquisition handler using the Copernicus Climate Data Store (CDS) API.

--- a/src/symfluence/data/acquisition/handlers/era5_land.py
+++ b/src/symfluence/data/acquisition/handlers/era5_land.py
@@ -26,8 +26,9 @@ from typing import Any, Dict, List
 import pandas as pd
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 # Variable mapping for ERA5-Land
 ERA5_LAND_VARIABLES = {
@@ -67,8 +68,8 @@ ALL_ERA5_LAND_VARIABLES = [
 ]
 
 
-@AcquisitionRegistry.register('ERA5_LAND')
-@AcquisitionRegistry.register('ERA5-LAND')
+@R.acquisition_handlers.add('ERA5_LAND')
+@R.acquisition_handlers.add('ERA5-LAND')
 class ERA5LandAcquirer(BaseAcquisitionHandler):
     """
     Handles ERA5-Land data acquisition from Copernicus CDS.

--- a/src/symfluence/data/acquisition/handlers/esa_cci_sm.py
+++ b/src/symfluence/data/acquisition/handlers/esa_cci_sm.py
@@ -25,6 +25,8 @@ import shutil
 from pathlib import Path
 from typing import Optional
 
+from symfluence.core.registries import R
+
 try:
     import cdsapi
     HAS_CDSAPI = True
@@ -33,10 +35,9 @@ except ImportError:
 
 from ..base import BaseAcquisitionHandler
 from ..mixins import ChunkedDownloadMixin, RetryMixin
-from ..registry import AcquisitionRegistry
 
 
-@AcquisitionRegistry.register('ESA_CCI_SM')
+@R.acquisition_handlers.add('ESA_CCI_SM')
 class ESACCISMAcquirer(BaseAcquisitionHandler, RetryMixin, ChunkedDownloadMixin):
     """
     Acquires ESA CCI Soil Moisture data via Copernicus CDS.

--- a/src/symfluence/data/acquisition/handlers/fluxcom_et.py
+++ b/src/symfluence/data/acquisition/handlers/fluxcom_et.py
@@ -53,8 +53,9 @@ import numpy as np
 import requests
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 # Latent heat of vaporization (J/kg)
 LATENT_HEAT_VAPORIZATION = 2.45e6
@@ -62,8 +63,8 @@ SECONDS_PER_DAY = 86400
 HOURS_PER_DAY = 24
 
 
-@AcquisitionRegistry.register('FLUXCOM_ET')
-@AcquisitionRegistry.register('FLUXCOM')
+@R.acquisition_handlers.add('FLUXCOM_ET')
+@R.acquisition_handlers.add('FLUXCOM')
 class FLUXCOMETAcquirer(BaseAcquisitionHandler):
     """
     Acquires FLUXCOM Evapotranspiration data.

--- a/src/symfluence/data/acquisition/handlers/fluxnet.py
+++ b/src/symfluence/data/acquisition/handlers/fluxnet.py
@@ -40,17 +40,18 @@ import numpy as np
 import pandas as pd
 import requests
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 from .fluxnet_constants import (
     FLUXNET_VARIABLE_MAPPING,
     convert_le_to_et,
 )
 
 
-@AcquisitionRegistry.register('FLUXNET')
-@AcquisitionRegistry.register('FLUXNET2015')
-@AcquisitionRegistry.register('AMERIFLUX')
+@R.acquisition_handlers.add('FLUXNET')
+@R.acquisition_handlers.add('FLUXNET2015')
+@R.acquisition_handlers.add('AMERIFLUX')
 class FLUXNETAcquirer(BaseAcquisitionHandler):
     """
     Acquires FLUXNET/AmeriFlux flux tower data for ET calibration.
@@ -660,7 +661,7 @@ class FLUXNETAcquirer(BaseAcquisitionHandler):
         return site_db.get(station_id, {'name': station_id, 'lat': None, 'lon': None})
 
 
-@AcquisitionRegistry.register('FLUXNET_ET')
+@R.acquisition_handlers.add('FLUXNET_ET')
 class FLUXNETETAcquirer(FLUXNETAcquirer):
     """Specialized FLUXNET acquirer focused on ET data."""
 

--- a/src/symfluence/data/acquisition/handlers/glacier.py
+++ b/src/symfluence/data/acquisition/handlers/glacier.py
@@ -24,8 +24,9 @@ from requests.adapters import HTTPAdapter
 from shapely.geometry import box
 from urllib3.util.retry import Retry
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 
 def create_robust_session(max_retries: int = 5, backoff_factor: float = 1.0):
@@ -78,8 +79,8 @@ GLIMS_WFS_URL = "https://www.glims.org/geoserver/GLIMS/wfs"
 GLIMS_WFS_TIMEOUT = 300  # Increased timeout for slow server
 
 
-@AcquisitionRegistry.register('GLACIER')
-@AcquisitionRegistry.register('RGI')
+@R.acquisition_handlers.add('GLACIER')
+@R.acquisition_handlers.add('RGI')
 class GlacierAcquirer(BaseAcquisitionHandler):
     """
     Glacier data acquisition handler.

--- a/src/symfluence/data/acquisition/handlers/glclu.py
+++ b/src/symfluence/data/acquisition/handlers/glclu.py
@@ -38,9 +38,10 @@ import rasterio
 from rasterio.merge import merge as rio_merge
 from rasterio.windows import from_bounds
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
 from ..mixins import RetryMixin
-from ..registry import AcquisitionRegistry
 from ..utils import create_robust_session
 
 _BASE_URL = "https://glad.umd.edu/users/Potapov/GLCLUC2020"
@@ -57,8 +58,8 @@ _LAYERS = {
 _DEFAULT_LAYERS = ['forest_extent_2020']
 
 
-@AcquisitionRegistry.register('GLCLU_2019')
-@AcquisitionRegistry.register('GLCLU')
+@R.acquisition_handlers.add('GLCLU_2019')
+@R.acquisition_handlers.add('GLCLU')
 class GLCLUAcquirer(BaseAcquisitionHandler, RetryMixin):
     """
     GLAD GLCLU 2020 land cover acquisition.

--- a/src/symfluence/data/acquisition/handlers/gldas_tws.py
+++ b/src/symfluence/data/acquisition/handlers/gldas_tws.py
@@ -17,12 +17,13 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 
-@AcquisitionRegistry.register('GLDAS')
-@AcquisitionRegistry.register('GLDAS_TWS')
+@R.acquisition_handlers.add('GLDAS')
+@R.acquisition_handlers.add('GLDAS_TWS')
 class GLDASAcquirer(BaseAcquisitionHandler):
     """
     Handles GLDAS-2.1 Noah monthly TWS data acquisition.

--- a/src/symfluence/data/acquisition/handlers/gleam_et.py
+++ b/src/symfluence/data/acquisition/handlers/gleam_et.py
@@ -36,16 +36,17 @@ import os
 from pathlib import Path
 from typing import List, Optional, Tuple
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 GLEAM_HOST = 'hydras.ugent.be'
 GLEAM_PORT = 2225
 DEFAULT_VERSION = 'v4.2a'
 
 
-@AcquisitionRegistry.register('GLEAM_ET')
-@AcquisitionRegistry.register('GLEAM')
+@R.acquisition_handlers.add('GLEAM_ET')
+@R.acquisition_handlers.add('GLEAM')
 class GLEAMETAcquirer(BaseAcquisitionHandler):
     """
     Acquires GLEAM evapotranspiration data via SFTP.

--- a/src/symfluence/data/acquisition/handlers/glhymps.py
+++ b/src/symfluence/data/acquisition/handlers/glhymps.py
@@ -32,8 +32,9 @@ from typing import Optional
 import geopandas as gpd
 from shapely.geometry import box
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 from ..utils import create_robust_session, download_file_streaming
 
 # GLHYMPS download sources — tried in order until one succeeds
@@ -63,8 +64,8 @@ _KEEP_COLUMNS = [
 ]
 
 
-@AcquisitionRegistry.register('GLHYMPS')
-@AcquisitionRegistry.register('GLHYMPS_V2')
+@R.acquisition_handlers.add('GLHYMPS')
+@R.acquisition_handlers.add('GLHYMPS_V2')
 class GLHYMPSAcquirer(BaseAcquisitionHandler):
     """
     GLHYMPS v2.0 global hydrogeology acquisition.

--- a/src/symfluence/data/acquisition/handlers/globsnow.py
+++ b/src/symfluence/data/acquisition/handlers/globsnow.py
@@ -35,9 +35,10 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
 from ..mixins import ChunkedDownloadMixin, RetryMixin, SpatialSubsetMixin
-from ..registry import AcquisitionRegistry
 from ..utils import create_robust_session, download_file_streaming
 
 # GlobSnow v3.0 archive URL
@@ -55,7 +56,7 @@ _URL_PATTERNS = {
 }
 
 
-@AcquisitionRegistry.register('GLOBSNOW')
+@R.acquisition_handlers.add('GLOBSNOW')
 class GlobSnowAcquirer(
     BaseAcquisitionHandler, RetryMixin, ChunkedDownloadMixin, SpatialSubsetMixin
 ):

--- a/src/symfluence/data/acquisition/handlers/glwd.py
+++ b/src/symfluence/data/acquisition/handlers/glwd.py
@@ -32,9 +32,10 @@ from typing import List, Optional
 import rasterio
 from rasterio.windows import from_bounds
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
 from ..mixins import RetryMixin
-from ..registry import AcquisitionRegistry
 from ..utils import create_robust_session, download_file_streaming
 
 # Figshare direct file download URLs for GLWD v2.0
@@ -49,9 +50,9 @@ _DOWNLOAD_URLS = {
 }
 
 
-@AcquisitionRegistry.register('GLWD')
-@AcquisitionRegistry.register('GLWD_V2')
-@AcquisitionRegistry.register('WETLANDS')
+@R.acquisition_handlers.add('GLWD')
+@R.acquisition_handlers.add('GLWD_V2')
+@R.acquisition_handlers.add('WETLANDS')
 class GLWDAcquirer(BaseAcquisitionHandler, RetryMixin):
     """
     GLWD v2.0 global wetland database acquisition.

--- a/src/symfluence/data/acquisition/handlers/gpm.py
+++ b/src/symfluence/data/acquisition/handlers/gpm.py
@@ -37,11 +37,12 @@ from typing import List
 import requests
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 
-@AcquisitionRegistry.register('GPM_IMERG')
+@R.acquisition_handlers.add('GPM_IMERG')
 class GPMIMERGAcquirer(BaseAcquisitionHandler):
     """
     Acquires GPM IMERG precipitation data via GES DISC.

--- a/src/symfluence/data/acquisition/handlers/grace.py
+++ b/src/symfluence/data/acquisition/handlers/grace.py
@@ -17,8 +17,9 @@ from typing import Any, Optional, Tuple
 import requests
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 from ..utils import resolve_earthdata_token
 from .merra2 import _EarthdataSession
 
@@ -56,7 +57,7 @@ def _ca_bundle() -> str:
         return certifi.where()
 
 
-@AcquisitionRegistry.register('GRACE')
+@R.acquisition_handlers.add('GRACE')
 class GRACEAcquirer(BaseAcquisitionHandler):
     """
     Handles GRACE/GRACE-FO data acquisition.

--- a/src/symfluence/data/acquisition/handlers/grdc.py
+++ b/src/symfluence/data/acquisition/handlers/grdc.py
@@ -25,11 +25,12 @@ from typing import List, Optional, Tuple
 import pandas as pd
 import requests
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 
-@AcquisitionRegistry.register('GRDC')
+@R.acquisition_handlers.add('GRDC')
 class GRDCAcquirer(BaseAcquisitionHandler):
     """
     Handles GRDC streamflow data acquisition.

--- a/src/symfluence/data/acquisition/handlers/gssurgo.py
+++ b/src/symfluence/data/acquisition/handlers/gssurgo.py
@@ -34,9 +34,10 @@ from typing import Dict, List, Optional
 
 import pandas as pd
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
 from ..mixins import RetryMixin
-from ..registry import AcquisitionRegistry
 from ..utils import create_robust_session
 
 # SDA REST endpoints
@@ -68,7 +69,7 @@ def _bbox_to_wkt(bbox: Dict[str, float]) -> str:
     )
 
 
-@AcquisitionRegistry.register('GSSURGO')
+@R.acquisition_handlers.add('GSSURGO')
 class GSSURGOAcquirer(BaseAcquisitionHandler, RetryMixin):
     """gSSURGO soil property acquisition via USDA Soil Data Access REST API.
 

--- a/src/symfluence/data/acquisition/handlers/hrrr.py
+++ b/src/symfluence/data/acquisition/handlers/hrrr.py
@@ -16,12 +16,13 @@ import pandas as pd
 import s3fs
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
 from ..mixins.retry import RetryMixin
-from ..registry import AcquisitionRegistry
 
 
-@AcquisitionRegistry.register('HRRR')
+@R.acquisition_handlers.add('HRRR')
 class HRRRAcquirer(BaseAcquisitionHandler, RetryMixin):
     """
     Download and process High Resolution Rapid Refresh (HRRR) atmospheric forcing data.

--- a/src/symfluence/data/acquisition/handlers/hydrolakes.py
+++ b/src/symfluence/data/acquisition/handlers/hydrolakes.py
@@ -26,8 +26,9 @@ from requests.adapters import HTTPAdapter
 from shapely.geometry import box
 from urllib3.util.retry import Retry
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 
 def _create_session(max_retries: int = 3, backoff_factor: float = 1.0):
@@ -72,8 +73,8 @@ KEEP_COLUMNS = [
 ]
 
 
-@AcquisitionRegistry.register("HYDROLAKES")
-@AcquisitionRegistry.register("HYDROLAKES_V10")
+@R.acquisition_handlers.add("HYDROLAKES")
+@R.acquisition_handlers.add("HYDROLAKES_V10")
 class HydroLAKESAcquirer(BaseAcquisitionHandler):
     """
     HydroLAKES global lake database acquisition handler.

--- a/src/symfluence/data/acquisition/handlers/hydrosheds.py
+++ b/src/symfluence/data/acquisition/handlers/hydrosheds.py
@@ -41,9 +41,10 @@ from typing import List
 
 import requests
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
 from ..mixins import RetryMixin
-from ..registry import AcquisitionRegistry
 from ..utils import create_robust_session
 
 # HydroBASINS download URL template (standard version, excludes endorheic)
@@ -66,8 +67,8 @@ _HYDROSHEDS_REGION_BBOXES = {
 }
 
 
-@AcquisitionRegistry.register('HYDROSHEDS')
-@AcquisitionRegistry.register('HYDROBASINS')
+@R.acquisition_handlers.add('HYDROSHEDS')
+@R.acquisition_handlers.add('HYDROBASINS')
 class HydroSHEDSAcquirer(BaseAcquisitionHandler, RetryMixin):
     """HydroSHEDS / HydroBASINS acquisition from hydrosheds.org.
 

--- a/src/symfluence/data/acquisition/handlers/ims_snow.py
+++ b/src/symfluence/data/acquisition/handlers/ims_snow.py
@@ -42,8 +42,9 @@ import pandas as pd
 import requests
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 # NSIDC data endpoint
 IMS_BASE_URL = "https://noaadata.apps.nsidc.org/NOAA/G02156"
@@ -68,8 +69,8 @@ IMS_GRIDS = {
 }
 
 
-@AcquisitionRegistry.register('IMS_SNOW')
-@AcquisitionRegistry.register('IMS')
+@R.acquisition_handlers.add('IMS_SNOW')
+@R.acquisition_handlers.add('IMS')
 class IMSSnowAcquirer(BaseAcquisitionHandler):
     """
     Handles IMS snow cover data acquisition from NSIDC.

--- a/src/symfluence/data/acquisition/handlers/ismn.py
+++ b/src/symfluence/data/acquisition/handlers/ismn.py
@@ -30,11 +30,12 @@ import numpy as np
 import pandas as pd
 import requests
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 
-@AcquisitionRegistry.register('ISMN')
+@R.acquisition_handlers.add('ISMN')
 class ISMNAcquirer(BaseAcquisitionHandler):
     """Acquires ISMN (International Soil Moisture Network) soil moisture data.
 

--- a/src/symfluence/data/acquisition/handlers/jrc_water.py
+++ b/src/symfluence/data/acquisition/handlers/jrc_water.py
@@ -37,12 +37,13 @@ from typing import List, Optional, Tuple
 import numpy as np
 import requests
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 
-@AcquisitionRegistry.register('JRC_WATER')
-@AcquisitionRegistry.register('JRC_GSW')
+@R.acquisition_handlers.add('JRC_WATER')
+@R.acquisition_handlers.add('JRC_GSW')
 class JRCWaterAcquirer(BaseAcquisitionHandler):
     """
     Acquires JRC Global Surface Water data from Google Cloud Storage.

--- a/src/symfluence/data/acquisition/handlers/landcover.py
+++ b/src/symfluence/data/acquisition/handlers/landcover.py
@@ -48,11 +48,12 @@ import rasterio
 import requests
 from rasterio.windows import Window, from_bounds
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 
-@AcquisitionRegistry.register('MODIS_LANDCOVER')
+@R.acquisition_handlers.add('MODIS_LANDCOVER')
 class MODISLandcoverAcquirer(BaseAcquisitionHandler):
     """MODIS MCD12Q1 land cover acquisition with multi-year support.
 
@@ -318,7 +319,7 @@ class MODISLandcoverAcquirer(BaseAcquisitionHandler):
         return out_path
 
 
-@AcquisitionRegistry.register('USGS_NLCD')
+@R.acquisition_handlers.add('USGS_NLCD')
 class USGSLandcoverAcquirer(BaseAcquisitionHandler):
     """USGS National Land Cover Database (NLCD) acquisition handler.
 

--- a/src/symfluence/data/acquisition/handlers/merit_basins.py
+++ b/src/symfluence/data/acquisition/handlers/merit_basins.py
@@ -32,9 +32,10 @@ from typing import List
 
 import requests
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
 from ..mixins import RetryMixin
-from ..registry import AcquisitionRegistry
 from ..utils import create_robust_session
 
 # MERIT-Basins data URLs
@@ -57,7 +58,7 @@ _PFAFSTETTER_L1_BBOXES = {
 }
 
 
-@AcquisitionRegistry.register('MERIT_BASINS')
+@R.acquisition_handlers.add('MERIT_BASINS')
 class MERITBasinsAcquirer(BaseAcquisitionHandler, RetryMixin):
     """MERIT-Basins vector data acquisition from reachhydro.org.
 

--- a/src/symfluence/data/acquisition/handlers/merit_hydro.py
+++ b/src/symfluence/data/acquisition/handlers/merit_hydro.py
@@ -37,9 +37,10 @@ from pathlib import Path
 import rasterio
 from rasterio.merge import merge as rio_merge
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
 from ..mixins import RetryMixin
-from ..registry import AcquisitionRegistry
 from ..utils import create_robust_session, download_file_streaming
 
 # Base URL for MERIT-Hydro v1.0.1
@@ -80,7 +81,7 @@ def _get_tile_origin(coord: int, tile_size: int = 5) -> int:
     return -((abs(coord) + tile_size - 1) // tile_size) * tile_size
 
 
-@AcquisitionRegistry.register('MERIT_HYDRO')
+@R.acquisition_handlers.add('MERIT_HYDRO')
 class MERITHydroAcquirer(BaseAcquisitionHandler, RetryMixin):
     """MERIT-Hydro acquisition via HTTP tile download.
 

--- a/src/symfluence/data/acquisition/handlers/merra2.py
+++ b/src/symfluence/data/acquisition/handlers/merra2.py
@@ -44,9 +44,10 @@ import pandas as pd
 import requests
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
 from ..mixins import ChunkedDownloadMixin, RetryMixin, SpatialSubsetMixin
-from ..registry import AcquisitionRegistry
 
 
 class _EarthdataSession(requests.Session):
@@ -178,7 +179,7 @@ def _build_subset_url(base_url, variables, lat_indices, lon_indices):
     return f"{base_url}.nc4?{','.join(constraints)}"
 
 
-@AcquisitionRegistry.register('MERRA2')
+@R.acquisition_handlers.add('MERRA2')
 class MERRA2Acquirer(
     BaseAcquisitionHandler, RetryMixin, ChunkedDownloadMixin, SpatialSubsetMixin
 ):

--- a/src/symfluence/data/acquisition/handlers/modis.py
+++ b/src/symfluence/data/acquisition/handlers/modis.py
@@ -12,11 +12,12 @@ from pathlib import Path
 
 import requests
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 
-@AcquisitionRegistry.register('MODIS_SNOW')
+@R.acquisition_handlers.add('MODIS_SNOW')
 class MODISSnowAcquirer(BaseAcquisitionHandler):
     """
     Acquires MODIS Snow Cover (MOD10A1/MYD10A1) data via THREDDS NCSS.

--- a/src/symfluence/data/acquisition/handlers/modis_et.py
+++ b/src/symfluence/data/acquisition/handlers/modis_et.py
@@ -40,13 +40,14 @@ import pandas as pd
 import requests
 import xarray as xr
 
-from ..registry import AcquisitionRegistry
+from symfluence.core.registries import R
+
 from .earthaccess_base import BaseEarthaccessAcquirer
 
 
-@AcquisitionRegistry.register('MOD16')
-@AcquisitionRegistry.register('MODIS_ET')
-@AcquisitionRegistry.register('MOD16A2')
+@R.acquisition_handlers.add('MOD16')
+@R.acquisition_handlers.add('MODIS_ET')
+@R.acquisition_handlers.add('MOD16A2')
 class MOD16ETAcquirer(BaseEarthaccessAcquirer):
     """
     Acquires MODIS MOD16A2/MYD16A2 Evapotranspiration data.

--- a/src/symfluence/data/acquisition/handlers/modis_lai.py
+++ b/src/symfluence/data/acquisition/handlers/modis_lai.py
@@ -39,12 +39,13 @@ import pandas as pd
 import requests
 import xarray as xr
 
-from ..registry import AcquisitionRegistry
+from symfluence.core.registries import R
+
 from .earthaccess_base import BaseEarthaccessAcquirer
 
 
-@AcquisitionRegistry.register('MODIS_LAI')
-@AcquisitionRegistry.register('MCD15')
+@R.acquisition_handlers.add('MODIS_LAI')
+@R.acquisition_handlers.add('MCD15')
 class MODISLAIAcquirer(BaseEarthaccessAcquirer):
     """
     Acquires MODIS LAI/FPAR data (MCD15A2H / MOD15A2H / MYD15A2H).

--- a/src/symfluence/data/acquisition/handlers/modis_lst.py
+++ b/src/symfluence/data/acquisition/handlers/modis_lst.py
@@ -22,15 +22,16 @@ from typing import Any, Dict, List, Optional
 
 import requests
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 # AppEEARS API endpoints
 APPEEARS_BASE = "https://appeears.earthdatacloud.nasa.gov/api"
 
 
-@AcquisitionRegistry.register('MODIS_LST')
-@AcquisitionRegistry.register('MOD11')
+@R.acquisition_handlers.add('MODIS_LST')
+@R.acquisition_handlers.add('MOD11')
 class MODISLSTAcquirer(BaseAcquisitionHandler):
     """
     Handles MODIS LST data acquisition via NASA AppEEARS.

--- a/src/symfluence/data/acquisition/handlers/modis_ndvi.py
+++ b/src/symfluence/data/acquisition/handlers/modis_ndvi.py
@@ -35,12 +35,13 @@ import pandas as pd
 import requests
 import xarray as xr
 
-from ..registry import AcquisitionRegistry
+from symfluence.core.registries import R
+
 from .earthaccess_base import BaseEarthaccessAcquirer
 
 
-@AcquisitionRegistry.register('MODIS_NDVI')
-@AcquisitionRegistry.register('MOD13')
+@R.acquisition_handlers.add('MODIS_NDVI')
+@R.acquisition_handlers.add('MOD13')
 class MODISNDVIAcquirer(BaseEarthaccessAcquirer):
     """
     Acquires MODIS NDVI/EVI vegetation index data (MOD13A2/MYD13A2).

--- a/src/symfluence/data/acquisition/handlers/modis_sca.py
+++ b/src/symfluence/data/acquisition/handlers/modis_sca.py
@@ -27,12 +27,13 @@ import pandas as pd
 import requests
 import xarray as xr
 
-from ..registry import AcquisitionRegistry
+from symfluence.core.registries import R
+
 from .earthaccess_base import BaseEarthaccessAcquirer
 
 
-@AcquisitionRegistry.register('MODIS_SCA')
-@AcquisitionRegistry.register('MODIS_SNOW_MERGED')
+@R.acquisition_handlers.add('MODIS_SCA')
+@R.acquisition_handlers.add('MODIS_SNOW_MERGED')
 class MODISSCAAcquirer(BaseEarthaccessAcquirer):
     """
     Acquires MODIS Snow Cover Area data from both Terra (MOD10A1) and Aqua (MYD10A1)

--- a/src/symfluence/data/acquisition/handlers/mswep.py
+++ b/src/symfluence/data/acquisition/handlers/mswep.py
@@ -41,11 +41,12 @@ from typing import List, Set
 
 import pandas as pd
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 
-@AcquisitionRegistry.register('MSWEP')
+@R.acquisition_handlers.add('MSWEP')
 class MSWEPAcquirer(BaseAcquisitionHandler):
     """
     Handles MSWEP precipitation data acquisition via Rclone + Google Drive.

--- a/src/symfluence/data/acquisition/handlers/nex_gddp.py
+++ b/src/symfluence/data/acquisition/handlers/nex_gddp.py
@@ -19,12 +19,13 @@ import pandas as pd
 import requests
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 
-@AcquisitionRegistry.register('NEX-GDDP-CMIP6')
-@AcquisitionRegistry.register('NEX-GDDP')
+@R.acquisition_handlers.add('NEX-GDDP-CMIP6')
+@R.acquisition_handlers.add('NEX-GDDP')
 class NEXGDDPCHandler(BaseAcquisitionHandler):
     """
     Acquires NEX-GDDP-CMIP6 downscaled climate projection data via THREDDS.

--- a/src/symfluence/data/acquisition/handlers/nldas.py
+++ b/src/symfluence/data/acquisition/handlers/nldas.py
@@ -33,9 +33,10 @@ import pandas as pd
 import requests
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
 from ..mixins import ChunkedDownloadMixin, RetryMixin, SpatialSubsetMixin
-from ..registry import AcquisitionRegistry
 
 # OPeNDAP base URL for NLDAS-2 at GES DISC
 _OPENDAP_BASE = "https://hydro1.gesdisc.eosdis.nasa.gov/opendap/NLDAS/NLDAS_FORA0125_H.2.0"
@@ -120,9 +121,9 @@ def _build_subset_url(base_url, variables, lat_indices, lon_indices):
     return f"{base_url}.nc4?{','.join(constraints)}"
 
 
-@AcquisitionRegistry.register('NLDAS')
-@AcquisitionRegistry.register('NLDAS2')
-@AcquisitionRegistry.register('NLDAS-2')
+@R.acquisition_handlers.add('NLDAS')
+@R.acquisition_handlers.add('NLDAS2')
+@R.acquisition_handlers.add('NLDAS-2')
 class NLDASAcquirer(
     BaseAcquisitionHandler, RetryMixin, ChunkedDownloadMixin, SpatialSubsetMixin
 ):

--- a/src/symfluence/data/acquisition/handlers/nwm3_retrospective.py
+++ b/src/symfluence/data/acquisition/handlers/nwm3_retrospective.py
@@ -49,8 +49,9 @@ import pandas as pd
 import s3fs
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 _S3_BUCKET = 'noaa-nwm-retrospective-3-0-pds'
 _ZARR_PREFIX = 'CONUS/zarr'
@@ -82,7 +83,7 @@ _NWM_FORCING_VARS = {
 }
 
 
-@AcquisitionRegistry.register('NWM3_RETROSPECTIVE')
+@R.acquisition_handlers.add('NWM3_RETROSPECTIVE')
 class NWM3RetrospectiveAcquirer(BaseAcquisitionHandler):
     """
     Download NOAA NWM v3.0 retrospective outputs from AWS S3 Zarr stores.

--- a/src/symfluence/data/acquisition/handlers/nws_hydrofabric.py
+++ b/src/symfluence/data/acquisition/handlers/nws_hydrofabric.py
@@ -36,12 +36,13 @@ from typing import TYPE_CHECKING, Optional, Set, Tuple
 
 import requests
 
+from symfluence.core.registries import R
+
 if TYPE_CHECKING:
     import geopandas as gpd
 
 from ..base import BaseAcquisitionHandler
 from ..mixins import RetryMixin
-from ..registry import AcquisitionRegistry
 from ..utils import create_robust_session
 
 # Community Hydrofabric S3 — public bucket, anonymous access
@@ -82,8 +83,8 @@ _NWS_VPU_BBOXES = {
 }
 
 
-@AcquisitionRegistry.register('NWS_HYDROFABRIC')
-@AcquisitionRegistry.register('NWS')
+@R.acquisition_handlers.add('NWS_HYDROFABRIC')
+@R.acquisition_handlers.add('NWS')
 class NWSHydrofabricAcquirer(BaseAcquisitionHandler, RetryMixin):
     """NWS NextGen Hydrofabric acquisition with local subsetting.
 

--- a/src/symfluence/data/acquisition/handlers/openet.py
+++ b/src/symfluence/data/acquisition/handlers/openet.py
@@ -26,12 +26,13 @@ from typing import Optional
 import pandas as pd
 import requests
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 
-@AcquisitionRegistry.register('OPENET')
-@AcquisitionRegistry.register('OpenET')
+@R.acquisition_handlers.add('OPENET')
+@R.acquisition_handlers.add('OpenET')
 class OpenETAcquirer(BaseAcquisitionHandler):
     """
     Handles OpenET data acquisition via OpenET API.

--- a/src/symfluence/data/acquisition/handlers/pelletier.py
+++ b/src/symfluence/data/acquisition/handlers/pelletier.py
@@ -36,9 +36,10 @@ import numpy as np
 import rasterio
 from rasterio.windows import from_bounds
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
 from ..mixins import RetryMixin
-from ..registry import AcquisitionRegistry
 from ..utils import create_robust_session
 
 # Cloud-hosted ORNL DAAC (replaces legacy daac.ornl.gov which is intermittent)
@@ -79,9 +80,9 @@ _PELLETIER_FILES = {
 _DEFAULT_VARIABLES = list(_PELLETIER_FILES.keys())
 
 
-@AcquisitionRegistry.register('PELLETIER')
-@AcquisitionRegistry.register('PELLETIER_SOIL_DEPTH')
-@AcquisitionRegistry.register('SOIL_REGOLITH_DEPTH')
+@R.acquisition_handlers.add('PELLETIER')
+@R.acquisition_handlers.add('PELLETIER_SOIL_DEPTH')
+@R.acquisition_handlers.add('SOIL_REGOLITH_DEPTH')
 class PelletierAcquirer(BaseAcquisitionHandler, RetryMixin):
     """
     Pelletier et al. (2016) global soil/regolith depth acquisition.

--- a/src/symfluence/data/acquisition/handlers/polaris.py
+++ b/src/symfluence/data/acquisition/handlers/polaris.py
@@ -36,9 +36,10 @@ from pathlib import Path
 import rasterio
 from rasterio.merge import merge as rio_merge
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
 from ..mixins import RetryMixin
-from ..registry import AcquisitionRegistry
 from ..utils import create_robust_session, download_file_streaming
 
 # Base URL for POLARIS v1.0
@@ -61,7 +62,7 @@ _DEFAULT_DEPTHS = ['0_5', '5_15', '15_30', '30_60', '60_100']
 _ALL_STATISTICS = ['mean', 'mode', 'p5', 'p50', 'p95']
 
 
-@AcquisitionRegistry.register('POLARIS')
+@R.acquisition_handlers.add('POLARIS')
 class POLARISAcquirer(BaseAcquisitionHandler, RetryMixin):
     """POLARIS 30m soil property acquisition via HTTP tile download.
 

--- a/src/symfluence/data/acquisition/handlers/rdrs.py
+++ b/src/symfluence/data/acquisition/handlers/rdrs.py
@@ -25,8 +25,9 @@ import pandas as pd
 import requests
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 from ..utils import create_robust_session
 
 # PAVICS THREDDS OPeNDAP endpoints
@@ -45,8 +46,8 @@ GPSCC_CASR_V32_BASE_URL = (
 )
 
 
-@AcquisitionRegistry.register('RDRS')
-@AcquisitionRegistry.register('RDRS_v3.1')
+@R.acquisition_handlers.add('RDRS')
+@R.acquisition_handlers.add('RDRS_v3.1')
 class RDRSAcquirer(BaseAcquisitionHandler):
     """
     Acquisition handler for CaSR/RDRS reanalysis data.

--- a/src/symfluence/data/acquisition/handlers/root_zone_storage.py
+++ b/src/symfluence/data/acquisition/handlers/root_zone_storage.py
@@ -32,9 +32,10 @@ from pathlib import Path
 import numpy as np
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
 from ..mixins import RetryMixin
-from ..registry import AcquisitionRegistry
 from ..utils import create_robust_session, download_file_streaming
 
 # Zenodo download URLs
@@ -58,9 +59,9 @@ _ZENODO_FILES = {
 _DEFAULT_VARIABLES = ['cwdx80', 'zroot_cwd80']
 
 
-@AcquisitionRegistry.register('ROOT_ZONE_STORAGE')
-@AcquisitionRegistry.register('RZSC')
-@AcquisitionRegistry.register('ROOTING_DEPTH')
+@R.acquisition_handlers.add('ROOT_ZONE_STORAGE')
+@R.acquisition_handlers.add('RZSC')
+@R.acquisition_handlers.add('ROOTING_DEPTH')
 class RootZoneStorageAcquirer(BaseAcquisitionHandler, RetryMixin):
     """
     Stocker et al. (2023) root zone storage capacity acquisition.

--- a/src/symfluence/data/acquisition/handlers/sentinel1_sm.py
+++ b/src/symfluence/data/acquisition/handlers/sentinel1_sm.py
@@ -26,12 +26,13 @@ from typing import Any, Dict, List, Optional
 
 import requests
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 
-@AcquisitionRegistry.register('SENTINEL1_SM')
-@AcquisitionRegistry.register('S1_SM')
+@R.acquisition_handlers.add('SENTINEL1_SM')
+@R.acquisition_handlers.add('S1_SM')
 class Sentinel1SMAcquirer(BaseAcquisitionHandler):
     """
     Handles Sentinel-1 soil moisture data acquisition.

--- a/src/symfluence/data/acquisition/handlers/sentinel2_snow.py
+++ b/src/symfluence/data/acquisition/handlers/sentinel2_snow.py
@@ -35,8 +35,9 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 # Planetary Computer STAC API endpoint
 PC_STAC_URL = "https://planetarycomputer.microsoft.com/api/stac/v1"
@@ -48,9 +49,9 @@ SCL_CLOUD_HIGH = 9
 SCL_THIN_CIRRUS = 10
 
 
-@AcquisitionRegistry.register('SENTINEL2_SNOW')
-@AcquisitionRegistry.register('S2_SNOW')
-@AcquisitionRegistry.register('SENTINEL2_SCF')
+@R.acquisition_handlers.add('SENTINEL2_SNOW')
+@R.acquisition_handlers.add('S2_SNOW')
+@R.acquisition_handlers.add('SENTINEL2_SCF')
 class Sentinel2SnowAcquirer(BaseAcquisitionHandler):
     """
     Acquires Sentinel-2 L2A snow cover fraction via Planetary Computer.

--- a/src/symfluence/data/acquisition/handlers/smap.py
+++ b/src/symfluence/data/acquisition/handlers/smap.py
@@ -36,11 +36,12 @@ import pandas as pd
 import requests
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 
-@AcquisitionRegistry.register('SMAP')
+@R.acquisition_handlers.add('SMAP')
 class SMAPAcquirer(BaseAcquisitionHandler):
     """
     Acquires SMAP Soil Moisture data via earthaccess streaming or NSIDC THREDDS NCSS.

--- a/src/symfluence/data/acquisition/handlers/smos_sm.py
+++ b/src/symfluence/data/acquisition/handlers/smos_sm.py
@@ -27,6 +27,8 @@ import shutil
 from pathlib import Path
 from typing import Optional
 
+from symfluence.core.registries import R
+
 try:
     import cdsapi
     HAS_CDSAPI = True
@@ -34,11 +36,10 @@ except ImportError:
     HAS_CDSAPI = False
 
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 
-@AcquisitionRegistry.register('SMOS')
-@AcquisitionRegistry.register('SMOS_SM')
+@R.acquisition_handlers.add('SMOS')
+@R.acquisition_handlers.add('SMOS_SM')
 class SMOSSMAcquirer(BaseAcquisitionHandler):
     """
     Acquires SMOS Soil Moisture data via Copernicus CDS.

--- a/src/symfluence/data/acquisition/handlers/snodas.py
+++ b/src/symfluence/data/acquisition/handlers/snodas.py
@@ -37,11 +37,12 @@ import numpy as np
 import requests
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 
-@AcquisitionRegistry.register('SNODAS')
+@R.acquisition_handlers.add('SNODAS')
 class SNODASAcquirer(BaseAcquisitionHandler):
     """
     Acquires SNODAS snow data from NSIDC.

--- a/src/symfluence/data/acquisition/handlers/soilgrids.py
+++ b/src/symfluence/data/acquisition/handlers/soilgrids.py
@@ -43,13 +43,14 @@ import rasterio
 import requests
 from rasterio.windows import from_bounds
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
 from ..mixins import RetryMixin
-from ..registry import AcquisitionRegistry
 from ..utils import create_robust_session
 
 
-@AcquisitionRegistry.register('SOILGRIDS')
+@R.acquisition_handlers.add('SOILGRIDS')
 class SoilGridsAcquirer(BaseAcquisitionHandler, RetryMixin):
     """SoilGrids v2 soil classification acquisition with dual-source strategy.
 

--- a/src/symfluence/data/acquisition/handlers/soilgrids_properties.py
+++ b/src/symfluence/data/acquisition/handlers/soilgrids_properties.py
@@ -40,9 +40,10 @@ from pathlib import Path
 import numpy as np
 import rasterio
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
 from ..mixins import RetryMixin
-from ..registry import AcquisitionRegistry
 from ..utils import create_robust_session
 
 # WCS endpoint template
@@ -84,7 +85,7 @@ _ALL_DEPTHS = ['0-5cm', '5-15cm', '15-30cm', '30-60cm', '60-100cm', '100-200cm']
 _DEFAULT_DEPTHS = ['0-5cm', '5-15cm', '15-30cm', '30-60cm', '60-100cm']
 
 
-@AcquisitionRegistry.register('SOILGRIDS_PROPERTIES')
+@R.acquisition_handlers.add('SOILGRIDS_PROPERTIES')
 class SoilGridsPropertiesAcquirer(BaseAcquisitionHandler, RetryMixin):
     """SoilGrids v2 continuous soil property acquisition via WCS.
 

--- a/src/symfluence/data/acquisition/handlers/ssebop.py
+++ b/src/symfluence/data/acquisition/handlers/ssebop.py
@@ -32,11 +32,12 @@ from typing import List, Optional
 import numpy as np
 import requests
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
-from ..registry import AcquisitionRegistry
 
 
-@AcquisitionRegistry.register('SSEBOP')
+@R.acquisition_handlers.add('SSEBOP')
 class SSEBopAcquirer(BaseAcquisitionHandler):
     """
     Acquires SSEBop ET data from USGS FEWS NET portal.

--- a/src/symfluence/data/acquisition/handlers/tdx_hydro.py
+++ b/src/symfluence/data/acquisition/handlers/tdx_hydro.py
@@ -31,9 +31,10 @@ from pathlib import Path
 
 import requests
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
 from ..mixins import RetryMixin
-from ..registry import AcquisitionRegistry
 from ..utils import create_robust_session
 
 # GEOGLOWS V2 S3 base URL (us-west-2, public)
@@ -47,8 +48,8 @@ _CATCHMENTS_URL_TEMPLATE = f"{_GEOGLOWS_S3_BASE}/hydrography/vpu={{vpu}}/catchme
 _STREAMS_URL_TEMPLATE = f"{_GEOGLOWS_S3_BASE}/hydrography/vpu={{vpu}}/streams_{{vpu}}.gpkg"
 
 
-@AcquisitionRegistry.register('TDX_HYDRO')
-@AcquisitionRegistry.register('GEOGLOWS')
+@R.acquisition_handlers.add('TDX_HYDRO')
+@R.acquisition_handlers.add('GEOGLOWS')
 class TDXHydroAcquirer(BaseAcquisitionHandler, RetryMixin):
     """TDX-Hydro / GEOGLOWS V2 acquisition via public S3.
 

--- a/src/symfluence/data/acquisition/handlers/viirs_snow.py
+++ b/src/symfluence/data/acquisition/handlers/viirs_snow.py
@@ -34,14 +34,15 @@ import numpy as np
 import requests
 import xarray as xr
 
-from ..registry import AcquisitionRegistry
+from symfluence.core.registries import R
+
 from .earthaccess_base import BaseEarthaccessAcquirer
 
 APPEEARS_BASE = "https://appeears.earthdatacloud.nasa.gov/api"
 
 
-@AcquisitionRegistry.register('VIIRS_SNOW')
-@AcquisitionRegistry.register('VNP10')
+@R.acquisition_handlers.add('VIIRS_SNOW')
+@R.acquisition_handlers.add('VNP10')
 class VIIRSSnowAcquirer(BaseEarthaccessAcquirer):
     """
     Handles VIIRS snow cover data acquisition.

--- a/src/symfluence/data/acquisition/handlers/wokam.py
+++ b/src/symfluence/data/acquisition/handlers/wokam.py
@@ -34,18 +34,19 @@ from typing import Optional
 import geopandas as gpd
 from shapely.geometry import box
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
 from ..mixins import RetryMixin
-from ..registry import AcquisitionRegistry
 from ..utils import create_robust_session, download_file_streaming
 
 # WOKAM download URL
 _WOKAM_URL = "https://download.bgr.de/bgr/grundwasser/whymap/shp/WHYMAP_WOKAM_v1.zip"
 
 
-@AcquisitionRegistry.register('WOKAM')
-@AcquisitionRegistry.register('KARST')
-@AcquisitionRegistry.register('KARST_AQUIFER')
+@R.acquisition_handlers.add('WOKAM')
+@R.acquisition_handlers.add('KARST')
+@R.acquisition_handlers.add('KARST_AQUIFER')
 class WOKAMAcquirer(BaseAcquisitionHandler, RetryMixin):
     """
     WOKAM (World Karst Aquifer Map) global karst acquisition.

--- a/src/symfluence/data/acquisition/handlers/worldclim.py
+++ b/src/symfluence/data/acquisition/handlers/worldclim.py
@@ -38,9 +38,10 @@ import numpy as np
 import rasterio
 from rasterio.windows import from_bounds
 
+from symfluence.core.registries import R
+
 from ..base import BaseAcquisitionHandler
 from ..mixins import RetryMixin
-from ..registry import AcquisitionRegistry
 from ..utils import create_robust_session, download_file_streaming
 
 _MIRRORS = [
@@ -61,8 +62,8 @@ _VARIABLES = {
 _DEFAULT_VARIABLES = list(_VARIABLES.keys())
 
 
-@AcquisitionRegistry.register('WORLDCLIM')
-@AcquisitionRegistry.register('WORLDCLIM_V21')
+@R.acquisition_handlers.add('WORLDCLIM')
+@R.acquisition_handlers.add('WORLDCLIM_V21')
 class WorldClimAcquirer(BaseAcquisitionHandler, RetryMixin):
     """
     WorldClim v2.1 monthly climate normals acquisition.

--- a/src/symfluence/data/acquisition/registry.py
+++ b/src/symfluence/data/acquisition/registry.py
@@ -40,7 +40,7 @@ class AcquisitionRegistry(BaseRegistry):
 
     Usage:
         # Handler registration (in handler module):
-        @AcquisitionRegistry.register('ERA5')
+        @R.acquisition_handlers.add('ERA5')
         class ERA5Acquirer(BaseAcquisitionHandler):
             ...
 

--- a/src/symfluence/data/observation/__init__.py
+++ b/src/symfluence/data/observation/__init__.py
@@ -7,7 +7,8 @@ This module provides handlers for acquiring observational data from various sour
 (GRACE, MODIS, USGS, etc.) and processing them into SYMFLUENCE-standard formats.
 
 The module uses a plugin-style registry pattern: observation handlers are defined
-in separate modules and self-register using the @ObservationRegistry.register() decorator.
+in separate modules and self-register via the unified registry
+(``@R.observation_handlers.add()``).
 Importing the handlers package triggers their registration, making them available
 for dynamic instantiation by type string.
 

--- a/src/symfluence/data/observation/handlers/ana.py
+++ b/src/symfluence/data/observation/handlers/ana.py
@@ -34,9 +34,9 @@ import pandas as pd
 import requests
 
 from symfluence.core.exceptions import DataAcquisitionError, symfluence_error_handler
+from symfluence.core.registries import R
 
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 ZENODO_STREAMFLOW_URL = (
     "https://zenodo.org/api/records/15025488/files/"
@@ -52,7 +52,7 @@ ANA_STATIONS = {
 }
 
 
-@ObservationRegistry.register("ana_streamflow")
+@R.observation_handlers.add("ana_streamflow")
 class ANAStreamflowHandler(BaseObservationHandler):
     """Handles Brazilian ANA streamflow data via CAMELS-BR (Zenodo).
 

--- a/src/symfluence/data/observation/handlers/camels.py
+++ b/src/symfluence/data/observation/handlers/camels.py
@@ -37,8 +37,9 @@ from typing import Dict, List, Optional
 import numpy as np
 import pandas as pd
 
+from symfluence.core.registries import R
+
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 # ============================================================================
 # Catchment attribute column mappings per CAMELS variant
@@ -345,7 +346,7 @@ class _BaseCAMELSStreamflowHandler(BaseObservationHandler):
 # CAMELS-US
 # ============================================================================
 
-@ObservationRegistry.register('camels_us_streamflow')
+@R.observation_handlers.add('camels_us_streamflow')
 class CAMELSUSStreamflowHandler(_BaseCAMELSStreamflowHandler):
     """CAMELS-US streamflow handler (671 USGS basins).
 
@@ -392,7 +393,7 @@ class CAMELSUSStreamflowHandler(_BaseCAMELSStreamflowHandler):
 # CAMELS-BR
 # ============================================================================
 
-@ObservationRegistry.register('camels_br_streamflow')
+@R.observation_handlers.add('camels_br_streamflow')
 class CAMELSBRStreamflowHandler(_BaseCAMELSStreamflowHandler):
     """CAMELS-BR streamflow handler (897 Brazilian basins).
 
@@ -469,7 +470,7 @@ class CAMELSBRStreamflowHandler(_BaseCAMELSStreamflowHandler):
 # CAMELS-CL
 # ============================================================================
 
-@ObservationRegistry.register('camels_cl_streamflow')
+@R.observation_handlers.add('camels_cl_streamflow')
 class CAMELSCLStreamflowHandler(_BaseCAMELSStreamflowHandler):
     """CAMELS-CL streamflow handler (516 Chilean basins).
 
@@ -534,7 +535,7 @@ class CAMELSCLStreamflowHandler(_BaseCAMELSStreamflowHandler):
 # CAMELS-AUS
 # ============================================================================
 
-@ObservationRegistry.register('camels_aus_streamflow')
+@R.observation_handlers.add('camels_aus_streamflow')
 class CAMELSAUSStreamflowHandler(_BaseCAMELSStreamflowHandler):
     """CAMELS-AUS streamflow handler (222 Australian basins).
 
@@ -599,7 +600,7 @@ class CAMELSAUSStreamflowHandler(_BaseCAMELSStreamflowHandler):
 # CAMELS-GB
 # ============================================================================
 
-@ObservationRegistry.register('camels_gb_streamflow')
+@R.observation_handlers.add('camels_gb_streamflow')
 class CAMELSGBStreamflowHandler(_BaseCAMELSStreamflowHandler):
     """CAMELS-GB streamflow handler (671 British basins).
 

--- a/src/symfluence/data/observation/handlers/canopy_height.py
+++ b/src/symfluence/data/observation/handlers/canopy_height.py
@@ -25,8 +25,9 @@ import pandas as pd
 import rasterio
 from rasterio.mask import mask as rio_mask
 
+from symfluence.core.registries import R
+
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 # Scale factors and valid ranges
 CANOPY_HEIGHT_VALID_RANGE = (0, 100)  # meters
@@ -35,9 +36,9 @@ META_HEIGHT_SCALE = 1.0  # Already in meters
 GLAD_COVER_SCALE = 1.0  # Percentage for tree cover
 
 
-@ObservationRegistry.register('canopy_height')
-@ObservationRegistry.register('tree_height')
-@ObservationRegistry.register('vegetation_height')
+@R.observation_handlers.add('canopy_height')
+@R.observation_handlers.add('tree_height')
+@R.observation_handlers.add('vegetation_height')
 class CanopyHeightHandler(BaseObservationHandler):
     """
     Unified handler for tree canopy height data from multiple sources.
@@ -431,7 +432,7 @@ class CanopyHeightHandler(BaseObservationHandler):
         return None
 
 
-@ObservationRegistry.register('gedi_canopy_height')
+@R.observation_handlers.add('gedi_canopy_height')
 class GEDICanopyHeightHandler(CanopyHeightHandler):
     """
     GEDI-specific canopy height handler.
@@ -446,8 +447,8 @@ class GEDICanopyHeightHandler(CanopyHeightHandler):
         self.canopy_height_source = 'gedi'
 
 
-@ObservationRegistry.register('meta_canopy_height')
-@ObservationRegistry.register('wri_canopy_height')
+@R.observation_handlers.add('meta_canopy_height')
+@R.observation_handlers.add('wri_canopy_height')
 class MetaCanopyHeightHandler(CanopyHeightHandler):
     """
     Meta/WRI-specific canopy height handler.
@@ -462,8 +463,8 @@ class MetaCanopyHeightHandler(CanopyHeightHandler):
         self.canopy_height_source = 'meta'
 
 
-@ObservationRegistry.register('glad_tree_height')
-@ObservationRegistry.register('umd_tree_height')
+@R.observation_handlers.add('glad_tree_height')
+@R.observation_handlers.add('umd_tree_height')
 class GLADTreeHeightHandler(CanopyHeightHandler):
     """
     GLAD/UMD-specific tree height handler.

--- a/src/symfluence/data/observation/handlers/canswe.py
+++ b/src/symfluence/data/observation/handlers/canswe.py
@@ -41,9 +41,9 @@ import requests
 import xarray as xr
 
 from symfluence.core.exceptions import DataAcquisitionError
+from symfluence.core.registries import R
 
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 # Zenodo record IDs for CanSWE versions
 CANSWE_ZENODO_RECORDS = {
@@ -56,8 +56,8 @@ CANSWE_ZENODO_RECORDS = {
 CANSWE_DEFAULT_VERSION = 'v6'
 
 
-@ObservationRegistry.register('canswe')
-@ObservationRegistry.register('canswe_swe')
+@R.observation_handlers.add('canswe')
+@R.observation_handlers.add('canswe_swe')
 class CanSWEHandler(BaseObservationHandler):
     """
     Handles CanSWE data acquisition and processing.
@@ -625,8 +625,8 @@ class CanSWEHandler(BaseObservationHandler):
 
 
 # Also register NorSWE as an alias with extended coverage
-@ObservationRegistry.register('norswe')
-@ObservationRegistry.register('norswe_swe')
+@R.observation_handlers.add('norswe')
+@R.observation_handlers.add('norswe_swe')
 class NorSWEHandler(CanSWEHandler):
     """
     Handles NorSWE (Northern Hemisphere SWE) data acquisition and processing.

--- a/src/symfluence/data/observation/handlers/chirps.py
+++ b/src/symfluence/data/observation/handlers/chirps.py
@@ -26,11 +26,12 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 
-@ObservationRegistry.register('chirps')
+@R.observation_handlers.add('chirps')
 class CHIRPSHandler(BaseObservationHandler):
     """
     Handles CHIRPS precipitation data acquisition and processing.

--- a/src/symfluence/data/observation/handlers/cmc_snow.py
+++ b/src/symfluence/data/observation/handlers/cmc_snow.py
@@ -28,15 +28,16 @@ from typing import List, Optional
 import numpy as np
 import pandas as pd
 
+from symfluence.core.registries import R
+
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 # Default bulk snow density (kg/m^3) for depth-to-SWE conversion
 DEFAULT_SNOW_DENSITY = 200.0
 
 
-@ObservationRegistry.register('cmc_snow')
-@ObservationRegistry.register('cmc_swe')
+@R.observation_handlers.add('cmc_snow')
+@R.observation_handlers.add('cmc_swe')
 class CMCSnowHandler(BaseObservationHandler):
     """
     Handles CMC Snow Depth Analysis data acquisition and processing.

--- a/src/symfluence/data/observation/handlers/cnes_grgs_tws.py
+++ b/src/symfluence/data/observation/handlers/cnes_grgs_tws.py
@@ -14,12 +14,13 @@ from pathlib import Path
 
 import pandas as pd
 
+from symfluence.core.registries import R
+
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 
-@ObservationRegistry.register('cnes_grgs')
-@ObservationRegistry.register('cnes_grgs_tws')
+@R.observation_handlers.add('cnes_grgs')
+@R.observation_handlers.add('cnes_grgs_tws')
 class CNESGRGSHandler(BaseObservationHandler):
     """
     Handles CNES/GRGS RL05 GRACE Total Water Storage data.

--- a/src/symfluence/data/observation/handlers/daymet.py
+++ b/src/symfluence/data/observation/handlers/daymet.py
@@ -17,11 +17,12 @@ import geopandas as gpd
 import pandas as pd
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 
-@ObservationRegistry.register('daymet')
+@R.observation_handlers.add('daymet')
 class DaymetHandler(BaseObservationHandler):
     """
     Handles Daymet climate data processing.

--- a/src/symfluence/data/observation/handlers/dga.py
+++ b/src/symfluence/data/observation/handlers/dga.py
@@ -36,9 +36,9 @@ import pandas as pd
 import requests
 
 from symfluence.core.exceptions import DataAcquisitionError, symfluence_error_handler
+from symfluence.core.registries import R
 
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 # PANGAEA direct download URL for CAMELS-CL streamflow (m3/s)
 PANGAEA_STREAMFLOW_URL = (
@@ -66,7 +66,7 @@ def _normalize_station_id(station_id: str) -> str:
     return str(station_id).split('-')[0].strip()
 
 
-@ObservationRegistry.register('dga_streamflow')
+@R.observation_handlers.add('dga_streamflow')
 class DGAStreamflowHandler(BaseObservationHandler):
     """Handles Chilean DGA streamflow data via CAMELS-CL (PANGAEA).
 

--- a/src/symfluence/data/observation/handlers/era5_land.py
+++ b/src/symfluence/data/observation/handlers/era5_land.py
@@ -17,8 +17,9 @@ import geopandas as gpd
 import pandas as pd
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 # Variable name mapping (CDS names to standard names)
 VARIABLE_MAPPING = {
@@ -59,8 +60,8 @@ UNIT_CONVERSIONS = {
 }
 
 
-@ObservationRegistry.register('era5_land')
-@ObservationRegistry.register('era5land')
+@R.observation_handlers.add('era5_land')
+@R.observation_handlers.add('era5land')
 class ERA5LandHandler(BaseObservationHandler):
     """
     Handles ERA5-Land reanalysis data processing for hydrological applications.

--- a/src/symfluence/data/observation/handlers/fluxcom.py
+++ b/src/symfluence/data/observation/handlers/fluxcom.py
@@ -14,11 +14,12 @@ from pathlib import Path
 import pandas as pd
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 
-@ObservationRegistry.register('fluxcom_et')
+@R.observation_handlers.add('fluxcom_et')
 class FLUXCOMETHandler(BaseObservationHandler):
     """
     Handles FLUXCOM Evapotranspiration data.

--- a/src/symfluence/data/observation/handlers/fluxnet.py
+++ b/src/symfluence/data/observation/handlers/fluxnet.py
@@ -20,14 +20,15 @@ from typing import Any, Dict, Optional
 
 import pandas as pd
 
+from symfluence.core.registries import R
+
 from ...acquisition.handlers.fluxnet_constants import convert_le_to_et
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 
-@ObservationRegistry.register('fluxnet')
-@ObservationRegistry.register('fluxnet_et')
-@ObservationRegistry.register('ameriflux')
+@R.observation_handlers.add('fluxnet')
+@R.observation_handlers.add('fluxnet_et')
+@R.observation_handlers.add('ameriflux')
 class FLUXNETObservationHandler(BaseObservationHandler):
 
     obs_type = "et"

--- a/src/symfluence/data/observation/handlers/ggmn.py
+++ b/src/symfluence/data/observation/handlers/ggmn.py
@@ -15,12 +15,12 @@ import pandas as pd
 import requests
 
 from symfluence.core.exceptions import DataAcquisitionError, symfluence_error_handler
+from symfluence.core.registries import R
 
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 
-@ObservationRegistry.register('ggmn')
+@R.observation_handlers.add('ggmn')
 class GGMNHandler(BaseObservationHandler):
     """
     Handles GGMN groundwater data acquisition and processing.

--- a/src/symfluence/data/observation/handlers/gldas_tws.py
+++ b/src/symfluence/data/observation/handlers/gldas_tws.py
@@ -13,12 +13,13 @@ from pathlib import Path
 
 import pandas as pd
 
+from symfluence.core.registries import R
+
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 
-@ObservationRegistry.register('gldas')
-@ObservationRegistry.register('gldas_tws')
+@R.observation_handlers.add('gldas')
+@R.observation_handlers.add('gldas_tws')
 class GLDASHandler(BaseObservationHandler):
     """
     Handles GLDAS-2.1 Noah Total Water Storage data.

--- a/src/symfluence/data/observation/handlers/gleam.py
+++ b/src/symfluence/data/observation/handlers/gleam.py
@@ -19,11 +19,12 @@ import pandas as pd
 import requests
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 
-@ObservationRegistry.register('gleam_et')
+@R.observation_handlers.add('gleam_et')
 class GLEAMETHandler(BaseObservationHandler):
     """
     Handles GLEAM evapotranspiration data.

--- a/src/symfluence/data/observation/handlers/gpm.py
+++ b/src/symfluence/data/observation/handlers/gpm.py
@@ -25,12 +25,13 @@ from typing import List, Optional
 import pandas as pd
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 
-@ObservationRegistry.register('gpm_imerg')
-@ObservationRegistry.register('gpm')
+@R.observation_handlers.add('gpm_imerg')
+@R.observation_handlers.add('gpm')
 class GPMIMERGHandler(BaseObservationHandler):
     """
     Handles GPM IMERG precipitation data acquisition and processing.

--- a/src/symfluence/data/observation/handlers/grace.py
+++ b/src/symfluence/data/observation/handlers/grace.py
@@ -17,11 +17,12 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 
-@ObservationRegistry.register('grace')
+@R.observation_handlers.add('grace')
 class GRACEHandler(BaseObservationHandler):
     """
     Handles GRACE Total Water Storage anomaly data.

--- a/src/symfluence/data/observation/handlers/grdc.py
+++ b/src/symfluence/data/observation/handlers/grdc.py
@@ -14,11 +14,12 @@ from typing import Optional
 
 import pandas as pd
 
+from symfluence.core.registries import R
+
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 
-@ObservationRegistry.register('grdc')
+@R.observation_handlers.add('grdc')
 class GRDCHandler(BaseObservationHandler):
     """
     Handles GRDC streamflow data processing.

--- a/src/symfluence/data/observation/handlers/hubeau.py
+++ b/src/symfluence/data/observation/handlers/hubeau.py
@@ -27,9 +27,9 @@ import pandas as pd
 import requests
 
 from symfluence.core.exceptions import DataAcquisitionError
+from symfluence.core.registries import R
 
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 # Hub'Eau API configuration
 HUBEAU_BASE_URL = "https://hubeau.eaufrance.fr/api/v1/hydrometrie"
@@ -85,7 +85,7 @@ def _hubeau_request(url: str, params: dict, timeout: int = DEFAULT_TIMEOUT) -> r
         raise HubEauAPIError(f"Hub'Eau API request timed out after {timeout}s") from None
 
 
-@ObservationRegistry.register('hubeau_streamflow')
+@R.observation_handlers.add('hubeau_streamflow')
 class HubEauStreamflowHandler(BaseObservationHandler):
     """
     Handles French streamflow (discharge) data from Hub'Eau API.
@@ -407,7 +407,7 @@ class HubEauStreamflowHandler(BaseObservationHandler):
         return df
 
 
-@ObservationRegistry.register('hubeau_waterlevel')
+@R.observation_handlers.add('hubeau_waterlevel')
 class HubEauWaterLevelHandler(BaseObservationHandler):
     """
     Handles French water level data from Hub'Eau API.

--- a/src/symfluence/data/observation/handlers/ims_snow.py
+++ b/src/symfluence/data/observation/handlers/ims_snow.py
@@ -27,12 +27,13 @@ from typing import Optional
 import pandas as pd
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 
-@ObservationRegistry.register('ims_snow')
-@ObservationRegistry.register('ims_sca')
+@R.observation_handlers.add('ims_snow')
+@R.observation_handlers.add('ims_sca')
 class IMSSnowHandler(BaseObservationHandler):
     """
     Handles IMS snow cover data acquisition and processing.

--- a/src/symfluence/data/observation/handlers/jrc_water.py
+++ b/src/symfluence/data/observation/handlers/jrc_water.py
@@ -25,13 +25,14 @@ from typing import Optional
 import numpy as np
 import pandas as pd
 
+from symfluence.core.registries import R
+
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 
-@ObservationRegistry.register('jrc_water')
-@ObservationRegistry.register('jrc_gsw')
-@ObservationRegistry.register('surface_water')
+@R.observation_handlers.add('jrc_water')
+@R.observation_handlers.add('jrc_gsw')
+@R.observation_handlers.add('surface_water')
 class JRCWaterHandler(BaseObservationHandler):
     """
     Handles JRC Global Surface Water data acquisition and processing.

--- a/src/symfluence/data/observation/handlers/lamah_ice.py
+++ b/src/symfluence/data/observation/handlers/lamah_ice.py
@@ -19,10 +19,10 @@ from typing import Iterable
 import pandas as pd
 
 from symfluence.core.exceptions import DataAcquisitionError
+from symfluence.core.registries import R
 from symfluence.data.acquisition.utils import create_robust_session
 
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 # HydroShare record for LamaH-Ice (Helgason & Nijssen, 2024, ESSD).
 # DOI: 10.4211/hs.86117a5f36cc4b7c90a5d54e18161c91
@@ -155,7 +155,7 @@ def _extract_d_gauges(zip_path: Path, lamah_path: Path,
         ) from e
 
 
-@ObservationRegistry.register('lamah_ice_streamflow')
+@R.observation_handlers.add('lamah_ice_streamflow')
 class LamahIceStreamflowHandler(BaseObservationHandler):
     """Handles LamaH-ICE streamflow data processing, with auto-download
     from HydroShare when the local dataset is missing."""

--- a/src/symfluence/data/observation/handlers/modis_et.py
+++ b/src/symfluence/data/observation/handlers/modis_et.py
@@ -21,13 +21,14 @@ from typing import Optional
 import pandas as pd
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 
-@ObservationRegistry.register('modis_et')
-@ObservationRegistry.register('mod16')
-@ObservationRegistry.register('mod16a2')
+@R.observation_handlers.add('modis_et')
+@R.observation_handlers.add('mod16')
+@R.observation_handlers.add('mod16a2')
 class MODISETHandler(BaseObservationHandler):
     """
     Handles MODIS MOD16A2 8-day Evapotranspiration (ET) data.

--- a/src/symfluence/data/observation/handlers/modis_lai.py
+++ b/src/symfluence/data/observation/handlers/modis_lai.py
@@ -28,8 +28,9 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 # Scale factors and valid ranges for MODIS LAI/FPAR
 LAI_SCALE_FACTOR = 0.1  # To get LAI in m²/m²
@@ -39,9 +40,9 @@ FPAR_VALID_RANGE = (0, 100)  # Valid DN range (0-1 after scaling)
 FILL_VALUE = 255
 
 
-@ObservationRegistry.register('modis_lai')
-@ObservationRegistry.register('mcd15')
-@ObservationRegistry.register('lai')
+@R.observation_handlers.add('modis_lai')
+@R.observation_handlers.add('mcd15')
+@R.observation_handlers.add('lai')
 class MODISLAIHandler(BaseObservationHandler):
     """
     Handles MODIS LAI/FPAR data processing.

--- a/src/symfluence/data/observation/handlers/modis_lst.py
+++ b/src/symfluence/data/observation/handlers/modis_lst.py
@@ -21,8 +21,9 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 # Scale factors and valid ranges
 LST_SCALE_FACTOR = 0.02  # Convert to Kelvin
@@ -33,8 +34,8 @@ LST_FILL_VALUE = 0
 QC_GOOD_QUALITY = [0, 1]  # Bits 0-1: 00=good, 01=other quality
 
 
-@ObservationRegistry.register('modis_lst')
-@ObservationRegistry.register('mod11')
+@R.observation_handlers.add('modis_lst')
+@R.observation_handlers.add('mod11')
 class MODISLSTHandler(BaseObservationHandler):
     """
     Handles MODIS Land Surface Temperature data processing.

--- a/src/symfluence/data/observation/handlers/modis_snow.py
+++ b/src/symfluence/data/observation/handlers/modis_snow.py
@@ -16,12 +16,13 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from symfluence.core.registries import R
+
 HAS_GEO = find_spec("geopandas") is not None
 if HAS_GEO:
     import geopandas as gpd
 
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 from .modis_utils import (
     CLOUD_VALUE,
     MODIS_FILL_VALUES,
@@ -29,7 +30,7 @@ from .modis_utils import (
 )
 
 
-@ObservationRegistry.register('modis_snow')
+@R.observation_handlers.add('modis_snow')
 class MODISSnowHandler(BaseObservationHandler):
     """
     Handles MODIS Snow Cover Area (SCA) data.
@@ -310,8 +311,8 @@ class MODISSnowHandler(BaseObservationHandler):
         return output_file
 
 
-@ObservationRegistry.register('modis_sca')
-@ObservationRegistry.register('modis_snow_merged')
+@R.observation_handlers.add('modis_sca')
+@R.observation_handlers.add('modis_snow_merged')
 class MODISSCAHandler(MODISSnowHandler):
     """
     Specialized handler for merged MODIS SCA (MOD10A1 + MYD10A1).

--- a/src/symfluence/data/observation/handlers/mswep.py
+++ b/src/symfluence/data/observation/handlers/mswep.py
@@ -18,11 +18,12 @@ import geopandas as gpd
 import pandas as pd
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 
-@ObservationRegistry.register('mswep')
+@R.observation_handlers.add('mswep')
 class MSWEPHandler(BaseObservationHandler):
     """
     Handles MSWEP precipitation data processing.

--- a/src/symfluence/data/observation/handlers/openet.py
+++ b/src/symfluence/data/observation/handlers/openet.py
@@ -15,11 +15,12 @@ from typing import Optional
 
 import pandas as pd
 
+from symfluence.core.registries import R
+
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 
-@ObservationRegistry.register('openet')
+@R.observation_handlers.add('openet')
 class OpenETHandler(BaseObservationHandler):
     """
     Handles OpenET evapotranspiration data processing.

--- a/src/symfluence/data/observation/handlers/sentinel1_sm.py
+++ b/src/symfluence/data/observation/handlers/sentinel1_sm.py
@@ -19,12 +19,13 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 
-@ObservationRegistry.register('sentinel1_sm')
-@ObservationRegistry.register('s1_sm')
+@R.observation_handlers.add('sentinel1_sm')
+@R.observation_handlers.add('s1_sm')
 class Sentinel1SMHandler(BaseObservationHandler):
     """
     Handles Sentinel-1 SAR soil moisture data processing.

--- a/src/symfluence/data/observation/handlers/smhi.py
+++ b/src/symfluence/data/observation/handlers/smhi.py
@@ -14,12 +14,12 @@ import pandas as pd
 import requests
 
 from symfluence.core.exceptions import DataAcquisitionError, symfluence_error_handler
+from symfluence.core.registries import R
 
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 
-@ObservationRegistry.register('smhi_streamflow')
+@R.observation_handlers.add('smhi_streamflow')
 class SMHIStreamflowHandler(BaseObservationHandler):
     """
     Handles SMHI streamflow data acquisition and processing.

--- a/src/symfluence/data/observation/handlers/snodas.py
+++ b/src/symfluence/data/observation/handlers/snodas.py
@@ -26,12 +26,13 @@ from typing import List, Optional
 import pandas as pd
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 
-@ObservationRegistry.register('snodas')
-@ObservationRegistry.register('snodas_swe')
+@R.observation_handlers.add('snodas')
+@R.observation_handlers.add('snodas_swe')
 class SNODASHandler(BaseObservationHandler):
     """
     Handles SNODAS snow data acquisition and processing.

--- a/src/symfluence/data/observation/handlers/snotel.py
+++ b/src/symfluence/data/observation/handlers/snotel.py
@@ -15,12 +15,12 @@ import pandas as pd
 import requests
 
 from symfluence.core.exceptions import DataAcquisitionError, symfluence_error_handler
+from symfluence.core.registries import R
 
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 
-@ObservationRegistry.register('snotel')
+@R.observation_handlers.add('snotel')
 class SNOTELHandler(BaseObservationHandler):
     """
     Handles SNOTEL data acquisition and processing.

--- a/src/symfluence/data/observation/handlers/soil_moisture.py
+++ b/src/symfluence/data/observation/handlers/soil_moisture.py
@@ -23,11 +23,12 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 
-@ObservationRegistry.register('smap')
+@R.observation_handlers.add('smap')
 class SMAPHandler(BaseObservationHandler):
     """
     Handles SMAP Soil Moisture data.
@@ -156,7 +157,7 @@ class SMAPHandler(BaseObservationHandler):
         return output_file
 
 
-@ObservationRegistry.register('ismn')
+@R.observation_handlers.add('ismn')
 class ISMNHandler(BaseObservationHandler):
     """
     Handles ISMN soil moisture data.
@@ -338,7 +339,7 @@ class ISMNHandler(BaseObservationHandler):
             self.logger.debug(f"Could not convert target_depth '{target_depth}' to float, using default 0.05")
             return 0.05
 
-@ObservationRegistry.register('esa_cci_sm')
+@R.observation_handlers.add('esa_cci_sm')
 class ESACCISMHandler(BaseObservationHandler):
     """
     Handles ESA CCI Soil Moisture data.
@@ -449,8 +450,8 @@ class ESACCISMHandler(BaseObservationHandler):
         return output_file
 
 
-@ObservationRegistry.register('smos')
-@ObservationRegistry.register('smos_sm')
+@R.observation_handlers.add('smos')
+@R.observation_handlers.add('smos_sm')
 class SMOSSMHandler(BaseObservationHandler):
     """
     Handles SMOS (Soil Moisture and Ocean Salinity) data.
@@ -589,8 +590,8 @@ class SMOSSMHandler(BaseObservationHandler):
         return output_file
 
 
-@ObservationRegistry.register('ascat')
-@ObservationRegistry.register('ascat_sm')
+@R.observation_handlers.add('ascat')
+@R.observation_handlers.add('ascat_sm')
 class ASCATSMHandler(BaseObservationHandler):
     """
     Handles ASCAT (Advanced Scatterometer) soil moisture data.

--- a/src/symfluence/data/observation/handlers/ssebop.py
+++ b/src/symfluence/data/observation/handlers/ssebop.py
@@ -26,12 +26,13 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 
-@ObservationRegistry.register('ssebop')
-@ObservationRegistry.register('ssebop_et')
+@R.observation_handlers.add('ssebop')
+@R.observation_handlers.add('ssebop_et')
 class SSEBopHandler(BaseObservationHandler):
     """
     Handles SSEBop ET data acquisition and processing.

--- a/src/symfluence/data/observation/handlers/usgs.py
+++ b/src/symfluence/data/observation/handlers/usgs.py
@@ -16,12 +16,12 @@ import requests
 
 from symfluence.core.constants import UnitConversion
 from symfluence.core.exceptions import DataAcquisitionError, symfluence_error_handler
+from symfluence.core.registries import R
 
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 
-@ObservationRegistry.register('usgs_streamflow')
+@R.observation_handlers.add('usgs_streamflow')
 class USGSStreamflowHandler(BaseObservationHandler):
     """
     Handles USGS streamflow (discharge) data acquisition and processing.
@@ -231,7 +231,7 @@ class USGSStreamflowHandler(BaseObservationHandler):
         return output_file
 
 
-@ObservationRegistry.register('usgs_gw')
+@R.observation_handlers.add('usgs_gw')
 class USGSGroundwaterHandler(BaseObservationHandler):
     """
     Handles USGS groundwater level data.

--- a/src/symfluence/data/observation/handlers/viirs_snow.py
+++ b/src/symfluence/data/observation/handlers/viirs_snow.py
@@ -18,16 +18,17 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from symfluence.core.registries import R
+
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 # VIIRS NDSI snow cover valid ranges and QA flags
 NDSI_VALID_RANGE = (0, 100)  # 0-100% snow cover
 NDSI_FILL_VALUES = [200, 201, 211, 237, 239, 250, 251, 252, 253, 254, 255]
 
 
-@ObservationRegistry.register('viirs_snow')
-@ObservationRegistry.register('vnp10')
+@R.observation_handlers.add('viirs_snow')
+@R.observation_handlers.add('vnp10')
 class VIIRSSnowHandler(BaseObservationHandler):
     """
     Handles VIIRS snow cover data processing.

--- a/src/symfluence/data/observation/handlers/wsc.py
+++ b/src/symfluence/data/observation/handlers/wsc.py
@@ -15,12 +15,12 @@ import pandas as pd
 import requests
 
 from symfluence.core.exceptions import DataAcquisitionError
+from symfluence.core.registries import R
 
 from ..base import BaseObservationHandler
-from ..registry import ObservationRegistry
 
 
-@ObservationRegistry.register('wsc_streamflow')
+@R.observation_handlers.add('wsc_streamflow')
 class WSCStreamflowHandler(BaseObservationHandler):
     """
     Handles WSC streamflow data acquisition and processing.

--- a/src/symfluence/data/observation/registry.py
+++ b/src/symfluence/data/observation/registry.py
@@ -15,7 +15,7 @@ Phase 4 delegation shim: all state lives in ``R.observation_handlers``.
 Example:
     Register a custom handler:
 
-    >>> @ObservationRegistry.register('custom_sensor')
+    >>> @R.observation_handlers.add('custom_sensor')
     ... class CustomHandler(BaseObservationHandler):
     ...     def acquire(self): ...
     ...     def process(self, input_path): ...

--- a/src/symfluence/data/preprocessing/dataset_handlers/aorc_utils.py
+++ b/src/symfluence/data/preprocessing/dataset_handlers/aorc_utils.py
@@ -18,13 +18,13 @@ import xarray as xr
 from shapely.geometry import Polygon
 
 from symfluence.core.constants import UnitConversion
+from symfluence.core.registries import R
 
 from ...utils import VariableStandardizer
 from .base_dataset import BaseDatasetHandler
-from .dataset_registry import DatasetRegistry
 
 
-@DatasetRegistry.register('aorc')
+@R.dataset_handlers.add('aorc')
 class AORCHandler(BaseDatasetHandler):
     """
     Handler for AORC (Analysis of Record for Calibration) dataset.

--- a/src/symfluence/data/preprocessing/dataset_handlers/base_dataset.py
+++ b/src/symfluence/data/preprocessing/dataset_handlers/base_dataset.py
@@ -251,7 +251,7 @@ class BaseDatasetHandler(ABC, ConfigMixin):
         domain_name (str): Domain identifier
 
     Example Subclass:
-        >>> @DatasetRegistry.register('my_dataset')
+        >>> @R.dataset_handlers.add('my_dataset')
         >>> class MyDatasetHandler(BaseDatasetHandler):
         ...     def get_variable_mapping(self):
         ...         return {'t2m': 'air_temperature', 'tp': 'precipitation_flux'}

--- a/src/symfluence/data/preprocessing/dataset_handlers/carra_utils.py
+++ b/src/symfluence/data/preprocessing/dataset_handlers/carra_utils.py
@@ -16,12 +16,13 @@ import xarray as xr
 from pyproj import CRS, Transformer
 from shapely.geometry import Polygon
 
+from symfluence.core.registries import R
+
 from ...utils import VariableStandardizer
 from .base_dataset import BaseDatasetHandler
-from .dataset_registry import DatasetRegistry
 
 
-@DatasetRegistry.register('carra')
+@R.dataset_handlers.add('carra')
 class CARRAHandler(BaseDatasetHandler):
     """Handler for CARRA (Copernicus Arctic Regional Reanalysis) dataset."""
 

--- a/src/symfluence/data/preprocessing/dataset_handlers/casr_utils.py
+++ b/src/symfluence/data/preprocessing/dataset_handlers/casr_utils.py
@@ -19,13 +19,13 @@ import xarray as xr
 from shapely.geometry import Polygon
 
 from symfluence.core.constants import PhysicalConstants, UnitConversion
+from symfluence.core.registries import R
 
 from ...utils import VariableStandardizer
 from .base_dataset import BaseDatasetHandler
-from .dataset_registry import DatasetRegistry
 
 
-@DatasetRegistry.register('casr')
+@R.dataset_handlers.add('casr')
 class CASRHandler(BaseDatasetHandler):
     """Handler for CASR (Canadian Arctic System Reanalysis) dataset."""
 

--- a/src/symfluence/data/preprocessing/dataset_handlers/cerra_utils.py
+++ b/src/symfluence/data/preprocessing/dataset_handlers/cerra_utils.py
@@ -16,12 +16,13 @@ import numpy as np
 import xarray as xr
 from shapely.geometry import Polygon
 
+from symfluence.core.registries import R
+
 from ...utils import VariableStandardizer
 from .base_dataset import BaseDatasetHandler
-from .dataset_registry import DatasetRegistry
 
 
-@DatasetRegistry.register('cerra')
+@R.dataset_handlers.add('cerra')
 class CERRAHandler(BaseDatasetHandler):
     """Handler for CERRA (Copernicus European Regional Reanalysis) dataset."""
 

--- a/src/symfluence/data/preprocessing/dataset_handlers/conus404_utils.py
+++ b/src/symfluence/data/preprocessing/dataset_handlers/conus404_utils.py
@@ -17,12 +17,13 @@ import numpy as np
 import xarray as xr
 from shapely.geometry import Polygon
 
+from symfluence.core.registries import R
+
 from ...utils import VariableStandardizer
 from .base_dataset import BaseDatasetHandler
-from .dataset_registry import DatasetRegistry
 
 
-@DatasetRegistry.register("conus404")
+@R.dataset_handlers.add("conus404")
 class CONUS404Handler(BaseDatasetHandler):
     """
     Handler for CONUS404 WRF reanalysis.

--- a/src/symfluence/data/preprocessing/dataset_handlers/dataset_registry.py
+++ b/src/symfluence/data/preprocessing/dataset_handlers/dataset_registry.py
@@ -18,9 +18,11 @@ class DatasetRegistry(BaseRegistry):
     """
     Registry for dataset preprocessing handlers.
 
-    Handlers are registered using the @register decorator and retrieved
-    using get_handler(). All keys are normalized to lowercase.
+    Handlers register via the unified registry (``@R.dataset_handlers.add('x')``)
+    and are retrieved using get_handler(). All keys are normalized to lowercase.
     """
+
+    _r_registry_name = "dataset_handlers"
 
     _handlers: Dict[str, Type] = {}
 

--- a/src/symfluence/data/preprocessing/dataset_handlers/daymet_utils.py
+++ b/src/symfluence/data/preprocessing/dataset_handlers/daymet_utils.py
@@ -21,12 +21,13 @@ import numpy as np
 import xarray as xr
 from shapely.geometry import Polygon
 
+from symfluence.core.registries import R
+
 from ...utils import VariableStandardizer
 from .base_dataset import BaseDatasetHandler
-from .dataset_registry import DatasetRegistry
 
 
-@DatasetRegistry.register("daymet")
+@R.dataset_handlers.add("daymet")
 class DaymetHandler(BaseDatasetHandler):
     """
     Handler for Daymet daily surface weather forcing data.

--- a/src/symfluence/data/preprocessing/dataset_handlers/era5_utils.py
+++ b/src/symfluence/data/preprocessing/dataset_handlers/era5_utils.py
@@ -17,13 +17,14 @@ import geopandas as gpd
 import xarray as xr
 from shapely.geometry import Polygon
 
+from symfluence.core.registries import R
+
 from ...utils import VariableStandardizer
 from .base_dataset import BaseDatasetHandler
-from .dataset_registry import DatasetRegistry
 
 
-@DatasetRegistry.register('era5')
-@DatasetRegistry.register('era5_cds')
+@R.dataset_handlers.add('era5')
+@R.dataset_handlers.add('era5_cds')
 class ERA5Handler(BaseDatasetHandler):
     """Handler for ERA5 (ECMWF Reanalysis v5) dataset."""
 

--- a/src/symfluence/data/preprocessing/dataset_handlers/hrrr_utils.py
+++ b/src/symfluence/data/preprocessing/dataset_handlers/hrrr_utils.py
@@ -17,12 +17,13 @@ import numpy as np
 import xarray as xr
 from shapely.geometry import Polygon
 
+from symfluence.core.registries import R
+
 from ...utils import VariableStandardizer
 from .base_dataset import BaseDatasetHandler
-from .dataset_registry import DatasetRegistry
 
 
-@DatasetRegistry.register("hrrr")
+@R.dataset_handlers.add("hrrr")
 class HRRRHandler(BaseDatasetHandler):
     """
     Handler for HRRR (High-Resolution Rapid Refresh) forcing data.

--- a/src/symfluence/data/preprocessing/dataset_handlers/nex_gddp_utils.py
+++ b/src/symfluence/data/preprocessing/dataset_handlers/nex_gddp_utils.py
@@ -17,13 +17,14 @@ import numpy as np
 import xarray as xr
 from shapely.geometry import Polygon
 
+from symfluence.core.registries import R
+
 from ...utils import VariableStandardizer
 from .base_dataset import BaseDatasetHandler
-from .dataset_registry import DatasetRegistry
 
 
-@DatasetRegistry.register("nex-gddp-cmip6")
-@DatasetRegistry.register("nex-gddp")
+@R.dataset_handlers.add("nex-gddp-cmip6")
+@R.dataset_handlers.add("nex-gddp")
 class NEXGDDPCMIP6Handler(BaseDatasetHandler):
     """
     Handler for NEX-GDDP-CMIP6 downscaled climate data.

--- a/src/symfluence/data/preprocessing/dataset_handlers/nwm3_retrospective_utils.py
+++ b/src/symfluence/data/preprocessing/dataset_handlers/nwm3_retrospective_utils.py
@@ -29,13 +29,13 @@ import xarray as xr
 from shapely.geometry import Polygon
 
 from symfluence.core.constants import UnitConversion
+from symfluence.core.registries import R
 
 from ...utils import VariableStandardizer
 from .base_dataset import BaseDatasetHandler
-from .dataset_registry import DatasetRegistry
 
 
-@DatasetRegistry.register('nwm3_retrospective')
+@R.dataset_handlers.add('nwm3_retrospective')
 class NWM3RetrospectiveHandler(BaseDatasetHandler):
     """
     Handler for NWM v3.0 Retrospective forcing dataset.

--- a/src/symfluence/data/preprocessing/dataset_handlers/rdrs_utils.py
+++ b/src/symfluence/data/preprocessing/dataset_handlers/rdrs_utils.py
@@ -19,13 +19,13 @@ import xarray as xr
 from shapely.geometry import Polygon
 
 from symfluence.core.constants import PhysicalConstants, UnitConversion
+from symfluence.core.registries import R
 
 from ...utils import VariableStandardizer
 from .base_dataset import BaseDatasetHandler
-from .dataset_registry import DatasetRegistry
 
 
-@DatasetRegistry.register('rdrs')
+@R.dataset_handlers.add('rdrs')
 class RDRSHandler(BaseDatasetHandler):
     """Handler for RDRS (Regional Deterministic Reforecast System) dataset."""
 

--- a/src/symfluence/evaluation/analysis_registry.py
+++ b/src/symfluence/evaluation/analysis_registry.py
@@ -16,12 +16,12 @@ Architecture:
        - Decision Analyzers: Model structure/decision comparison analysis
 
     2. Registration Mechanism (Decorator Pattern):
-       Each model registers its analyzers using class decorators:
+       Each model registers its analyzers via the unified registry:
 
-       @AnalysisRegistry.register_sensitivity_analyzer('SUMMA')
+       @R.sensitivity_analyzers.add('SUMMA')
        class SummaSensitivityAnalyzer: ...
 
-       @AnalysisRegistry.register_decision_analyzer('SUMMA')
+       @R.decision_analyzers.add('SUMMA')
        class SummaStructureAnalyzer: ...
 
     3. Discovery and Instantiation (Factory Pattern):
@@ -37,9 +37,9 @@ Benefits:
 
 Example Registration:
     # In models/summa/__init__.py
-    from symfluence.evaluation.analysis_registry import AnalysisRegistry
+    from symfluence.core.registries import R
 
-    @AnalysisRegistry.register_decision_analyzer('SUMMA')
+    @R.decision_analyzers.add('SUMMA')
     class SummaStructureAnalyzer(BaseStructureEnsembleAnalyzer):
         def run_full_analysis(self):
             ...
@@ -86,7 +86,7 @@ class AnalysisRegistry:
 
     Example:
         >>> # Register a decision analyzer
-        >>> @AnalysisRegistry.register_decision_analyzer('SUMMA')
+        >>> @R.decision_analyzers.add('SUMMA')
         ... class SummaStructureAnalyzer:
         ...     def run_full_analysis(self): ...
 

--- a/src/symfluence/evaluation/evaluators/et.py
+++ b/src/symfluence/evaluation/evaluators/et.py
@@ -49,9 +49,9 @@ import pandas as pd
 import xarray as xr
 
 from symfluence.core.constants import UnitConverter
+from symfluence.core.registries import R
 from symfluence.data.observation.paths import et_observation_candidates, first_existing_path
 from symfluence.evaluation.output_file_locator import OutputFileLocator
-from symfluence.evaluation.registry import EvaluationRegistry
 
 from .base import ModelEvaluator
 
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
     from symfluence.core.config.models import SymfluenceConfig
 
 
-@EvaluationRegistry.register('ET')
+@R.evaluators.add('ET')
 class ETEvaluator(ModelEvaluator):
     """Evapotranspiration and latent heat evaluator with multi-source support.
 

--- a/src/symfluence/evaluation/evaluators/groundwater.py
+++ b/src/symfluence/evaluation/evaluators/groundwater.py
@@ -42,9 +42,9 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 import pandas as pd
 import xarray as xr
 
+from symfluence.core.registries import R
 from symfluence.data.observation.paths import first_existing_path, groundwater_observation_candidates
 from symfluence.evaluation.output_file_locator import OutputFileLocator
-from symfluence.evaluation.registry import EvaluationRegistry
 
 from .base import ModelEvaluator
 
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
     from symfluence.core.config.models import SymfluenceConfig
 
 
-@EvaluationRegistry.register('GROUNDWATER')
+@R.evaluators.add('GROUNDWATER')
 class GroundwaterEvaluator(ModelEvaluator):
     """Groundwater evaluator comparing SUMMA to well or GRACE observations.
 

--- a/src/symfluence/evaluation/evaluators/snow.py
+++ b/src/symfluence/evaluation/evaluators/snow.py
@@ -20,9 +20,9 @@ import pandas as pd
 import xarray as xr
 
 from symfluence.core.constants import UnitConverter
+from symfluence.core.registries import R
 from symfluence.data.observation.paths import first_existing_path, snow_observation_candidates
 from symfluence.evaluation.output_file_locator import OutputFileLocator
-from symfluence.evaluation.registry import EvaluationRegistry
 
 from .base import ModelEvaluator
 
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from symfluence.core.config.models import SymfluenceConfig
 
 
-@EvaluationRegistry.register('SNOW')
+@R.evaluators.add('SNOW')
 class SnowEvaluator(ModelEvaluator):
     """Snow evaluator for SWE and SCA calibration.
 

--- a/src/symfluence/evaluation/evaluators/soil_moisture.py
+++ b/src/symfluence/evaluation/evaluators/soil_moisture.py
@@ -46,9 +46,9 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from symfluence.core.registries import R
 from symfluence.data.observation.paths import first_existing_path, soil_moisture_observation_candidates
 from symfluence.evaluation.output_file_locator import OutputFileLocator
-from symfluence.evaluation.registry import EvaluationRegistry
 
 from .base import ModelEvaluator
 
@@ -56,7 +56,7 @@ if TYPE_CHECKING:
     from symfluence.core.config.models import SymfluenceConfig
 
 
-@EvaluationRegistry.register('SOIL_MOISTURE')
+@R.evaluators.add('SOIL_MOISTURE')
 class SoilMoistureEvaluator(ModelEvaluator):
     """Soil moisture evaluator supporting multiple observation sources.
 

--- a/src/symfluence/evaluation/evaluators/streamflow.py
+++ b/src/symfluence/evaluation/evaluators/streamflow.py
@@ -22,9 +22,9 @@ import xarray as xr
 
 from symfluence.core.constants import UnitConverter
 from symfluence.core.path_resolver import find_basin_shapefile
+from symfluence.core.registries import R
 from symfluence.data.observation.paths import first_existing_path, streamflow_observation_candidates
 from symfluence.evaluation.output_file_locator import OutputFileLocator
-from symfluence.evaluation.registry import EvaluationRegistry
 
 from .base import ModelEvaluator
 
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     pass
 
 
-@EvaluationRegistry.register('STREAMFLOW')
+@R.evaluators.add('STREAMFLOW')
 class StreamflowEvaluator(ModelEvaluator):
     """Streamflow evaluator for calibrating hydrological models.
 

--- a/src/symfluence/evaluation/evaluators/tws.py
+++ b/src/symfluence/evaluation/evaluators/tws.py
@@ -20,13 +20,13 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from symfluence.core.registries import R
 from symfluence.data.observation.paths import (
     first_existing_path,
     tws_default_observation_path,
     tws_observation_candidates,
 )
 from symfluence.evaluation.output_file_locator import OutputFileLocator
-from symfluence.evaluation.registry import EvaluationRegistry
 
 from .base import ModelEvaluator
 
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from symfluence.core.config.models import SymfluenceConfig
 
 
-@EvaluationRegistry.register('TWS')
+@R.evaluators.add('TWS')
 class TWSEvaluator(ModelEvaluator):
     """Total Water Storage evaluator comparing SUMMA to GRACE satellites.
 

--- a/src/symfluence/evaluation/koopman_analysis.py
+++ b/src/symfluence/evaluation/koopman_analysis.py
@@ -19,10 +19,10 @@ Architecture:
     This module follows the same pattern as SensitivityAnalyzer and Benchmarker:
     - Standalone class with __init__(config, logger, reporting_manager)
     - Main entry point: run_koopman_analysis() -> Dict[str, Any]
-    - Registered with AnalysisRegistry for discovery by AnalysisManager
+    - Registered with the unified registry for discovery by AnalysisManager
 
 Registration:
-    @AnalysisRegistry.register_koopman_analyzer()
+    @R.koopman_analyzers.add('DEFAULT')
     class KoopmanAnalyzer: ...
 
 Example:
@@ -40,10 +40,10 @@ import numpy as np
 import pandas as pd
 
 from symfluence.core.mixins import ConfigMixin
-from symfluence.evaluation.analysis_registry import AnalysisRegistry
+from symfluence.core.registries import R
 
 
-@AnalysisRegistry.register_koopman_analyzer()
+@R.koopman_analyzers.add('DEFAULT')
 class KoopmanAnalyzer(ConfigMixin):
     """Koopman operator analysis of multi-model hydrological ensembles.
 

--- a/src/symfluence/geospatial/delineation_registry.py
+++ b/src/symfluence/geospatial/delineation_registry.py
@@ -15,7 +15,7 @@ Pattern:
 
 Usage:
     # In delineator module:
-    @DelineationRegistry.register('lumped')
+    @R.delineation_strategies.add('lumped')
     class LumpedWatershedDelineator(BaseGeofabricDelineator):
         ...
 
@@ -52,7 +52,7 @@ class DelineationRegistry:
         _aliases: Dictionary mapping alternate names to canonical names.
 
     Example:
-        >>> @DelineationRegistry.register('lumped')
+        >>> @R.delineation_strategies.add('lumped')
         ... class LumpedDelineator:
         ...     pass
         >>> DelineationRegistry.get_strategy('lumped')

--- a/src/symfluence/geospatial/geofabric/delineators/distributed_delineator.py
+++ b/src/symfluence/geospatial/geofabric/delineators/distributed_delineator.py
@@ -15,7 +15,8 @@ from typing import Any, Dict, Optional, Tuple
 
 import geopandas as gpd
 
-from ....geospatial.delineation_registry import DelineationRegistry
+from symfluence.core.registries import R
+
 from ..base.base_delineator import BaseGeofabricDelineator
 from ..methods.curvature import CurvatureMethod
 from ..methods.multi_scale import MultiScaleMethod
@@ -31,7 +32,7 @@ from ..utils.validation import GeofabricValidator
 from .coastal_delineator import CoastalWatershedDelineator
 
 
-@DelineationRegistry.register('semidistributed')
+@R.delineation_strategies.add('semidistributed')
 class GeofabricDelineator(BaseGeofabricDelineator):
     """
     Main geofabric delineation class for distributed and semi-distributed domains.

--- a/src/symfluence/geospatial/geofabric/delineators/grid_delineator.py
+++ b/src/symfluence/geospatial/geofabric/delineators/grid_delineator.py
@@ -19,7 +19,8 @@ import numpy as np
 import rasterio
 from shapely.geometry import box
 
-from ....geospatial.delineation_registry import DelineationRegistry
+from symfluence.core.registries import R
+
 from ....geospatial.raster_utils import _scipy_mode_compat
 from ..base.base_delineator import BaseGeofabricDelineator
 from ..processors.gdal_processor import GDALProcessor
@@ -39,7 +40,7 @@ D8_OFFSETS = {
 }
 
 
-@DelineationRegistry.register('distributed')
+@R.delineation_strategies.add('distributed')
 class GridDelineator(BaseGeofabricDelineator):
     """
     Creates a regular mesh grid for fully distributed modeling.

--- a/src/symfluence/geospatial/geofabric/delineators/lumped_delineator.py
+++ b/src/symfluence/geospatial/geofabric/delineators/lumped_delineator.py
@@ -22,13 +22,14 @@ import rasterio
 from rasterio.features import shapes
 from shapely.geometry import shape
 
-from ....geospatial.delineation_registry import DelineationRegistry
+from symfluence.core.registries import R
+
 from ..base.base_delineator import BaseGeofabricDelineator
 from ..processors.gdal_processor import GDALProcessor
 from ..processors.taudem_executor import TauDEMExecutor
 
 
-@DelineationRegistry.register('lumped')
+@R.delineation_strategies.add('lumped')
 class LumpedWatershedDelineator(BaseGeofabricDelineator):
     """
     Delineates lumped watersheds using TauDEM.

--- a/src/symfluence/geospatial/geofabric/delineators/point_delineator.py
+++ b/src/symfluence/geospatial/geofabric/delineators/point_delineator.py
@@ -16,11 +16,12 @@ from typing import Optional
 import geopandas as gpd
 from shapely.geometry import Polygon
 
-from ....geospatial.delineation_registry import DelineationRegistry
+from symfluence.core.registries import R
+
 from ..base.base_delineator import BaseGeofabricDelineator
 
 
-@DelineationRegistry.register('point')
+@R.delineation_strategies.add('point')
 class PointDelineator(BaseGeofabricDelineator):
     """
     Handles point-scale domain delineation by creating a small square basin

--- a/src/symfluence/models/adapters/adapter_registry.py
+++ b/src/symfluence/models/adapters/adapter_registry.py
@@ -24,11 +24,12 @@ class ForcingAdapterRegistry:
     """
     Registry for model forcing adapters.
 
-    Adapters register themselves using the @register_adapter decorator,
-    enabling dynamic discovery without hardcoded model names.
+    Deprecated delegation shim: adapters now register via the unified
+    registry (``@R.forcing_adapters.add('SUMMA')``); lookups here read
+    from ``R.forcing_adapters``.
 
     Example:
-        >>> @ForcingAdapterRegistry.register_adapter('SUMMA')
+        >>> @R.forcing_adapters.add('SUMMA')
         >>> class SUMMAForcingAdapter(ForcingAdapter):
         ...     pass
         ...

--- a/src/symfluence/models/adapters/base_adapter.py
+++ b/src/symfluence/models/adapters/base_adapter.py
@@ -40,7 +40,7 @@ class ForcingAdapter(ConfigMixin, ABC):
         - Add model-specific metadata
 
     Example Implementation:
-        >>> @ForcingAdapterRegistry.register_adapter('SUMMA')
+        >>> @R.forcing_adapters.add('SUMMA')
         >>> class SUMMAForcingAdapter(ForcingAdapter):
         ...     def get_variable_mapping(self):
         ...         return {

--- a/src/symfluence/models/base/base_postprocessor.py
+++ b/src/symfluence/models/base/base_postprocessor.py
@@ -52,7 +52,7 @@ class BaseModelPostProcessor(ABC, ModelComponentMixin, PathResolverMixin):  # ty
         experiment_id: Current experiment identifier
 
     Example:
-        >>> @ModelRegistry.register_postprocessor('MYMODEL')
+        >>> @R.postprocessors.add('MYMODEL')
         >>> class MyModelPostProcessor(BaseModelPostProcessor):
         ...     def _get_model_name(self) -> str:
         ...         return "MYMODEL"

--- a/src/symfluence/models/fuse/forcing_adapter.py
+++ b/src/symfluence/models/fuse/forcing_adapter.py
@@ -13,10 +13,11 @@ from typing import Callable, Dict, List
 
 import xarray as xr
 
-from symfluence.models.adapters import ForcingAdapter, ForcingAdapterRegistry
+from symfluence.core.registries import R
+from symfluence.models.adapters import ForcingAdapter
 
 
-@ForcingAdapterRegistry.register_adapter('FUSE')
+@R.forcing_adapters.add('FUSE')
 class FUSEForcingAdapter(ForcingAdapter):
     """
     Forcing adapter for FUSE model.

--- a/src/symfluence/models/fuse/init_preset.py
+++ b/src/symfluence/models/fuse/init_preset.py
@@ -4,15 +4,15 @@
 """
 FUSE initialization presets.
 
-This module registers FUSE-specific presets with the PresetRegistry,
+This module registers FUSE-specific presets with the unified registry,
 keeping model-specific configuration within the model directory.
 """
 from __future__ import annotations
 
-from symfluence.cli.preset_registry import PresetRegistry
+from symfluence.core.registries import R
 
 
-@PresetRegistry.register_preset('fuse-provo')
+@R.presets.add('fuse-provo')
 def fuse_provo_preset():
     """FUSE model for Provo River, Utah with ERA5 forcing."""
     return {
@@ -86,7 +86,7 @@ def fuse_provo_preset():
     }
 
 
-@PresetRegistry.register_preset('fuse-basic')
+@R.presets.add('fuse-basic')
 def fuse_basic_preset():
     """Generic FUSE lumped setup with ERA5 forcing."""
     return {

--- a/src/symfluence/models/gr/forcing_adapter.py
+++ b/src/symfluence/models/gr/forcing_adapter.py
@@ -13,10 +13,11 @@ from typing import Callable, Dict, List
 
 import xarray as xr
 
-from symfluence.models.adapters import ForcingAdapter, ForcingAdapterRegistry
+from symfluence.core.registries import R
+from symfluence.models.adapters import ForcingAdapter
 
 
-@ForcingAdapterRegistry.register_adapter('GR')
+@R.forcing_adapters.add('GR')
 class GRForcingAdapter(ForcingAdapter):
     """
     Forcing adapter for GR family models (GR4J, GR5J, etc.).

--- a/src/symfluence/models/hype/forcing_adapter.py
+++ b/src/symfluence/models/hype/forcing_adapter.py
@@ -14,10 +14,11 @@ from typing import Callable, Dict, List
 
 import xarray as xr
 
-from symfluence.models.adapters import ForcingAdapter, ForcingAdapterRegistry
+from symfluence.core.registries import R
+from symfluence.models.adapters import ForcingAdapter
 
 
-@ForcingAdapterRegistry.register_adapter('HYPE')
+@R.forcing_adapters.add('HYPE')
 class HYPEForcingAdapter(ForcingAdapter):
     """
     Forcing adapter for HYPE model.

--- a/src/symfluence/models/mesh/forcing_adapter.py
+++ b/src/symfluence/models/mesh/forcing_adapter.py
@@ -12,10 +12,11 @@ from __future__ import annotations
 
 from typing import Dict, List
 
-from symfluence.models.adapters import ForcingAdapter, ForcingAdapterRegistry
+from symfluence.core.registries import R
+from symfluence.models.adapters import ForcingAdapter
 
 
-@ForcingAdapterRegistry.register_adapter('MESH')
+@R.forcing_adapters.add('MESH')
 class MESHForcingAdapter(ForcingAdapter):
     """
     Forcing adapter for MESH model.

--- a/src/symfluence/models/ngen/forcing_adapter.py
+++ b/src/symfluence/models/ngen/forcing_adapter.py
@@ -13,10 +13,11 @@ from typing import Callable, Dict, List
 
 import xarray as xr
 
-from symfluence.models.adapters import ForcingAdapter, ForcingAdapterRegistry
+from symfluence.core.registries import R
+from symfluence.models.adapters import ForcingAdapter
 
 
-@ForcingAdapterRegistry.register_adapter('NGEN')
+@R.forcing_adapters.add('NGEN')
 class NGENForcingAdapter(ForcingAdapter):
     """
     Forcing adapter for NOAA NextGen framework.

--- a/src/symfluence/models/rhessys/forcing_adapter.py
+++ b/src/symfluence/models/rhessys/forcing_adapter.py
@@ -12,10 +12,11 @@ from __future__ import annotations
 
 from typing import Callable, Dict, List
 
-from symfluence.models.adapters import ForcingAdapter, ForcingAdapterRegistry
+from symfluence.core.registries import R
+from symfluence.models.adapters import ForcingAdapter
 
 
-@ForcingAdapterRegistry.register_adapter('RHESSYS')
+@R.forcing_adapters.add('RHESSYS')
 class RHESSysForcingAdapter(ForcingAdapter):
     """
     Forcing adapter for RHESSys model.

--- a/src/symfluence/models/summa/forcing_adapter.py
+++ b/src/symfluence/models/summa/forcing_adapter.py
@@ -14,10 +14,11 @@ from typing import Dict, List
 
 import xarray as xr
 
-from symfluence.models.adapters import ForcingAdapter, ForcingAdapterRegistry
+from symfluence.core.registries import R
+from symfluence.models.adapters import ForcingAdapter
 
 
-@ForcingAdapterRegistry.register_adapter('SUMMA')
+@R.forcing_adapters.add('SUMMA')
 class SUMMAForcingAdapter(ForcingAdapter):
     """
     Forcing adapter for SUMMA model.

--- a/src/symfluence/models/summa/init_preset.py
+++ b/src/symfluence/models/summa/init_preset.py
@@ -4,15 +4,15 @@
 """
 SUMMA initialization presets.
 
-This module registers SUMMA-specific presets with the PresetRegistry,
+This module registers SUMMA-specific presets with the unified registry,
 keeping model-specific configuration within the model directory.
 """
 from __future__ import annotations
 
-from symfluence.cli.preset_registry import PresetRegistry
+from symfluence.core.registries import R
 
 
-@PresetRegistry.register_preset('bow-river')
+@R.presets.add('bow-river')
 def bow_river_preset():
     """Bow River at Banff lumped SUMMA setup with ERA5 forcing and DDS calibration."""
     return {
@@ -87,7 +87,7 @@ def bow_river_preset():
     }
 
 
-@PresetRegistry.register_preset('summa-basic')
+@R.presets.add('summa-basic')
 def summa_basic_preset():
     """Generic SUMMA distributed setup with ERA5 forcing."""
     return {

--- a/src/symfluence/optimization/model_optimizers/__init__.py
+++ b/src/symfluence/optimization/model_optimizers/__init__.py
@@ -9,10 +9,9 @@ These provide a unified interface while handling model-specific setup.
 
 Model-specific optimizers are available via:
 1. Direct import: from symfluence.models.{model}.calibration.optimizer import {Model}ModelOptimizer
-2. Registry pattern: OptimizerRegistry.get_optimizer('{MODEL}')
+2. Registry pattern: R.optimizers.get('{MODEL}')
 
-Registration happens via ``@OptimizerRegistry.register_optimizer``
-decorators.  This module auto-discovers all model packages at import time
+Registration happens via ``@R.optimizers.add`` decorators.  This module auto-discovers all model packages at import time
 so that every ``calibration/optimizer.py`` is imported and its decorator
 fires.
 """

--- a/src/symfluence/optimization/objectives/base.py
+++ b/src/symfluence/optimization/objectives/base.py
@@ -81,9 +81,9 @@ class BaseObjective(ConfigMixin, ABC):
             objective = (1 - KGE) + 0.1*|PBIAS|/100 + 0.01*RMSE/sigma
 
     Registry Pattern:
-        Objective classes are registered using the ObjectiveRegistry decorator::
+        Objective classes are registered via the unified registry::
 
-            @ObjectiveRegistry.register('MULTIVARIATE')
+            @R.objectives.add('MULTIVARIATE')
             class MultivariateObjective(BaseObjective):
                 def calculate(self, evaluation_results):
                     # Implementation here
@@ -119,10 +119,10 @@ class BaseObjective(ConfigMixin, ABC):
         - Be stateless with respect to evaluation results
 
     Example Implementation:
+        >>> from symfluence.core.registries import R
         >>> from symfluence.optimization.objectives.base import BaseObjective
-        >>> from symfluence.optimization.objectives.registry import ObjectiveRegistry
         >>>
-        >>> @ObjectiveRegistry.register('SIMPLE_KGE')
+        >>> @R.objectives.add('SIMPLE_KGE')
         >>> class SimpleKGEObjective(BaseObjective):
         ...     '''Minimize 1 - KGE for streamflow only'''
         ...

--- a/src/symfluence/optimization/objectives/multivariate.py
+++ b/src/symfluence/optimization/objectives/multivariate.py
@@ -14,11 +14,12 @@ from __future__ import annotations
 
 from typing import Dict
 
+from symfluence.core.registries import R
+
 from .base import BaseObjective
-from .registry import ObjectiveRegistry
 
 
-@ObjectiveRegistry.register('MULTIVARIATE')
+@R.objectives.add('MULTIVARIATE')
 class MultivariateObjective(BaseObjective):
     """Weighted multi-variable objective function.
 

--- a/src/symfluence/optimization/objectives/registry.py
+++ b/src/symfluence/optimization/objectives/registry.py
@@ -6,8 +6,9 @@
 Provides a central registry for objective functions used in calibration.
 
 This module implements a plugin pattern for objective functions. Objective classes
-register themselves using the @ObjectiveRegistry.register() decorator, enabling
+register themselves via the unified registry (``@R.objectives.add()``), enabling
 dynamic instantiation by type string from configuration without hardcoded imports.
+``ObjectiveRegistry`` is a deprecated delegation shim kept for plugin compatibility.
 
 This design allows users to select different objective functions (single-variable,
 multi-variable, custom) via configuration and enables straightforward addition of
@@ -16,7 +17,7 @@ new objectives without modifying the registry code.
 Example:
     Register a custom objective:
 
-    >>> @ObjectiveRegistry.register('CUSTOM_OBJECTIVE')
+    >>> @R.objectives.add('CUSTOM_OBJECTIVE')
     ... class CustomObjective(BaseObjective):
     ...     def calculate(self, evaluation_results): ...
 

--- a/src/symfluence/optimization/optimizers/component_factory.py
+++ b/src/symfluence/optimization/optimizers/component_factory.py
@@ -61,7 +61,7 @@ class OptimizerComponentFactory:
             raise RuntimeError(
                 f"No parameter manager registered for model '{model_name}'. "
                 f"Ensure the parameter manager is decorated with "
-                f"@OptimizerRegistry.register_parameter_manager('{model_name}')"
+                f"@R.parameter_managers.add('{model_name}')"
             )
 
         settings_dir = self.get_settings_directory(model_name)
@@ -91,7 +91,7 @@ class OptimizerComponentFactory:
             raise RuntimeError(
                 f"No worker registered for model '{model_name}'. "
                 f"Ensure the worker is decorated with "
-                f"@OptimizerRegistry.register_worker('{model_name}')"
+                f"@R.workers.add('{model_name}')"
             )
 
         self.logger.debug(f"Creating worker: {worker_cls.__name__} for {model_name}")

--- a/src/symfluence/optimization/parameter_managers/__init__.py
+++ b/src/symfluence/optimization/parameter_managers/__init__.py
@@ -14,10 +14,9 @@ Each parameter manager is responsible for:
 
 Model-specific parameter managers are available via:
 1. Direct import: from symfluence.models.{model}.calibration.parameter_manager import {Model}ParameterManager
-2. Registry pattern: OptimizerRegistry.get_parameter_manager('{MODEL}')
+2. Registry pattern: R.parameter_managers.get('{MODEL}')
 
-Registration happens via ``@OptimizerRegistry.register_parameter_manager``
-decorators.  This module auto-discovers all model packages at import time
+Registration happens via ``@R.parameter_managers.add`` decorators.  This module auto-discovers all model packages at import time
 so that every ``calibration/parameter_manager.py`` is imported and its
 decorator fires.
 """

--- a/tests/unit/data/acquisition/test_handler_registration_completeness.py
+++ b/tests/unit/data/acquisition/test_handler_registration_completeness.py
@@ -43,13 +43,13 @@ _ACQ_HANDLER_DIR = _SRC_ROOT / "data" / "acquisition" / "handlers"
 _OBS_HANDLER_DIR = _SRC_ROOT / "data" / "observation" / "handlers"
 
 
-def _modules_with_decorator(handler_dir: Path, decorator: str) -> list[str]:
-    """Return module stems whose source contains ``<decorator>.register(``."""
+def _modules_with_decorator(handler_dir: Path, registry_namespace: str) -> list[str]:
+    """Return module stems whose source contains ``@R.<namespace>.add(``."""
     found = []
     for path in sorted(handler_dir.glob("*.py")):
         if path.name == "__init__.py":
             continue
-        if f"{decorator}.register" in path.read_text(encoding="utf-8"):
+        if f"R.{registry_namespace}.add(" in path.read_text(encoding="utf-8"):
             found.append(path.stem)
     return found
 
@@ -59,7 +59,7 @@ class TestAcquisitionRegistrationCompleteness:
     """Every decorated acquisition handler must be in the import list."""
 
     def test_all_decorated_modules_are_in_import_list(self):
-        """A handler file with @AcquisitionRegistry.register must be listed.
+        """A handler file with @R.acquisition_handlers.add must be listed.
 
         Scans the handler directory for the register decorator and asserts each
         such module name appears in ``_handler_modules`` in ``__init__.py``.
@@ -71,11 +71,11 @@ class TestAcquisitionRegistrationCompleteness:
         list_body = init_src.split("_handler_modules", 1)[1].split("]", 1)[0]
         listed = set(re.findall(r"['\"]([a-zA-Z0-9_]+)['\"]", list_body))
 
-        decorated = _modules_with_decorator(_ACQ_HANDLER_DIR, "AcquisitionRegistry")
+        decorated = _modules_with_decorator(_ACQ_HANDLER_DIR, "acquisition_handlers")
         missing = sorted(m for m in decorated if m not in listed)
 
         assert not missing, (
-            "These acquisition handler modules use @AcquisitionRegistry.register "
+            "These acquisition handler modules use @R.acquisition_handlers.add "
             "but are NOT in _handler_modules in handlers/__init__.py, so they "
             f"will never register: {missing}. Add them to the list."
         )
@@ -94,7 +94,7 @@ class TestObservationRegistrationCompleteness:
     """
 
     def test_all_decorated_modules_are_reachable(self):
-        """A handler file with @ObservationRegistry.register must be reachable.
+        """A handler file with @R.observation_handlers.add must be reachable.
 
         Purely static: for each decorated observation module, require that its
         module stem is referenced by a relative import in ``__init__.py``. This
@@ -103,7 +103,7 @@ class TestObservationRegistrationCompleteness:
         optional dependencies are installed).
         """
         init_src = (_OBS_HANDLER_DIR / "__init__.py").read_text(encoding="utf-8")
-        decorated = _modules_with_decorator(_OBS_HANDLER_DIR, "ObservationRegistry")
+        decorated = _modules_with_decorator(_OBS_HANDLER_DIR, "observation_handlers")
 
         missing = []
         for module in decorated:
@@ -112,7 +112,7 @@ class TestObservationRegistrationCompleteness:
                 missing.append(module)
 
         assert not missing, (
-            "These observation handler modules use @ObservationRegistry.register "
+            "These observation handler modules use @R.observation_handlers.add "
             "but are NOT imported in observation/handlers/__init__.py, so they "
             f"will never register: {missing}. Add a `from .<module> import ...`."
         )


### PR DESCRIPTION
## Summary

Closes out the RTI review **item 9** tail: every remaining in-tree call-site of the deprecated per-domain registry decorators now uses the unified `R.*` facade. The original `Registry.register_*` grep undercounted the tail — the no-underscore `register()` shims (`EvaluationRegistry`, `DelineationRegistry`, `ObjectiveRegistry`, and the `BaseRegistry`-derived data registries) were also deprecated and firing `DeprecationWarning`s on plain `import symfluence`. All of those are migrated too.

### What moved

| Legacy decorator | New form | Sites |
|---|---|---|
| `@ForcingAdapterRegistry.register_adapter` | `@R.forcing_adapters.add` | 7 model forcing adapters |
| `@PresetRegistry.register_preset` | `@R.presets.add` | 4 (SUMMA/FUSE init presets) |
| `BuildInstructionsRegistry.register_instructions` | `R.build_instructions.add` | 7 infrastructure tools |
| `@AnalysisRegistry.register_koopman_analyzer` | `@R.koopman_analyzers.add` | 1 |
| `@EvaluationRegistry.register` | `@R.evaluators.add` | 6 evaluators |
| `@DelineationRegistry.register` | `@R.delineation_strategies.add` | 4 delineators |
| `@ObjectiveRegistry.register` | `@R.objectives.add` | 1 |
| `@{Acquisition,Observation,Dataset}Registry.register` | `@R.{acquisition,observation,dataset}_handlers.add` | 105 data handler modules |

### Bug fixed along the way

`R.dataset_handlers` was an **orphan namespace** — `DatasetRegistry` never set `_r_registry_name`, so the 13 dataset preprocessing handlers lived only in its private `_handlers` dict and the unified registry showed zero entries. It is now wired (`_r_registry_name = "dataset_handlers"`), so registration and lookup both go through `R`.

### Test hardening

`test_handler_registration_completeness.py` statically greps handler sources for the registration decorator — after the codemod it would have **passed vacuously** (zero matches for the old pattern). It now scans for `@R.<ns>.add(` and detects 68 acquisition + 37 observation modules.

Docstrings and error messages that taught the legacy pattern (base classes, shim module docs, `component_factory` errors) now show the `R` facade. The only remaining `Registry.register_*` textual matches are the deprecation shims themselves.

## Verification

- **Registry parity:** key-set dump of all 30 `R.*` registries vs `origin/develop` — 0 diffs across 29 registries; `dataset_handlers` intentionally +13 (orphan now populated).
- **No in-tree deprecations:** `import symfluence` + all handler/evaluator/delineator/preset/adapter modules with `DeprecationWarning` promoted to error — clean (previously warned on bare import).
- **Tests:** 8337 unit tests pass; completeness test verified non-vacuous.
- **Lint/type:** ruff clean, mypy clean (pre-commit).

### Still open from item 9 / open question 1

The shims themselves (`ForcingAdapterRegistry`, `PresetRegistry`, `AnalysisRegistry`, `EvaluationRegistry`, `DelineationRegistry`, `ObjectiveRegistry`, `BMIRegistry`, `BaseRegistry.register`) stay in place for out-of-tree plugin compatibility. Q1's written decision — which release deletes them — is still pending and is a one-paragraph ADR once decided.

> Repo and code assistance from [Claude](https://claude.ai) (Anthropic).