### PR TITLE
refactor(registry)!: remove the deprecated register* decorator API

### DIFF
--- a/src/symfluence/cli/preset_registry.py
+++ b/src/symfluence/cli/preset_registry.py
@@ -8,14 +8,14 @@ This module provides a registry pattern for model-specific presets,
 enabling each model to register its own initialization presets without
 hardcoding them in the central init_presets.py file.
 
-Phase 4 delegation shim: resolved presets live in ``R.presets``.  The
-``_preset_loaders`` dict is kept locally for lazy loader execution.
+Lookup facade: presets register via ``R.presets.add()`` (either a resolved
+dict or a lazy loader callable); lookups here read from ``R.presets`` and
+resolve loaders on first access.
 """
 from __future__ import annotations
 
 import logging
-import warnings
-from typing import Any, Callable, Dict, List
+from typing import Any, Dict, List
 
 from symfluence.core.registries import R
 
@@ -26,9 +26,8 @@ class PresetRegistry:
     """
     Registry for model-specific initialization presets.
 
-    Deprecated delegation shim: presets now register via the unified
-    registry (``@R.presets.add('fuse-basic')``); lookups here read from
-    ``R.presets``.
+    Presets register via the unified registry (``@R.presets.add('fuse-basic')``);
+    lookups here read from ``R.presets``.
 
     Example:
         >>> @R.presets.add('fuse-basic')
@@ -39,57 +38,6 @@ class PresetRegistry:
         ...         'fuse_decisions': {...},
         ...     }
     """
-
-    # Keep loaders locally for lazy execution; resolved values live in
-    # R.presets.
-    _preset_loaders: Dict[str, Callable[[], Dict[str, Any]]] = {}
-
-    @classmethod
-    def register_preset(cls, name: str) -> Callable:
-        """
-        Decorator to register a preset loader function.
-
-        Args:
-            name: Preset name (e.g., 'fuse-basic', 'summa-distributed')
-
-        Returns:
-            Decorator function
-
-        Example:
-            >>> @PresetRegistry.register_preset('fuse-basic')
-            >>> def fuse_basic_preset():
-            ...     return {'description': '...', 'settings': {...}}
-        """
-        def decorator(loader_func: Callable[[], Dict[str, Any]]) -> Callable:
-            warnings.warn(
-                "PresetRegistry.register_preset() is deprecated; "
-                "use R.presets.add() instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            cls._preset_loaders[name] = loader_func
-            logger.debug(f"Registered preset: {name}")
-            R.presets.add(name, loader_func)
-            return loader_func
-        return decorator
-
-    @classmethod
-    def register_preset_dict(cls, name: str, preset: Dict[str, Any]) -> None:
-        """
-        Register a preset directly as a dictionary.
-
-        Args:
-            name: Preset name
-            preset: Preset configuration dictionary
-        """
-        warnings.warn(
-            "PresetRegistry.register_preset_dict() is deprecated; "
-            "use R.presets.add() instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        logger.debug(f"Registered preset dict: {name}")
-        R.presets.add(name, preset)
 
     @classmethod
     def get_preset(cls, name: str) -> Dict[str, Any]:
@@ -118,12 +66,6 @@ class PresetRegistry:
                 return result.copy() if isinstance(result, dict) else result
             return value.copy() if isinstance(value, dict) else value
 
-        # Check local loaders
-        if name in cls._preset_loaders:
-            result = cls._preset_loaders[name]()
-            R.presets.add(name, result)
-            return result
-
         available = sorted(cls.list_presets())
         raise ValueError(
             f"Unknown preset: '{name}'. Available presets: {', '.join(available)}"
@@ -138,9 +80,7 @@ class PresetRegistry:
             List of preset names
         """
         cls._import_model_presets()
-        all_names = set(R.presets.keys())
-        all_names |= set(cls._preset_loaders.keys())
-        return sorted(all_names)
+        return sorted(R.presets.keys())
 
     @classmethod
     def get_all_presets(cls) -> Dict[str, Dict[str, Any]]:
@@ -153,19 +93,7 @@ class PresetRegistry:
         cls._import_model_presets()
         result = {}
 
-        # Resolve any local loaders not yet in R.presets
-        for name, loader in cls._preset_loaders.items():
-            if R.presets.get(name) is None or (
-                callable(R.presets.get(name))
-                and not isinstance(R.presets.get(name), type)
-            ):
-                try:
-                    resolved = loader()
-                    R.presets.add(name, resolved)
-                except Exception:  # noqa: BLE001
-                    logger.debug(f"Failed to load preset: {name}")
-
-        # Build result from R.presets
+        # Build result from R.presets, resolving lazy loaders
         for key, value in R.presets.items():
             if callable(value) and not isinstance(value, type):
                 try:

--- a/src/symfluence/coupling/bmi_registry.py
+++ b/src/symfluence/coupling/bmi_registry.py
@@ -15,7 +15,6 @@ dCoupler component adapter for any SYMFLUENCE model.
 from __future__ import annotations
 
 import logging
-import warnings
 from typing import Type
 
 from symfluence.core.registries import R
@@ -98,25 +97,6 @@ class BMIRegistry:
                 f"Unknown model '{model_name}'. Available: {available}"
             )
         return result
-
-    def register(self, model_name: str, class_path: str) -> None:
-        """Register a custom model adapter.
-
-        Args:
-            model_name: Model identifier (will be uppercased)
-            class_path: Fully qualified class path, e.g.
-                "my_package.adapters.MyComponent"
-
-        .. deprecated::
-            Use ``R.bmi_adapters.add_lazy()`` instead.
-        """
-        warnings.warn(
-            "BMIRegistry.register() is deprecated; "
-            "use R.bmi_adapters.add_lazy() instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        R.bmi_adapters.add_lazy(model_name, class_path)
 
     def is_jax_model(self, model_name: str) -> bool:
         """Check if a model uses JAX (differentiable) backend."""

--- a/src/symfluence/data/acquisition/registry.py
+++ b/src/symfluence/data/acquisition/registry.py
@@ -12,7 +12,7 @@ Phase 4 delegation shim: all state lives in ``R.acquisition_handlers``.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 from symfluence.core.exceptions import DataAcquisitionError
 from symfluence.data.base_registry import BaseRegistry
@@ -52,7 +52,6 @@ class AcquisitionRegistry(BaseRegistry):
     """
 
     _r_registry_name = "acquisition_handlers"
-    _handlers: Dict[str, Type] = {}
 
     @classmethod
     def get_handler(  # type: ignore[override]

--- a/src/symfluence/data/base_registry.py
+++ b/src/symfluence/data/base_registry.py
@@ -4,22 +4,21 @@
 """
 BaseRegistry - Standardized registry pattern for SYMFLUENCE.
 
-This module provides a consistent registry pattern used across:
+This module provides a consistent lookup facade used across:
 - AcquisitionRegistry: Data acquisition handlers
 - DatasetRegistry: Dataset preprocessing handlers
 - ObservationRegistry: Observation data handlers
 
 All registries use lowercase keys internally for consistency.
 
-Phase 4 delegation shim: internal ``_handlers`` dicts are retained only as
-a fallback for subclasses that have not yet set ``_r_registry_name``.
-Subclasses that *do* set the attribute delegate all state to
-``R.<_r_registry_name>``.
+Registration goes through the unified registry facade
+(``R.<registry>.add()``); subclasses set ``_r_registry_name`` to the
+corresponding attribute name on ``R`` (e.g. ``"acquisition_handlers"``)
+and all state lives there.
 """
 from __future__ import annotations
 
 import logging
-import warnings
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Generic, List, Optional, Type, TypeVar
 
@@ -28,33 +27,31 @@ T = TypeVar('T')
 
 class BaseRegistry(ABC, Generic[T]):
     """
-    Abstract base class for handler registries.
+    Abstract base class for handler registry lookup facades.
 
     Provides consistent API for:
-    - Registering handlers via decorator
     - Retrieving handler instances
     - Listing available handlers
     - Checking handler availability
 
     All keys are normalized to lowercase internally.
 
-    Subclasses should set ``_r_registry_name`` to the corresponding attribute
-    name on ``R`` (e.g. ``"acquisition_handlers"``).  When set, all state is
-    delegated to the unified registry and the internal ``_handlers`` dict is
-    unused.
+    Subclasses must set ``_r_registry_name`` to the corresponding attribute
+    name on ``R`` (e.g. ``"acquisition_handlers"``); all state is delegated
+    to that unified registry.
     """
 
-    _handlers: Dict[str, Type[T]] = {}
-
     # Subclasses set this to the R.* attribute name they delegate to.
-    # When ``None``, the base class falls back to ``_handlers``.
     _r_registry_name: Optional[str] = None
 
     @classmethod
     def _get_r_registry(cls):
-        """Return the unified ``R.<name>`` Registry instance, or ``None``."""
+        """Return the unified ``R.<name>`` Registry instance."""
         if cls._r_registry_name is None:
-            return None
+            raise TypeError(
+                f"{cls.__name__} must set _r_registry_name to the R.* "
+                "registry attribute it delegates to"
+            )
         from symfluence.core.registries import R
         return getattr(R, cls._r_registry_name)
 
@@ -62,41 +59,6 @@ class BaseRegistry(ABC, Generic[T]):
     def _normalize_key(cls, key: str) -> str:
         """Normalize registry key to lowercase."""
         return key.lower()
-
-    @classmethod
-    def register(cls, name: str):
-        """
-        Decorator to register a handler class.
-
-        Args:
-            name: Name to register the handler under
-
-        Returns:
-            Decorator function
-
-        Example:
-            @MyRegistry.register('era5')
-            class ERA5Handler(BaseHandler):
-                pass
-        """
-        def decorator(handler_class: Type[T]) -> Type[T]:
-            r_reg = cls._get_r_registry()
-            if r_reg is not None:
-                warnings.warn(
-                    f"{cls.__name__}.register() is deprecated; "
-                    "use R.{}.add() or model_manifest() instead.".format(
-                        cls._r_registry_name
-                    ),
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                r_reg.add(name, handler_class)
-            else:
-                # Fallback for subclasses without _r_registry_name
-                normalized_name = cls._normalize_key(name)
-                cls._handlers[normalized_name] = handler_class
-            return handler_class
-        return decorator
 
     @classmethod
     @abstractmethod
@@ -134,23 +96,13 @@ class BaseRegistry(ABC, Generic[T]):
         normalized_name = cls._normalize_key(name)
         r_reg = cls._get_r_registry()
 
-        if r_reg is not None:
-            handler = r_reg.get(normalized_name)
-            if handler is None:
-                available = ', '.join(sorted(r_reg.keys()))
-                raise ValueError(
-                    f"Unknown handler: '{name}'. Available: {available}"
-                )
-            return handler
-
-        # Fallback for subclasses without _r_registry_name
-        if normalized_name not in cls._handlers:
-            available = ', '.join(sorted(cls._handlers.keys()))
+        handler = r_reg.get(normalized_name)
+        if handler is None:
+            available = ', '.join(sorted(r_reg.keys()))
             raise ValueError(
                 f"Unknown handler: '{name}'. Available: {available}"
             )
-
-        return cls._handlers[normalized_name]
+        return handler
 
     @classmethod
     def list_handlers(cls) -> List[str]:
@@ -160,10 +112,7 @@ class BaseRegistry(ABC, Generic[T]):
         Returns:
             Sorted list of handler names
         """
-        r_reg = cls._get_r_registry()
-        if r_reg is not None:
-            return sorted(r_reg.keys())
-        return sorted(cls._handlers.keys())
+        return sorted(cls._get_r_registry().keys())
 
     @classmethod
     def is_registered(cls, name: str) -> bool:
@@ -176,18 +125,12 @@ class BaseRegistry(ABC, Generic[T]):
         Returns:
             True if registered, False otherwise
         """
-        r_reg = cls._get_r_registry()
-        if r_reg is not None:
-            return cls._normalize_key(name) in r_reg
-        return cls._normalize_key(name) in cls._handlers
+        return cls._normalize_key(name) in cls._get_r_registry()
 
     @classmethod
     def clear(cls) -> None:
         """Clear all registered handlers (mainly for testing)."""
-        r_reg = cls._get_r_registry()
-        if r_reg is not None:
-            r_reg.clear()
-        cls._handlers.clear()
+        cls._get_r_registry().clear()
 
 
 class HandlerRegistry(BaseRegistry[T]):

--- a/src/symfluence/data/observation/registry.py
+++ b/src/symfluence/data/observation/registry.py
@@ -40,7 +40,6 @@ class ObservationRegistry(HandlerRegistry["BaseObservationHandler"]):
     """Plugin registry for observation data handlers.
 
     Inherits from HandlerRegistry which provides:
-    - register(name) decorator (keys normalized to lowercase)
     - get_handler(name, config, logger)
     - is_registered(name)
     - list_handlers()
@@ -48,13 +47,10 @@ class ObservationRegistry(HandlerRegistry["BaseObservationHandler"]):
 
     All keys are automatically normalized to lowercase for consistency.
     Lookups are case-insensitive (e.g., 'GRACE' and 'grace' both work).
-
-    Class Attributes:
-        _handlers (dict): Maps observation type strings (lowercase) to handler classes.
+    Registration goes through ``R.observation_handlers.add()``.
     """
 
     _r_registry_name = "observation_handlers"
-    _handlers = {}  # Separate dict for this registry subclass
 
     @classmethod
     def list_observations(cls) -> list:

--- a/src/symfluence/data/preprocessing/dataset_handlers/dataset_registry.py
+++ b/src/symfluence/data/preprocessing/dataset_handlers/dataset_registry.py
@@ -9,7 +9,7 @@ Uses standardized BaseRegistry pattern with lowercase key normalization.
 """
 from __future__ import annotations
 
-from typing import Dict, List, Type
+from typing import List
 
 from symfluence.data.base_registry import BaseRegistry
 
@@ -23,8 +23,6 @@ class DatasetRegistry(BaseRegistry):
     """
 
     _r_registry_name = "dataset_handlers"
-
-    _handlers: Dict[str, Type] = {}
 
     @classmethod
     def get_handler(

--- a/src/symfluence/evaluation/analysis_registry.py
+++ b/src/symfluence/evaluation/analysis_registry.py
@@ -57,7 +57,6 @@ See Also:
 """
 from __future__ import annotations
 
-import warnings
 from typing import Dict, List, Optional, Type
 
 from symfluence.core.registries import R
@@ -68,8 +67,9 @@ class AnalysisRegistry:
 
     Implements the Registry Pattern to enable dynamic analysis component discovery
     and extensibility without tight coupling. Model-specific analyzers self-register
-    via decorators, allowing the framework to instantiate appropriate components
-    based on model configuration.
+    via ``R.sensitivity_analyzers.add()`` / ``R.decision_analyzers.add()`` /
+    ``R.koopman_analyzers.add()``, allowing the framework to instantiate
+    appropriate components based on model configuration.
 
     The registry stores two types of analysis components:
     1. Sensitivity Analyzers: Parameter importance/uncertainty analysis
@@ -79,10 +79,6 @@ class AnalysisRegistry:
         AnalysisManager queries registry by model name and retrieves class
         references for instantiation. Returns None for unregistered models
         (graceful fallback vs hard error).
-
-    Attributes:
-        _sensitivity_analyzers: Dict[model_name] -> sensitivity_analyzer_class
-        _decision_analyzers: Dict[model_name] -> decision_analyzer_class
 
     Example:
         >>> # Register a decision analyzer
@@ -96,69 +92,6 @@ class AnalysisRegistry:
         ...     analyzer = analyzer_cls(config, logger)
         ...     results = analyzer.run_full_analysis()
     """
-
-    @classmethod
-    def register_sensitivity_analyzer(cls, model_name: str):
-        """Decorator to register a sensitivity analyzer for a model.
-
-        The analyzer should implement a `run_sensitivity_analysis(results_file)` method
-        that returns sensitivity analysis results (typically a Dict).
-
-        Args:
-            model_name: Model identifier (e.g., 'SUMMA', 'FUSE', 'GR')
-
-        Returns:
-            Decorator function that registers the class
-
-        Example:
-            @AnalysisRegistry.register_sensitivity_analyzer('SUMMA')
-            class SummaSensitivityAnalyzer:
-                def __init__(self, config, logger, reporting_manager=None):
-                    ...
-                def run_sensitivity_analysis(self, results_file):
-                    ...
-        """
-        def decorator(analyzer_cls: Type) -> Type:
-            warnings.warn(
-                "AnalysisRegistry.register_sensitivity_analyzer() is deprecated; "
-                "use R.sensitivity_analyzers.add() or model_manifest() instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            R.sensitivity_analyzers.add(model_name, analyzer_cls)
-            return analyzer_cls
-        return decorator
-
-    @classmethod
-    def register_decision_analyzer(cls, model_name: str):
-        """Decorator to register a decision/structure analyzer for a model.
-
-        The analyzer should extend BaseStructureEnsembleAnalyzer or implement
-        a compatible interface with `run_full_analysis()` method that returns
-        a tuple of (results_file_path, best_combinations_dict).
-
-        Args:
-            model_name: Model identifier (e.g., 'SUMMA', 'FUSE', 'GR')
-
-        Returns:
-            Decorator function that registers the class
-
-        Example:
-            @AnalysisRegistry.register_decision_analyzer('SUMMA')
-            class SummaStructureAnalyzer(BaseStructureEnsembleAnalyzer):
-                def run_full_analysis(self):
-                    return results_file, best_combinations
-        """
-        def decorator(analyzer_cls: Type) -> Type:
-            warnings.warn(
-                "AnalysisRegistry.register_decision_analyzer() is deprecated; "
-                "use R.decision_analyzers.add() or model_manifest() instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            R.decision_analyzers.add(model_name, analyzer_cls)
-            return analyzer_cls
-        return decorator
 
     @classmethod
     def get_sensitivity_analyzer(cls, model_name: str) -> Optional[Type]:
@@ -243,39 +176,6 @@ class AnalysisRegistry:
     # ------------------------------------------------------------------
     # Koopman analyzers
     # ------------------------------------------------------------------
-
-    @classmethod
-    def register_koopman_analyzer(cls, name: str = "DEFAULT"):
-        """Decorator to register a Koopman operator analyzer.
-
-        Koopman analyzers use EDMD with multi-model ensemble outputs as
-        lifting functions to approximate the Koopman operator of the
-        watershed system.
-
-        Args:
-            name: Analyzer identifier (default "DEFAULT")
-
-        Returns:
-            Decorator function that registers the class
-
-        Example:
-            @AnalysisRegistry.register_koopman_analyzer()
-            class KoopmanAnalyzer:
-                def __init__(self, config, logger, reporting_manager=None):
-                    ...
-                def run_koopman_analysis(self, ensemble_df, obs_streamflow):
-                    ...
-        """
-        def decorator(analyzer_cls: Type) -> Type:
-            warnings.warn(
-                "AnalysisRegistry.register_koopman_analyzer() is deprecated; "
-                "use R.koopman_analyzers.add() or model_manifest() instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            R.koopman_analyzers.add(name, analyzer_cls)
-            return analyzer_cls
-        return decorator
 
     @classmethod
     def get_koopman_analyzer(cls, name: str = "DEFAULT") -> Optional[Type]:

--- a/src/symfluence/evaluation/registry.py
+++ b/src/symfluence/evaluation/registry.py
@@ -9,7 +9,6 @@ Provides a central registry for performance evaluation handlers.
 from __future__ import annotations
 
 import logging
-import warnings
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -17,20 +16,10 @@ from symfluence.core.registries import R
 
 
 class EvaluationRegistry:
+    """Lookup facade over ``R.evaluators``.
 
-    @classmethod
-    def register(cls, variable_type: str):
-        """Decorator to register an evaluation handler."""
-        def decorator(handler_class):
-            warnings.warn(
-                "EvaluationRegistry.register() is deprecated; "
-                "use R.evaluators.add() or model_manifest() instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            R.evaluators.add(variable_type, handler_class)
-            return handler_class
-        return decorator
+    Registration goes through ``R.evaluators.add()`` or ``model_manifest()``.
+    """
 
     @classmethod
     def get_evaluator(

--- a/src/symfluence/geospatial/delineation_registry.py
+++ b/src/symfluence/geospatial/delineation_registry.py
@@ -32,8 +32,7 @@ Usage:
 
 from __future__ import annotations
 
-import warnings
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Type
+from typing import TYPE_CHECKING, Dict, List, Optional, Type
 
 from symfluence.core.registries import R
 
@@ -70,38 +69,6 @@ class DelineationRegistry:
         'subset': 'semidistributed',  # subset is semidistributed with flag
         'discretized': 'semidistributed',  # deprecated
     }
-
-    @classmethod
-    def register(cls, method_name: str) -> Callable[[Type], Type]:
-        """
-        Decorator to register a delineation strategy class.
-
-        Args:
-            method_name: Canonical name for the delineation method
-                (e.g., 'point', 'lumped', 'semidistributed', 'distributed')
-
-        Returns:
-            Decorator function that registers the class and returns it unchanged.
-
-        Example:
-            >>> @DelineationRegistry.register('point')
-            ... class PointDelineator:
-            ...     def delineate(self):
-            ...         pass
-
-        .. deprecated::
-            Use ``R.delineation_strategies.add()`` or ``model_manifest()`` instead.
-        """
-        def decorator(strategy_cls: Type) -> Type:
-            warnings.warn(
-                "DelineationRegistry.register() is deprecated; "
-                "use R.delineation_strategies.add() instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            R.delineation_strategies.add(method_name, strategy_cls)
-            return strategy_cls
-        return decorator
 
     @classmethod
     def get_strategy(cls, method_name: str) -> Optional[Type]:

--- a/src/symfluence/models/adapters/adapter_registry.py
+++ b/src/symfluence/models/adapters/adapter_registry.py
@@ -10,8 +10,7 @@ enabling dynamic discovery and instantiation without hardcoded model names.
 from __future__ import annotations
 
 import logging
-import warnings
-from typing import Any, Callable, Dict, Optional, Type
+from typing import Any, Dict, Optional, Type
 
 from symfluence.core.registries import R
 
@@ -24,9 +23,9 @@ class ForcingAdapterRegistry:
     """
     Registry for model forcing adapters.
 
-    Deprecated delegation shim: adapters now register via the unified
-    registry (``@R.forcing_adapters.add('SUMMA')``); lookups here read
-    from ``R.forcing_adapters``.
+    Lookup facade: adapters register via the unified registry
+    (``@R.forcing_adapters.add('SUMMA')``) or ``model_manifest()``;
+    lookups here read from ``R.forcing_adapters``.
 
     Example:
         >>> @R.forcing_adapters.add('SUMMA')
@@ -35,34 +34,6 @@ class ForcingAdapterRegistry:
         ...
         >>> adapter = ForcingAdapterRegistry.get_adapter('SUMMA', config)
     """
-
-    @classmethod
-    def register_adapter(cls, model_name: str) -> Callable[[Type[ForcingAdapter]], Type[ForcingAdapter]]:
-        """
-        Decorator to register a forcing adapter.
-
-        Args:
-            model_name: Model name (e.g., 'SUMMA', 'HYPE')
-
-        Returns:
-            Decorator function
-
-        Example:
-            >>> @ForcingAdapterRegistry.register_adapter('SUMMA')
-            >>> class SUMMAForcingAdapter(ForcingAdapter):
-            ...     pass
-        """
-        def decorator(adapter_cls: Type[ForcingAdapter]) -> Type[ForcingAdapter]:
-            warnings.warn(
-                "ForcingAdapterRegistry.register_adapter() is deprecated; "
-                "use R.forcing_adapters.add() or model_manifest() instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            R.forcing_adapters.add(model_name, adapter_cls)
-            logger.debug(f"Registered forcing adapter for model: {model_name}")
-            return adapter_cls
-        return decorator
 
     @classmethod
     def get_adapter(

--- a/src/symfluence/optimization/objectives/registry.py
+++ b/src/symfluence/optimization/objectives/registry.py
@@ -8,7 +8,7 @@ Provides a central registry for objective functions used in calibration.
 This module implements a plugin pattern for objective functions. Objective classes
 register themselves via the unified registry (``@R.objectives.add()``), enabling
 dynamic instantiation by type string from configuration without hardcoded imports.
-``ObjectiveRegistry`` is a deprecated delegation shim kept for plugin compatibility.
+``ObjectiveRegistry`` is a lookup facade over ``R.objectives``.
 
 This design allows users to select different objective functions (single-variable,
 multi-variable, custom) via configuration and enables straightforward addition of
@@ -29,7 +29,6 @@ Example:
 """
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from symfluence.core.registries import R
@@ -38,46 +37,12 @@ if TYPE_CHECKING:
     from .base import BaseObjective
 
 class ObjectiveRegistry:
-    """Plugin registry for objective function implementations.
+    """Lookup facade for objective function implementations.
 
-    Manages objective function classes using a plugin pattern. Objectives register
-    themselves using @register() decorator and are dynamically instantiated via
-    get_objective() based on a type string from configuration.
-
-    Class Attributes:
-        _handlers (dict): Maps objective type strings (uppercase) to objective classes.
+    Objectives register themselves via ``@R.objectives.add()`` and are
+    dynamically instantiated via get_objective() based on a type string
+    from configuration.
     """
-
-    @classmethod
-    def register(cls, objective_type: str):
-        """Decorator to register an objective function class.
-
-        Registers an objective class for a given type string. The type is converted
-        to uppercase for case-insensitive lookups. The decorated class must implement
-        the BaseObjective interface (calculate method).
-
-        Args:
-            objective_type: Case-insensitive type identifier for the objective
-                (e.g., 'MULTIVARIATE', 'SINGLE_VARIABLE'). Will be stored in uppercase.
-
-        Returns:
-            Decorator function that registers the class and returns it unchanged.
-
-        Example:
-            >>> @ObjectiveRegistry.register('MULTIVARIATE')
-            ... class MultivariateObjective(BaseObjective):
-            ...     pass
-        """
-        def decorator(handler_class):
-            warnings.warn(
-                "ObjectiveRegistry.register() is deprecated; "
-                "use R.objectives.add() or model_manifest() instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            R.objectives.add(objective_type, handler_class)
-            return handler_class
-        return decorator
 
     @classmethod
     def get_objective(

--- a/src/symfluence/optimization/parameter_managers/__init__.py
+++ b/src/symfluence/optimization/parameter_managers/__init__.py
@@ -28,7 +28,7 @@ def _register_parameter_managers():
 
     Scans ``symfluence.models.*`` for sub-packages that contain a
     ``calibration.parameter_manager`` module and imports each one to
-    trigger its ``@register_parameter_manager`` decorator.  Models with no
+    trigger its ``R.parameter_managers`` registration.  Models with no
     calibration support are skipped silently; models whose parameter-manager
     module *exists but fails to import* are surfaced at WARNING (see
     ``discover_calibration_components``) instead of vanishing silently.

--- a/tests/unit/coupling/test_graph_builder.py
+++ b/tests/unit/coupling/test_graph_builder.py
@@ -27,9 +27,14 @@ class TestBMIRegistry:
             registry.get("NONEXISTENT")
 
     def test_register_custom(self):
+        from symfluence.core.registries import R
+
         registry = BMIRegistry()
-        registry.register("MYMODEL", "some.module.MyClass")
-        assert "MYMODEL" in registry.available_models()
+        R.bmi_adapters.add_lazy("MYMODEL", "some.module.MyClass")
+        try:
+            assert "MYMODEL" in registry.available_models()
+        finally:
+            R.bmi_adapters.remove("MYMODEL")
 
     def test_available_models(self):
         registry = BMIRegistry()

--- a/tests/unit/data/acquisition/test_registry.py
+++ b/tests/unit/data/acquisition/test_registry.py
@@ -17,6 +17,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fixtures.acquisition_fixtures import MockConfigFactory
 
+from symfluence.core.registries import R
+
 # =============================================================================
 # Test Fixtures
 # =============================================================================
@@ -76,7 +78,7 @@ class TestHandlerRegistration:
 
     def test_register_decorator(self, isolated_registry, mock_handler_class):
         """Register decorator should add handler to registry."""
-        @isolated_registry.register('test_handler')
+        @R.acquisition_handlers.add('test_handler')
         class TestHandler(mock_handler_class):
             pass
 
@@ -84,11 +86,11 @@ class TestHandlerRegistration:
 
     def test_register_multiple_handlers(self, isolated_registry, mock_handler_class):
         """Multiple handlers can be registered."""
-        @isolated_registry.register('handler_a')
+        @R.acquisition_handlers.add('handler_a')
         class HandlerA(mock_handler_class):
             pass
 
-        @isolated_registry.register('handler_b')
+        @R.acquisition_handlers.add('handler_b')
         class HandlerB(mock_handler_class):
             pass
 
@@ -97,7 +99,7 @@ class TestHandlerRegistration:
 
     def test_register_normalizes_to_lowercase(self, isolated_registry, mock_handler_class):
         """Registration should normalize names to lowercase."""
-        @isolated_registry.register('TEST_HANDLER')
+        @R.acquisition_handlers.add('TEST_HANDLER')
         class TestHandler(mock_handler_class):
             pass
 
@@ -106,7 +108,7 @@ class TestHandlerRegistration:
 
     def test_register_returns_class(self, isolated_registry, mock_handler_class):
         """Register decorator should return the class unchanged."""
-        @isolated_registry.register('test_handler')
+        @R.acquisition_handlers.add('test_handler')
         class TestHandler(mock_handler_class):
             pass
 
@@ -127,7 +129,7 @@ class TestHandlerRetrieval:
         self, isolated_registry, mock_handler_class, mock_config, mock_logger
     ):
         """get_handler should return an instance of the registered handler."""
-        @isolated_registry.register('test_handler')
+        @R.acquisition_handlers.add('test_handler')
         class TestHandler(mock_handler_class):
             pass
 
@@ -140,7 +142,7 @@ class TestHandlerRetrieval:
         self, isolated_registry, mock_handler_class, mock_config, mock_logger
     ):
         """get_handler should be case-insensitive."""
-        @isolated_registry.register('test_handler')
+        @R.acquisition_handlers.add('test_handler')
         class TestHandler(mock_handler_class):
             pass
 
@@ -200,7 +202,7 @@ class TestHandlerRetrieval:
         self, isolated_registry, mock_handler_class, mock_config, mock_logger
     ):
         """Error message should list available handlers."""
-        @isolated_registry.register('available_handler')
+        @R.acquisition_handlers.add('available_handler')
         class AvailableHandler(mock_handler_class):
             pass
 
@@ -221,7 +223,7 @@ class TestGetHandlerClass:
 
     def test_get_handler_class_returns_class(self, isolated_registry, mock_handler_class):
         """_get_handler_class should return the class, not instance."""
-        @isolated_registry.register('test_handler')
+        @R.acquisition_handlers.add('test_handler')
         class TestHandler(mock_handler_class):
             pass
 
@@ -232,7 +234,7 @@ class TestGetHandlerClass:
 
     def test_get_handler_class_case_insensitive(self, isolated_registry, mock_handler_class):
         """_get_handler_class should be case-insensitive."""
-        @isolated_registry.register('test_handler')
+        @R.acquisition_handlers.add('test_handler')
         class TestHandler(mock_handler_class):
             pass
 
@@ -262,11 +264,11 @@ class TestListHandlers:
 
     def test_list_handlers_returns_all(self, isolated_registry, mock_handler_class):
         """list_handlers should return all registered handlers."""
-        @isolated_registry.register('handler_a')
+        @R.acquisition_handlers.add('handler_a')
         class HandlerA(mock_handler_class):
             pass
 
-        @isolated_registry.register('handler_b')
+        @R.acquisition_handlers.add('handler_b')
         class HandlerB(mock_handler_class):
             pass
 
@@ -277,15 +279,15 @@ class TestListHandlers:
 
     def test_list_handlers_sorted(self, isolated_registry, mock_handler_class):
         """list_handlers should return sorted list."""
-        @isolated_registry.register('zebra')
+        @R.acquisition_handlers.add('zebra')
         class Zebra(mock_handler_class):
             pass
 
-        @isolated_registry.register('alpha')
+        @R.acquisition_handlers.add('alpha')
         class Alpha(mock_handler_class):
             pass
 
-        @isolated_registry.register('beta')
+        @R.acquisition_handlers.add('beta')
         class Beta(mock_handler_class):
             pass
 
@@ -296,7 +298,7 @@ class TestListHandlers:
 
     def test_list_datasets_alias(self, isolated_registry, mock_handler_class):
         """list_datasets should be alias for list_handlers."""
-        @isolated_registry.register('test_handler')
+        @R.acquisition_handlers.add('test_handler')
         class TestHandler(mock_handler_class):
             pass
 
@@ -316,7 +318,7 @@ class TestIsRegistered:
 
     def test_is_registered_true(self, isolated_registry, mock_handler_class):
         """is_registered should return True for registered handlers."""
-        @isolated_registry.register('test_handler')
+        @R.acquisition_handlers.add('test_handler')
         class TestHandler(mock_handler_class):
             pass
 
@@ -328,7 +330,7 @@ class TestIsRegistered:
 
     def test_is_registered_case_insensitive(self, isolated_registry, mock_handler_class):
         """is_registered should be case-insensitive."""
-        @isolated_registry.register('test_handler')
+        @R.acquisition_handlers.add('test_handler')
         class TestHandler(mock_handler_class):
             pass
 
@@ -346,11 +348,11 @@ class TestClearRegistry:
 
     def test_clear_removes_all_handlers(self, isolated_registry, mock_handler_class):
         """clear should remove all registered handlers."""
-        @isolated_registry.register('handler_a')
+        @R.acquisition_handlers.add('handler_a')
         class HandlerA(mock_handler_class):
             pass
 
-        @isolated_registry.register('handler_b')
+        @R.acquisition_handlers.add('handler_b')
         class HandlerB(mock_handler_class):
             pass
 

--- a/tests/unit/optimization/test_optimization_registry.py
+++ b/tests/unit/optimization/test_optimization_registry.py
@@ -93,21 +93,3 @@ def test_objective_registry_get_and_list(temp_register):
     assert isinstance(instance, FakeObjective)
     assert ObjectiveRegistry.get_objective("DEFINITELY_UNKNOWN", {}, None) is None
     assert "FAKEOBJ" in ObjectiveRegistry.list_objectives()
-
-
-def test_objective_register_decorator_is_deprecated():
-    from symfluence.optimization.objectives.registry import ObjectiveRegistry
-
-    try:
-        with pytest.warns(DeprecationWarning):
-            @ObjectiveRegistry.register("TMPOBJ")
-            class _TmpObjective:
-                def __init__(self, config, logger):
-                    pass
-
-        assert R.objectives.get("TMPOBJ") is _TmpObjective
-    finally:
-        try:
-            R.objectives.remove("TMPOBJ")
-        except Exception:  # noqa: BLE001
-            pass

--- a/tests/unit/optimization/test_worker_contracts.py
+++ b/tests/unit/optimization/test_worker_contracts.py
@@ -466,7 +466,7 @@ class TestSUMMAWorkerContract:
 
     def test_summa_worker_registered(self):
         """Test that SUMMAWorker is registered with registry."""
-        from symfluence.models.summa.calibration.worker import SUMMAWorker  # noqa: F401 — triggers @register_worker
+        from symfluence.models.summa.calibration.worker import SUMMAWorker  # noqa: F401 — triggers worker registration
         worker_cls = R.workers.get('SUMMA')
         assert worker_cls is not None
         assert worker_cls.__name__ == 'SUMMAWorker'
@@ -495,7 +495,7 @@ class TestFUSEWorkerContract:
 
     def test_fuse_worker_registered(self):
         """Test that FUSEWorker is registered with registry."""
-        from symfluence.models.fuse.calibration.worker import FUSEWorker  # noqa: F401 — triggers @register_worker
+        from symfluence.models.fuse.calibration.worker import FUSEWorker  # noqa: F401 — triggers worker registration
         worker_cls = R.workers.get('FUSE')
         assert worker_cls is not None
         assert worker_cls.__name__ == 'FUSEWorker'
@@ -519,7 +519,7 @@ class TestNgenWorkerContract:
 
     def test_ngen_worker_registered(self):
         """Test that NgenWorker is registered with registry."""
-        from symfluence.models.ngen.calibration.worker import NgenWorker  # noqa: F401 — triggers @register_worker
+        from symfluence.models.ngen.calibration.worker import NgenWorker  # noqa: F401 — triggers worker registration
         worker_cls = R.workers.get('NGEN')
         assert worker_cls is not None
         assert worker_cls.__name__ == 'NgenWorker'


### PR DESCRIPTION
## Summary

Pre-1.0 API cleanup, following up on #211 (item-9 tail): the deprecated `register*` decorator methods are now **removed** rather than warning. Registration goes exclusively through `R.<registry>.add()` / `add_lazy()` or `model_manifest()`; the per-subsystem registry classes survive as lookup facades only.

Removed (all emitted `DeprecationWarning` since the item-9 migration; zero production call sites remained):

- `EvaluationRegistry.register()`
- `ObjectiveRegistry.register()`
- `AnalysisRegistry.register_{sensitivity,decision,koopman}_analyzer()`
- `DelineationRegistry.register()`
- `BMIRegistry().register()`
- `ForcingAdapterRegistry.register_adapter()`
- `PresetRegistry.register_preset()` / `register_preset_dict()` (+ the now-unreachable `_preset_loaders` fallback)
- `BaseRegistry.register()` and the legacy local `_handlers` fallback — `_r_registry_name` is now required on subclasses; stale `_handlers = {}` declarations dropped from `AcquisitionRegistry`/`DatasetRegistry`/`ObservationRegistry`

## Tests

Migrated, not deleted — `R.<registry>.add()` has a decorator form, so the swap is drop-in and behavior assertions (lowercase key normalization, case-insensitive lookup) are preserved:

- `tests/unit/data/acquisition/test_registry.py`: `@isolated_registry.register(...)` → `@R.acquisition_handlers.add(...)`
- `tests/unit/coupling/test_graph_builder.py`: `BMIRegistry().register` → `R.bmi_adapters.add_lazy` (+ cleanup)
- `tests/unit/optimization/test_optimization_registry.py`: dropped the test asserting the deprecation warning (the method no longer exists)

## Notes

- This reconciles the ADR-0001 tension (PR #209): lookup APIs are supported first-class; registration is R-only.
- Verified: full unit suite 8,336 passed; ruff clean; mypy clean on all touched modules; all pre-commit guards green.

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).