### PR TITLE
refactor(models)!: remove deprecated *Postprocessor spelling aliases (RTI item 23)

### DIFF
--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -209,7 +209,7 @@ accessible through the ``Registries`` facade (aliased as ``R``):
        preprocessor=MyModelPreprocessor,
        runner=MyModelRunner,
        runner_method="run_mymodel",
-       postprocessor=MyModelPostprocessor,
+       postprocessor=MyModelPostProcessor,
        config_adapter=MyModelConfigAdapter,
    )
 
@@ -542,14 +542,14 @@ Adding a New Model
    from symfluence.core.registry import model_manifest
    from .preprocessor import MyModelPreprocessor
    from .runner import MyModelRunner
-   from .postprocessor import MyModelPostprocessor
+   from .postprocessor import MyModelPostProcessor
 
    model_manifest(
        "MYMODEL",
        preprocessor=MyModelPreprocessor,
        runner=MyModelRunner,
        runner_method="run_mymodel",
-       postprocessor=MyModelPostprocessor,
+       postprocessor=MyModelPostProcessor,
    )
 
 Adding a New Optimization Algorithm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,19 +84,21 @@ dependencies = [
 # JAX-based model plugins (Snow-17, SAC-SMA, Xinanjiang, HBV, HEC-HMS, TOPMODEL).
 # Optional: only needed to run those models, discovered via entry points at runtime.
 #   pip install "symfluence[jax]"
+# Floors require the *PostProcessor-spelling plugin releases (the old
+# *Postprocessor base-class aliases were removed pre-1.0, RTI item 23).
 jax = [
   "jsnow17>=0.1.0",
-  "jsacsma>=0.1.0",
-  "jxaj>=0.1.0",
-  "jhbv>=0.1.0",
-  "jhechms>=0.1.0",
-  "jtopmodel>=0.1.0",
+  "jsacsma>=0.2.3",
+  "jxaj>=0.2.3",
+  "jhbv>=0.2.4",
+  "jhechms>=0.2.3",
+  "jtopmodel>=0.2.3",
 ]
 # dRoute differentiable river routing plugin (C++ engine + SYMFLUENCE integration).
 # Optional: only needed to run dRoute routing/calibration, discovered via entry points at runtime.
 #   pip install "symfluence[droute]"
 droute = [
-  "droute>=0.6.0",
+  "droute>=0.6.1",
 ]
 # LLM agent integration. Optional: only needed for `symfluence agent` features.
 #   pip install "symfluence[llm]"

--- a/src/symfluence/models/base/__init__.py
+++ b/src/symfluence/models/base/__init__.py
@@ -29,8 +29,3 @@ __all__ = [
     'ModelPreProcessor',
     'ModelPostProcessor',
 ]
-
-
-# Deprecated pre-1.0 spellings (RTI review item 23) — use the *PostProcessor names.
-StandardModelPostprocessor = StandardModelPostProcessor
-RoutedModelPostprocessor = RoutedModelPostProcessor

--- a/src/symfluence/models/base/standard_postprocessor.py
+++ b/src/symfluence/models/base/standard_postprocessor.py
@@ -577,13 +577,3 @@ class RoutedModelPostProcessor(StandardModelPostProcessor):
         except Exception as e:  # noqa: BLE001 — model execution resilience
             self.logger.error(f"Error reading routing output: {e}", exc_info=True)
             return None
-
-
-# ---------------------------------------------------------------------------
-# Deprecated pre-1.0 spellings. The canonical class name is *PostProcessor
-# (matching BaseModelPostProcessor). These aliases keep existing
-# imports/subclasses working through the 1.0 transition and should be removed
-# at v1.0 (see RTI review item 23 / open question 1).
-# ---------------------------------------------------------------------------
-StandardModelPostprocessor = StandardModelPostProcessor
-RoutedModelPostprocessor = RoutedModelPostProcessor

--- a/src/symfluence/models/fuse/__init__.py
+++ b/src/symfluence/models/fuse/__init__.py
@@ -101,6 +101,3 @@ def register() -> None:
         plotter=FUSEPlotter,
         build_instructions_module="symfluence.models.fuse.build_instructions",
     )
-
-# Deprecated pre-1.0 spelling (RTI item 23) — use FUSEPostProcessor.
-FUSEPostprocessor = FUSEPostProcessor

--- a/src/symfluence/models/gnn/__init__.py
+++ b/src/symfluence/models/gnn/__init__.py
@@ -15,8 +15,6 @@ _LAZY_IMPORTS = {
     'GNNRunner': ('.runner', 'GNNRunner'),
     'GNNPreProcessor': ('.preprocessor', 'GNNPreProcessor'),
     'GNNPostProcessor': ('.postprocessor', 'GNNPostProcessor'),
-    # Deprecated pre-1.0 spelling (RTI item 23) — use GNNPostProcessor.
-    'GNNPostprocessor': ('.postprocessor', 'GNNPostProcessor'),
 }
 
 

--- a/src/symfluence/models/gr/__init__.py
+++ b/src/symfluence/models/gr/__init__.py
@@ -94,6 +94,3 @@ def register() -> None:
         config_adapter=GRConfigAdapter,
         result_extractor=GRResultExtractor,
     )
-
-# Deprecated pre-1.0 spelling (RTI item 23) — use GRPostProcessor.
-GRPostprocessor = GRPostProcessor

--- a/src/symfluence/models/lstm/__init__.py
+++ b/src/symfluence/models/lstm/__init__.py
@@ -26,9 +26,6 @@ _LAZY_ALIASES = {
     'FlashRunner': ('.runner', 'LSTMRunner'),
     'FlashPreProcessor': ('.preprocessor', 'LSTMPreProcessor'),
     'FlashPostProcessor': ('.postprocessor', 'LSTMPostProcessor'),
-    # Deprecated pre-1.0 spellings (RTI item 23) — use *PostProcessor.
-    'LSTMPostprocessor': ('.postprocessor', 'LSTMPostProcessor'),
-    'FlashPostprocessor': ('.postprocessor', 'LSTMPostProcessor'),
 }
 
 

--- a/src/symfluence/models/ngen/__init__.py
+++ b/src/symfluence/models/ngen/__init__.py
@@ -104,6 +104,3 @@ def register() -> None:
         plotter=NGENPlotter,
         build_instructions_module="symfluence.models.ngen.build_instructions",
     )
-
-# Deprecated pre-1.0 spelling (RTI item 23) — use NgenPostProcessor.
-NgenPostprocessor = NgenPostProcessor

--- a/src/symfluence/models/summa/__init__.py
+++ b/src/symfluence/models/summa/__init__.py
@@ -113,6 +113,3 @@ def register() -> None:
         plotter=SUMMAPlotter,
         build_instructions_module="symfluence.models.summa.build_instructions",
     )
-
-# Deprecated pre-1.0 spelling (RTI item 23) — use SUMMAPostProcessor.
-SUMMAPostprocessor = SUMMAPostProcessor


### PR DESCRIPTION
## Summary

Executes the ratified item-23 tail: the silent `*Postprocessor` (lowercase-p) spelling aliases from PR #169 were scheduled for removal at v1.0 — this removes them. The canonical spelling is `*PostProcessor`, matching `BaseModelPostProcessor`.

Removed: `StandardModelPostprocessor` / `RoutedModelPostprocessor` (both definition sites), `NgenPostprocessor`, `GRPostprocessor`, `FUSEPostprocessor`, `SUMMAPostprocessor`, and the lazy-map entries `GNNPostprocessor` / `LSTMPostprocessor` / `FlashPostprocessor`. The `docs/source/architecture.rst` examples now teach the canonical spelling.

## External plugins updated in lockstep

The removal surfaced that **eight installed plugins** still subclassed the old base-class spellings — their bootstrap imports broke, which silently de-registered them (caught because the shipped-config strict guard lost the plugins' key schemas, and plugin-parametrized tests shrank the suite count). All eight are fixed and committed in their own repos: cFUSE, jFUSE, jHBV, jSACSMA, jHECHMS, jTOPMODEL, jXAJ (pushed to main) and dRoute (committed on its active feature branch `feat/mc-coupling-aware-multigauge`, not pushed — that branch has unrelated WIP in flight).

## Verification

Full unit suite 8,352 passed with all plugins registering (CFUSE/DROUTE/HBV/SACSMA/HECHMS/TOPMODEL/JFUSE/XINANJIANG verified in `R.workers`/`R.config_schemas`); jHBV 52, jHECHMS 3, jTOPMODEL 3 plugin suites pass (jSACSMA has 4 pre-existing failures unrelated to this change — a SNOW17 parameter-count drift, 11 vs expected 10). Ruff/mypy/pre-commit green.

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).