### PR TITLE
fix(evaluation): unify catchment-area resolution between trial and final-eval metrics

### DIFF
--- a/src/symfluence/evaluation/evaluators/streamflow.py
+++ b/src/symfluence/evaluation/evaluators/streamflow.py
@@ -693,10 +693,16 @@ class StreamflowEvaluator(ModelEvaluator):
                 return validated
             # Fall through to other methods if fixed area is invalid
 
-        # Priority 1: Try SUMMA attributes file first (most reliable)
+        # Priority 1: SUMMA attributes file — model-specific, so only consult
+        # it when SUMMA is actually the configured model (most reliable there;
+        # other models must not read another model's settings files).
+        active_model = str(self._get_config_value(
+            lambda: self.config.model.hydrological_model,
+            default='', dict_key='HYDROLOGICAL_MODEL'
+        ) or '').upper()
         try:
             attrs_file = self.project_dir / 'settings' / 'SUMMA' / 'attributes.nc'
-            if attrs_file.exists():
+            if active_model == 'SUMMA' and attrs_file.exists():
                 with xr.open_dataset(attrs_file) as attrs:
                     if 'HRUarea' in attrs.data_vars:
                         catchment_area_m2 = float(attrs['HRUarea'].values.sum())

--- a/src/symfluence/evaluation/utilities/streamflow_metrics.py
+++ b/src/symfluence/evaluation/utilities/streamflow_metrics.py
@@ -188,10 +188,16 @@ class StreamflowMetrics:
         domain_name: str,
         source: str = 'shapefile',
         settings_dir: Optional[Path] = None,
-        default_area: float = 1000.0
+        default_area: float = 1.0
     ) -> float:
         """
         Get catchment area in km2 from various sources.
+
+        FIXED_CATCHMENT_AREA (m²) always wins when set. The last-resort
+        default is 1 km² and must stay identical to the
+        StreamflowEvaluator fallback: trial metrics and the final
+        evaluation convert units with this value, and any disagreement
+        makes their scores incomparable.
 
         Args:
             config: Configuration dictionary
@@ -205,6 +211,12 @@ class StreamflowMetrics:
             Catchment area in km2
         """
         try:
+            fixed_area_m2 = config.get('FIXED_CATCHMENT_AREA')
+            if fixed_area_m2:
+                area_km2 = float(fixed_area_m2) / 1e6
+                logger.debug(f"Using fixed catchment area from config: {area_km2:.2f} km2")
+                return area_km2
+
             if source == 'shapefile':
                 return self._get_area_from_shapefile(config, project_dir, domain_name, default_area)
             elif source == 'netcdf':
@@ -246,7 +258,8 @@ class StreamflowMetrics:
             logger.warning(
                 f"Catchment shapefile not found for {domain_name}. "
                 f"Using default area {default_area} km2. "
-                f"This may cause incorrect unit conversions during calibration!"
+                f"This makes discharge unit conversions physically meaningless — "
+                f"set FIXED_CATCHMENT_AREA in the config to the true area in m²."
             )
             return default_area
 

--- a/src/symfluence/models/fuse/calibration/model_execution.py
+++ b/src/symfluence/models/fuse/calibration/model_execution.py
@@ -21,6 +21,10 @@ from symfluence.models.fuse.calibration.file_manager import resolve_fuse_id
 
 logger = logging.getLogger(__name__)
 
+# Run modes already warned about — the rejection fires on every calibration
+# trial, so without dedupe a 1000-iteration run logs it 1000 times.
+_REJECTED_MODES_WARNED: set = set()
+
 
 def detect_fuse_run_mode(config: Dict[str, Any], kwargs: Dict[str, Any],
                          log: Optional[logging.Logger] = None) -> str:
@@ -49,12 +53,13 @@ def detect_fuse_run_mode(config: Dict[str, Any], kwargs: Dict[str, Any],
     log = log or logger
 
     requested = config.get('FUSE_RUN_MODE') or kwargs.get('mode')
-    if requested and requested != 'run_pre':
+    if requested and requested != 'run_pre' and requested not in _REJECTED_MODES_WARNED:
+        _REJECTED_MODES_WARNED.add(requested)
         log.warning(
-            f"FUSE run mode '{requested}' requested for calibration — ignored. "
-            "Calibration always uses run_pre (trial parameters are read from "
-            "para_def.nc); run_def is only used by the runner's initial "
-            "default run to generate para_def.nc."
+            f"FUSE run mode '{requested}' requested for calibration — ignored "
+            "(warning shown once per run). Calibration always uses run_pre "
+            "(trial parameters are read from para_def.nc); run_def is only "
+            "used by the runner's initial default run to generate para_def.nc."
         )
 
     return 'run_pre'

--- a/tests/unit/evaluation/test_catchment_area_consistency.py
+++ b/tests/unit/evaluation/test_catchment_area_consistency.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Catchment-area resolution contract for the worker metrics path.
+
+Trial metrics (StreamflowMetrics) and the final evaluation
+(StreamflowEvaluator) resolve catchment area independently, and a
+disagreement makes the calibration score and the final-evaluation score
+incomparable. The contract: FIXED_CATCHMENT_AREA always wins, and the
+last-resort default (1 km²) is identical in both paths.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from symfluence.evaluation.utilities.streamflow_metrics import StreamflowMetrics
+
+
+@pytest.fixture
+def metrics():
+    return StreamflowMetrics()
+
+
+class TestFixedAreaOverride:
+    def test_fixed_catchment_area_wins(self, metrics, tmp_path):
+        """FIXED_CATCHMENT_AREA (m²) must drive trial metrics too, not just
+        the final-evaluation chain."""
+        config = {'FIXED_CATCHMENT_AREA': 2.207e9}  # 2207 km² in m²
+        area = metrics.get_catchment_area(config, tmp_path, 'nodomain')
+        assert area == pytest.approx(2207.0)
+
+    def test_fixed_area_skips_shapefile_lookup(self, metrics, tmp_path):
+        """No shapefile exists under tmp_path; the override must not care."""
+        config = {'FIXED_CATCHMENT_AREA': 5.0e8}
+        area = metrics.get_catchment_area(
+            config, tmp_path, 'nodomain', source='shapefile'
+        )
+        assert area == pytest.approx(500.0)
+
+
+class TestDefaultConsistency:
+    def test_last_resort_default_matches_evaluator(self, metrics, tmp_path, caplog):
+        """With no area source at all, the fallback is 1 km² — the same
+        last resort the StreamflowEvaluator chain uses — and it warns."""
+        with caplog.at_level(logging.WARNING):
+            area = metrics.get_catchment_area({}, tmp_path, 'nodomain')
+        assert area == 1.0
+        assert any('FIXED_CATCHMENT_AREA' in r.message for r in caplog.records)

--- a/tests/unit/evaluation/test_streamflow_evaluator.py
+++ b/tests/unit/evaluation/test_streamflow_evaluator.py
@@ -245,7 +245,7 @@ class TestGetCatchmentArea:
         assert result == 1e8
 
     def test_reads_from_summa_attributes(self, streamflow_evaluator, tmp_path):
-        """Test reading area from SUMMA attributes.nc."""
+        """SUMMA attributes.nc is consulted when SUMMA is the active model."""
         # Create attributes file
         attrs_dir = tmp_path / 'settings' / 'SUMMA'
         attrs_dir.mkdir(parents=True)
@@ -259,11 +259,33 @@ class TestGetCatchmentArea:
         ds.to_netcdf(attrs_file)
 
         streamflow_evaluator._project_dir = tmp_path
-        streamflow_evaluator.config_dict = {}
+        streamflow_evaluator.config_dict = {'HYDROLOGICAL_MODEL': 'SUMMA'}
 
         result = streamflow_evaluator._get_catchment_area()
 
         assert result == pytest.approx(8e6)
+
+    def test_summa_attributes_ignored_for_other_models(
+        self, streamflow_evaluator, tmp_path
+    ):
+        """A non-SUMMA run never reads SUMMA's settings files for area."""
+        attrs_dir = tmp_path / 'settings' / 'SUMMA'
+        attrs_dir.mkdir(parents=True)
+        ds = xr.Dataset(
+            {'HRUarea': (['hru'], [5e6, 3e6])}, coords={'hru': [0, 1]}
+        )
+        ds.to_netcdf(attrs_dir / 'attributes.nc')
+
+        streamflow_evaluator._project_dir = tmp_path
+        streamflow_evaluator.config_dict = {
+            'HYDROLOGICAL_MODEL': 'FUSE',
+            'FIXED_CATCHMENT_AREA': None,
+            'REQUIRE_EXPLICIT_CATCHMENT_AREA': False,
+        }
+
+        result = streamflow_evaluator._get_catchment_area()
+
+        assert result == pytest.approx(1e6)
 
     def test_default_fallback(self, streamflow_evaluator, tmp_path):
         """Test default fallback to 1 km²."""

--- a/tests/unit/models/fuse/test_run_mode.py
+++ b/tests/unit/models/fuse/test_run_mode.py
@@ -24,6 +24,8 @@ class TestDetectFuseRunMode:
         assert detect_fuse_run_mode({'FUSE_RUN_MODE': 'run_pre'}, {}) == 'run_pre'
 
     def test_config_run_def_is_rejected_with_warning(self, caplog):
+        from symfluence.models.fuse.calibration import model_execution
+        model_execution._REJECTED_MODES_WARNED.clear()
         with caplog.at_level(logging.WARNING):
             mode = detect_fuse_run_mode({'FUSE_RUN_MODE': 'run_def'}, {})
         assert mode == 'run_pre'
@@ -31,10 +33,22 @@ class TestDetectFuseRunMode:
                    for r in caplog.records)
 
     def test_kwargs_run_def_is_rejected_with_warning(self, caplog):
+        from symfluence.models.fuse.calibration import model_execution
+        model_execution._REJECTED_MODES_WARNED.clear()
         with caplog.at_level(logging.WARNING):
             mode = detect_fuse_run_mode({}, {'mode': 'run_def'})
         assert mode == 'run_pre'
         assert any('run_def' in r.message for r in caplog.records)
+
+    def test_rejection_warning_fires_once_per_run(self, caplog):
+        """A 1000-iteration calibration must not log the warning 1000 times."""
+        from symfluence.models.fuse.calibration import model_execution
+        model_execution._REJECTED_MODES_WARNED.clear()
+        with caplog.at_level(logging.WARNING):
+            for _ in range(5):
+                assert detect_fuse_run_mode({'FUSE_RUN_MODE': 'run_def'}, {}) == 'run_pre'
+        warnings_logged = [r for r in caplog.records if 'ignored' in r.message]
+        assert len(warnings_logged) == 1
 
     def test_regionalization_methods_all_use_run_pre(self):
         for method in ('lumped', 'semi_distributed', 'transfer_function'):


### PR DESCRIPTION
## Summary

Closes out the two findings from the FUSE run-mode verification.

### The final-eval KGE gap — diagnosed, and it's not warmup

Runtime diagnosis on the Bow-at-Banff FUSE domain: with a complete domain, the final evaluation matches the DDS best almost exactly (KGE 0.8332 vs 0.8329) — **the framework is consistent and there is no warmup contamination**. The original −0.43 vs +0.21 gap reproduced only in a domain with no area source: the worker metrics path (`StreamflowMetrics`, used by FUSE/VIC/PIHM/MODFLOW) and the final evaluation (`StreamflowEvaluator`) resolve catchment area **independently**, and their silent fallbacks disagreed by 1000× (1000 km² vs 1 km²) — so trial scores and the final score were computed in incompatible units.

Fixes:
- `StreamflowMetrics.get_catchment_area` now honors **`FIXED_CATCHMENT_AREA` first** — the documented user override was silently ignored on this path.
- Its last-resort default now matches the evaluator's **1 km²**, with a loud warning naming `FIXED_CATCHMENT_AREA` (a constant default is calibration-safe — all trials share it; only the divergence was harmful).
- The evaluator's SUMMA-attributes area source is **gated on SUMMA being the configured model** — model-agnostic code must not read another model's settings files.

### Warning noise

The FUSE run-mode rejection warning (new in #216) fired once per trial — 1,000 lines on a real calibration. Now deduped to once per run.

## Verification

New contract tests for the override precedence, the unified default, the SUMMA gate (positive + negative), and the once-per-run dedupe. Full unit suite 8,372 passed.

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).