### PR TITLE
Fix USGS NWIS timestamps: convert gauge-local time to UTC

### DIFF
--- a/src/symfluence/data/observation/handlers/usgs.py
+++ b/src/symfluence/data/observation/handlers/usgs.py
@@ -25,6 +25,10 @@ from ..base import BaseObservationHandler
 class USGSStreamflowHandler(BaseObservationHandler):
     """
     Handles USGS streamflow (discharge) data acquisition and processing.
+
+    Processed timestamps are UTC (tz-naive). NWIS RDB carries gauge-local
+    clock time plus a per-row ``tz_cd`` code; ``process()`` uses that code to
+    shift each row to UTC so observations align with (UTC) forcing data.
     """
 
     obs_type = "streamflow"
@@ -33,6 +37,22 @@ class USGSStreamflowHandler(BaseObservationHandler):
         'source': 'USGS NWIS',
         'source_doi': '10.5066/F7P55KJN',
         'url': 'https://waterservices.usgs.gov/nwis/',
+    }
+
+    # NWIS ``tz_cd`` codes → UTC offset in hours. Each row carries the code
+    # in effect at that timestamp, so a fixed per-code offset handles DST
+    # transitions exactly (MDT rows are -6, MST rows are -7).
+    NWIS_TZ_UTC_OFFSET_HOURS = {
+        'UTC': 0.0, 'GMT': 0.0,
+        'AST': -4.0, 'ADT': -3.0,    # Atlantic (Puerto Rico, USVI)
+        'EST': -5.0, 'EDT': -4.0,
+        'CST': -6.0, 'CDT': -5.0,
+        'MST': -7.0, 'MDT': -6.0,
+        'PST': -8.0, 'PDT': -7.0,
+        'AKST': -9.0, 'AKDT': -8.0,
+        'HST': -10.0, 'HAST': -10.0, 'HADT': -9.0,
+        'SST': -11.0,                # American Samoa
+        'GST': 10.0, 'CHST': 10.0,   # Guam / Chamorro
     }
 
     def acquire(self) -> Path:
@@ -110,9 +130,14 @@ class USGSStreamflowHandler(BaseObservationHandler):
         """Fetch discharge data from USGS API."""
         self.logger.info(f"Downloading USGS streamflow data for station {station_id}")
 
-        # Use experiment time range or defaults
+        # Use the experiment time range; only fall back to "now" when no
+        # experiment end is configured (a fixed end keeps downloads bounded
+        # and reproducible — previously this always used datetime.now()).
         start_date = self.start_date.strftime("%Y-%m-%d")
-        end_date = datetime.now().strftime("%Y-%m-%d")
+        if self.end_date is not None and not pd.isna(self.end_date):
+            end_date = pd.Timestamp(self.end_date).strftime("%Y-%m-%d")
+        else:
+            end_date = datetime.now().strftime("%Y-%m-%d")
         parameter_cd = "00060"  # Discharge in cfs
 
         base_url = "https://nwis.waterservices.usgs.gov/nwis/iv/"
@@ -206,6 +231,25 @@ class USGSStreamflowHandler(BaseObservationHandler):
         df[datetime_col] = pd.to_datetime(df[datetime_col], errors='coerce')
         df[discharge_col] = pd.to_numeric(df[discharge_col], errors='coerce')
         df = df.dropna(subset=[datetime_col, discharge_col])
+
+        # Shift gauge-local clock time to UTC using the per-row NWIS tz code.
+        # Without this, timestamps stay in local time (with DST jumps) and are
+        # misaligned with UTC forcing by up to several hours.
+        tz_col = self._find_col(df.columns, ['tz_cd'])
+        if tz_col:
+            codes = df[tz_col].astype(str).str.strip().str.upper()
+            offsets = codes.map(self.NWIS_TZ_UTC_OFFSET_HOURS)
+            unknown = sorted(codes[offsets.isna()].unique())
+            if unknown:
+                self.logger.warning(
+                    f"Unknown NWIS tz_cd codes {unknown}; treating those rows as UTC"
+                )
+            df[datetime_col] = df[datetime_col] - pd.to_timedelta(
+                offsets.fillna(0.0), unit='h'
+            ).to_numpy()
+        elif isinstance(df[datetime_col].dtype, pd.DatetimeTZDtype):
+            # ISO timestamps with offsets (e.g. manual CSV exports)
+            df[datetime_col] = df[datetime_col].dt.tz_convert('UTC').dt.tz_localize(None)
 
         df.set_index(datetime_col, inplace=True)
         df.sort_index(inplace=True)

--- a/tests/unit/data/observation/test_usgs_streamflow_handler.py
+++ b/tests/unit/data/observation/test_usgs_streamflow_handler.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Unit tests for the USGS streamflow handler.
+
+Covers the two bugs found by the 2026-06 native-vs-CSFS parity experiment:
+
+1. NWIS RDB timestamps are gauge-local clock time with a per-row ``tz_cd``
+   code; the handler previously ignored the code, leaving processed
+   timestamps in local time (with DST discontinuities) while forcing is UTC.
+2. ``_download_data`` previously hardcoded ``endDT=datetime.now()``,
+   downloading years past the experiment window.
+"""
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from symfluence.data.observation.handlers.usgs import USGSStreamflowHandler
+
+pytestmark = [pytest.mark.unit, pytest.mark.data]
+
+
+@pytest.fixture
+def mock_config(tmp_path):
+    return {
+        'SYMFLUENCE_DATA_DIR': str(tmp_path),
+        'SYMFLUENCE_CODE_DIR': str(tmp_path),
+        'DOMAIN_NAME': 'test_domain',
+        'EXPERIMENT_ID': 'test_exp',
+        'EXPERIMENT_TIME_START': '2023-06-01 00:00',
+        'EXPERIMENT_TIME_END': '2023-06-15 00:00',
+        'DOMAIN_DEFINITION_METHOD': 'lumped',
+        'SUB_GRID_DISCRETIZATION': 'lumped',
+        'FORCING_DATASET': 'ERA5',
+        'HYDROLOGICAL_MODEL': 'SUMMA',
+        'FORCING_TIME_STEP_SIZE': 3600,
+        'BOUNDING_BOX_COORDS': '46/-111/44/-110',
+        'STATION_ID': '06191500',
+    }
+
+
+@pytest.fixture
+def handler(mock_config):
+    return USGSStreamflowHandler(mock_config, logging.getLogger('test_usgs'))
+
+
+def _rdb(rows: str) -> str:
+    """Build a minimal NWIS RDB document around tab-separated data rows."""
+    header = "agency_cd\tsite_no\tdatetime\ttz_cd\t147720_00060\t147720_00060_cd"
+    fmt = "5s\t15s\t20d\t6s\t14n\t10s"
+    return "\n".join([
+        "# Data provided for site 06191500",
+        "#  TS_ID    Parameter  Description",
+        header,
+        fmt,
+        rows,
+    ]) + "\n"
+
+
+class TestTimezoneHandling:
+    def test_rdb_local_time_converted_to_utc(self, handler, tmp_path):
+        """MDT rows shift +6 h, MST rows +7 h — DST handled per row."""
+        raw = tmp_path / "usgs_06191500_raw.rdb"
+        raw.write_text(_rdb(
+            "USGS\t06191500\t2023-06-01 12:00\tMDT\t3530\tA\n"
+            "USGS\t06191500\t2023-06-01 13:00\tMDT\t3540\tA\n"
+            "USGS\t06191500\t2023-01-15 12:00\tMST\t900\tA"
+        ))
+
+        out = handler.process(raw)
+        df = pd.read_csv(out, index_col='datetime', parse_dates=True)
+
+        # 12:00 MDT == 18:00 UTC; 12:00 MST == 19:00 UTC. The observed values
+        # must land in the UTC-shifted hourly bins (resampling pads the index,
+        # so assert on values, not index membership).
+        factor = 0.028316846592
+        assert df.loc[pd.Timestamp('2023-06-01 18:00'), 'discharge_cms'] == pytest.approx(3530 * factor)
+        assert df.loc[pd.Timestamp('2023-06-01 19:00'), 'discharge_cms'] == pytest.approx(3540 * factor)
+        assert df.loc[pd.Timestamp('2023-01-15 19:00'), 'discharge_cms'] == pytest.approx(900 * factor)
+
+    def test_unknown_tz_code_warns_and_passes_through(self, mock_config, tmp_path, caplog):
+        logger = logging.getLogger('test_usgs_unknown_tz')
+        h = USGSStreamflowHandler(mock_config, logger)
+        raw = tmp_path / "usgs_06191500_raw.rdb"
+        raw.write_text(_rdb("USGS\t06191500\t2023-06-01 12:00\tXYZ\t3530\tA"))
+
+        with caplog.at_level(logging.WARNING, logger='test_usgs_unknown_tz'):
+            out = h.process(raw)
+
+        assert any('XYZ' in r.message for r in caplog.records)
+        df = pd.read_csv(out, index_col='datetime', parse_dates=True)
+        # Treated as UTC: timestamp unchanged
+        assert pd.Timestamp('2023-06-01 12:00') in df.index
+
+    def test_csv_without_tz_column_unchanged(self, handler, tmp_path):
+        """Manual CSV exports without tz info keep their timestamps as-is."""
+        raw = tmp_path / "usgs_06191500_raw.csv"
+        pd.DataFrame({
+            'datetime': ['2023-06-01 12:00', '2023-06-01 13:00'],
+            'discharge': [100.0, 110.0],
+        }).to_csv(raw, index=False)
+
+        out = handler.process(raw)
+        df = pd.read_csv(out, index_col='datetime', parse_dates=True)
+        assert pd.Timestamp('2023-06-01 12:00') in df.index
+
+    def test_exact_unit_conversion(self, handler, tmp_path):
+        raw = tmp_path / "usgs_06191500_raw.rdb"
+        raw.write_text(_rdb("USGS\t06191500\t2023-06-01 12:00\tMDT\t1000\tA"))
+
+        out = handler.process(raw)
+        df = pd.read_csv(out, index_col='datetime', parse_dates=True)
+        assert df['discharge_cms'].iloc[0] == pytest.approx(28.316846592, rel=1e-12)
+
+
+class TestDownloadWindow:
+    def test_end_dt_uses_experiment_end_not_now(self, handler, tmp_path):
+        captured = {}
+
+        def fake_get(url, timeout):
+            captured['url'] = url
+            resp = MagicMock()
+            resp.text = _rdb("USGS\t06191500\t2023-06-01 12:00\tMDT\t3530\tA")
+            resp.raise_for_status = MagicMock()
+            return resp
+
+        with patch('symfluence.data.observation.handlers.usgs.requests.get', side_effect=fake_get):
+            handler._download_data('06191500', tmp_path / 'out.rdb')
+
+        assert 'startDT=2023-06-01' in captured['url']
+        assert 'endDT=2023-06-15' in captured['url']


### PR DESCRIPTION
## Summary

A live parity experiment (native handler vs the CSFS `usgs` connector, both reading the same NWIS API) surfaced two bugs in `USGSStreamflowHandler`:

1. **Timezone**: NWIS RDB carries gauge-local clock time plus a per-row `tz_cd` code. The handler parsed the naive local timestamp and ignored `tz_cd`, so processed streamflow was offset from UTC forcing by up to 10 hours (e.g. +6 h at MDT gauges) with discontinuities at DST transitions. Fixed by mapping each row's `tz_cd` to its fixed UTC offset (per-row codes make DST exact: MDT rows −6, MST rows −7) and shifting to tz-naive UTC. tz-aware ISO inputs (manual CSV exports) are likewise normalized.
2. **Download window**: `_download_data` hardcoded `endDT=datetime.now()`, fetching years beyond `EXPERIMENT_TIME_END` (4.2 MB instead of 56 KB for a 2-week window). Now bounded to the experiment end, falling back to now() only when no end is configured.

## Validation

Live re-run of the parity experiment (Yellowstone at Corwin Springs, 2023-06-01..15, hourly):
- pre-fix: best alignment at **+6 h lag**, every value biased
- post-fix: **325/331 overlapping hours bit-identical** to the independent CSFS pipeline, 5 hours within one float64 ulp (≤5e-16 rel), and only the final window-boundary bin differs (window-inclusion semantics at the very last timestamp).

New unit tests cover MDT/MST conversion, DST handling across rows, unknown-code warning, CSV passthrough, the exact cfs→m³/s factor, and the bounded `endDT`. `tests/unit/data/observation`: 57 passed; ruff + mypy clean.

## Behavior change

Processed streamflow timestamps move from gauge-local to UTC, correcting observation/forcing alignment in calibration. Domains calibrated against sub-daily USGS observations will see shifted (corrected) alignment.

## Possible follow-up

WSC and SMHI handlers parse datetimes without explicit timezone normalization; their upstream conventions (GeoMet, SMHI API) should get the same audit — not changed here since only USGS was experimentally verified.

> Repo and code assistance from [Claude](https://claude.ai) (Anthropic).