### PR TITLE
Fix six native data-handler bugs found by parity validation

### DIFF
--- a/src/symfluence/data/acquisition/handlers/em_earth.py
+++ b/src/symfluence/data/acquisition/handlers/em_earth.py
@@ -15,9 +15,16 @@ import pandas as pd
 import s3fs
 import xarray as xr
 
+from symfluence.core.exceptions import DataAcquisitionError
 from symfluence.core.registries import R
 
 from ..base import BaseAcquisitionHandler
+
+# EM-Earth published record (Tang et al. 2022): daily data 1950-01 .. 2019-12.
+_RECORD_START = pd.Timestamp('1950-01-01')
+_RECORD_END = pd.Timestamp('2019-12-31')
+
+_FRDR_DATASET_URL = "https://www.frdr-dfdr.ca/repo/dataset/8d30ab02-f2bd-4d05-ae43-11f4a387e5ad"
 
 
 @R.acquisition_handlers.add('EM-EARTH')
@@ -30,43 +37,77 @@ class EMEarthAcquirer(BaseAcquisitionHandler):
     globally from 1950-2019, available in deterministic and probabilistic
     variants. Data includes precipitation, temperature (mean, range), and
     dewpoint temperature.
+
+    S3 access: the ``emearth`` bucket allows anonymous LIST but currently
+    denies anonymous GET. Set ``EM_EARTH_S3_ANON: false`` to use the standard
+    AWS credential chain (environment variables, ``~/.aws/credentials``,
+    instance profile), or stage the data from FRDR instead:
+    https://www.frdr-dfdr.ca/repo/dataset/8d30ab02-f2bd-4d05-ae43-11f4a387e5ad
+
+    Bucket layout (verified live): monthly files sit directly under
+    ``emearth/nc/<product>/<var>/`` — there are no region subfolders.
     """
 
     def download(self, output_dir: Path) -> Path:
         self.logger.info("Downloading EM-Earth data from AWS S3")
-        fs = s3fs.S3FileSystem(anon=True)
+        anon = bool(self._get_config_value(lambda: None, default=True, dict_key='EM_EARTH_S3_ANON'))
+        fs = s3fs.S3FileSystem(anon=anon)
         emearth_type = str(self._get_config_value(lambda: self.config.forcing.em_earth.data_type, default="deterministic", dict_key='EM_EARTH_DATA_TYPE')).lower()
         base_folder = "nc/deterministic_raw_daily" if emearth_type == "deterministic" else "nc/probabilistic_daily"
         precip_var = self._get_config_value(lambda: self.config.forcing.em_earth.prcp_var, default="prcp", dict_key='EM_PRCP')
-        vars = [precip_var, "tmean", "trange", "tdew"]
-        region = str(self._get_config_value(lambda: None, default="global", dict_key='EM_EARTH_REGION_FOLDER'))
-        use_region = region.lower() not in ("global", "")
-        start_year, end_year = max(self.start_date.year, 1950), min(self.end_date.year, 2019)
+        variables = [precip_var, "tmean", "trange", "tdew"]
+
+        if self.start_date > _RECORD_END or self.end_date < _RECORD_START:
+            raise DataAcquisitionError(
+                f"EM-Earth record covers {_RECORD_START.date()} to {_RECORD_END.date()}; the requested "
+                f"window {self.start_date.date()} to {self.end_date.date()} is entirely outside it. "
+                "Choose a window within the record or use a different forcing dataset."
+            )
+        # Only probe the months actually requested (clamped to the record).
+        months = pd.period_range(
+            max(self.start_date, _RECORD_START), min(self.end_date, _RECORD_END), freq='M'
+        )
+
         all_datasets = {}
-        for var in vars:
+        for var in variables:
             var_datasets = []
-            for year in range(start_year, end_year + 1):
-                for month in range(1, 13):
-                    ym = f"{year}{month:02d}"
-                    fname = f"EM_Earth_{emearth_type}_daily_{var}_{ym}.nc"
-                    key = f"emearth/{base_folder}/{var}/{region}/{fname}" if use_region else f"emearth/{base_folder}/{var}/{fname}"
-                    try:
-                        if fs.exists(key):
-                            with fs.open(key, "rb") as f:
-                                ds = xr.open_dataset(f, engine="h5netcdf")
-                                ds_subset = ds.sel(lat=slice(self.bbox["lat_min"], self.bbox["lat_max"]), lon=slice(self.bbox["lon_min"], self.bbox["lon_max"]))
-                                real_start, real_end = max(self.start_date, pd.Timestamp(f"{year}-{month:02d}-01")), min(self.end_date, pd.Timestamp(f"{year}-{month:02d}-01") + pd.offsets.MonthEnd(0))
-                                ds_subset = ds_subset.sel(time=slice(real_start, real_end))
-                                if len(ds_subset.time) > 0: var_datasets.append(ds_subset.load())
-                    except (OSError, KeyError, ValueError) as e:
-                        self.logger.debug(f"EM-Earth file not available for {var} {ym}: {e}")
-                        continue
-            if var_datasets: all_datasets[var] = xr.concat(var_datasets, dim="time")
-        if not all_datasets: raise ValueError("No EM-Earth data downloaded")
+            for period in months:
+                ym = f"{period.year}{period.month:02d}"
+                fname = f"EM_Earth_{emearth_type}_daily_{var}_{ym}.nc"
+                # No region path component: bucket keys are
+                # emearth/nc/<product>/<var>/<fname> (verified against live listing).
+                key = f"emearth/{base_folder}/{var}/{fname}"
+                try:
+                    if fs.exists(key):
+                        with fs.open(key, "rb") as f:
+                            ds = xr.open_dataset(f, engine="h5netcdf")
+                            ds_subset = ds.sel(lat=slice(self.bbox["lat_min"], self.bbox["lat_max"]), lon=slice(self.bbox["lon_min"], self.bbox["lon_max"]))
+                            real_start = max(self.start_date, period.start_time)
+                            real_end = min(self.end_date, period.end_time)
+                            ds_subset = ds_subset.sel(time=slice(real_start, real_end))
+                            if len(ds_subset.time) > 0:
+                                var_datasets.append(ds_subset.load())
+                except PermissionError as e:
+                    raise DataAcquisitionError(
+                        "EM-Earth S3 access denied: the 'emearth' bucket denies anonymous GET. "
+                        "Provide AWS credentials with bucket access (standard AWS credential "
+                        "chain) and set EM_EARTH_S3_ANON: false in your configuration, or "
+                        f"stage the data from FRDR: {_FRDR_DATASET_URL}"
+                    ) from e
+                except (OSError, KeyError, ValueError) as e:
+                    self.logger.debug(f"EM-Earth file not available for {var} {ym}: {e}")
+                    continue
+            if var_datasets:
+                all_datasets[var] = xr.concat(var_datasets, dim="time")
+        if not all_datasets:
+            raise DataAcquisitionError(
+                "No EM-Earth data downloaded for the requested window "
+                f"({self.start_date.date()} to {self.end_date.date()})."
+            )
         ds_final = xr.merge(list(all_datasets.values()))
         ds_final.attrs.update({"source": "EM-Earth", "bbox": str(self.bbox)})
         save_dir = output_dir / "raw_data_em_earth" if self._get_config_value(lambda: self.config.forcing.supplement, default=False, dict_key='SUPPLEMENT_FORCING') else output_dir
         save_dir.mkdir(parents=True, exist_ok=True)
-        output_file = save_dir / f"{self.domain_name}_EM-Earth_{emearth_type}_{start_year}-{end_year}.nc"
+        output_file = save_dir / f"{self.domain_name}_EM-Earth_{emearth_type}_{months[0].year}-{months[-1].year}.nc"
         ds_final.to_netcdf(output_file)
         return output_file

--- a/src/symfluence/data/acquisition/handlers/mswep.py
+++ b/src/symfluence/data/acquisition/handlers/mswep.py
@@ -63,15 +63,27 @@ class MSWEPAcquirer(BaseAcquisitionHandler):
 
     Configuration:
         MSWEP_RCLONE_REMOTE: Rclone remote name (default: GoogleDrive)
-        MSWEP_VERSION: 'V280' or 'V300' (default: V280)
+        MSWEP_VERSION: e.g. 'V280', 'V315', 'V316' (default: V316).
+            Note: GloH2O flags a low-precipitation artifact over
+            2000-2015 in V3.15/V3.16.
         MSWEP_RESOLUTION: 'daily', '3hourly', 'monthly' (default: daily)
         MSWEP_PRODUCT: 'Past', 'Past_nogauge', 'NRT' (default: Past)
         MSWEP_DATA_DIR: Path to pre-downloaded MSWEP data (skips Rclone)
+
+    Remote layout (GloH2O V3.16 docs): ``{VERSION}/{Past|Past_nogauge|NRT}/
+    {Hourly|3hourly|Daily|Monthly}/`` with filenames ``YYYYDOY.HH.nc``
+    (3-hourly) / ``YYYYDOY.nc`` (daily) / ``YYYYMM.nc`` (monthly); there
+    are NO per-year subfolders. Worked example from the docs:
+    ``MSWEP_V315/Past/Hourly/2020116.18.nc``.
     """
+
+    DEFAULT_VERSION = 'V316'
 
     GDRIVE_FOLDERS = {
         'V280': 'MSWEP_V280',
         'V300': 'MSWEP_V300',
+        'V315': 'MSWEP_V315',
+        'V316': 'MSWEP_V316',
     }
 
     def download(self, output_dir: Path) -> Path:
@@ -128,6 +140,9 @@ class MSWEPAcquirer(BaseAcquisitionHandler):
 
     def _generate_file_list(self, resolution: str, product: str) -> List[dict]:
         files = []
+        # NOTE: remote filenames are YYYYDOY-prefixed and live directly under
+        # the resolution folder — there are NO per-year subfolders (GloH2O
+        # V3.16 docs, worked example: MSWEP_V315/Past/Hourly/2020116.18.nc).
         if resolution == '3hourly':
             current = self.start_date
             while current <= self.end_date:
@@ -135,7 +150,7 @@ class MSWEPAcquirer(BaseAcquisitionHandler):
                 doy = current.timetuple().tm_yday
                 for hour in range(0, 24, 3):
                     files.append({
-                        'relative_path': f"{product}/3hourly/{year}/{doy:03d}{hour:02d}.nc",
+                        'relative_path': f"{product}/3hourly/{year}{doy:03d}.{hour:02d}.nc",
                         'local_name': f"mswep_{year}{doy:03d}{hour:02d}.nc",
                     })
                 current += pd.Timedelta(days=1)
@@ -146,7 +161,7 @@ class MSWEPAcquirer(BaseAcquisitionHandler):
                 year = current.year
                 doy = current.timetuple().tm_yday
                 files.append({
-                    'relative_path': f"{product}/Daily/{year}/{doy:03d}.nc",
+                    'relative_path': f"{product}/Daily/{year}{doy:03d}.nc",
                     'local_name': f"mswep_{year}{doy:03d}.nc",
                 })
                 current += pd.Timedelta(days=1)
@@ -207,7 +222,7 @@ class MSWEPAcquirer(BaseAcquisitionHandler):
 
     def _get_gdrive_folder(self) -> str:
         version = self._get_config_value(
-            lambda: None, default='V280', dict_key='MSWEP_VERSION')
+            lambda: None, default=self.DEFAULT_VERSION, dict_key='MSWEP_VERSION')
         return self.GDRIVE_FOLDERS.get(version, f'MSWEP_{version}')
 
     def _download_rclone(

--- a/src/symfluence/data/acquisition/handlers/nex_gddp.py
+++ b/src/symfluence/data/acquisition/handlers/nex_gddp.py
@@ -35,12 +35,12 @@ class NEXGDDPCHandler(BaseAcquisitionHandler):
     (historical, SSP1-2.6, SSP2-4.5, SSP3-7.0, SSP5-8.5), and ensemble members.
     """
 
+    # Filename suffixes published on the THREDDS server, newest first. Most
+    # files carry _v2.0, some only _v1.1, and a few are unsuffixed.
+    FILENAME_SUFFIXES = ("_v2.0", "_v1.1", "")
+
     def download(self, output_dir: Path) -> Path:
-        exp_start = self.start_date
-        exp_end = self.end_date
-        exp_start.strftime("%Y-%m-%d")
-        exp_end.strftime("%Y-%m-%d")
-        start_dt, end_dt = exp_start.date(), exp_end.date()
+        start_dt, end_dt = self.start_date.date(), self.end_date.date()
         bbox = self.bbox
         lat_min, lat_max = sorted([bbox["lat_min"], bbox["lat_max"]])
         lon_min, lon_max = sorted([bbox["lon_min"], bbox["lon_max"]])
@@ -72,6 +72,7 @@ class NEXGDDPCHandler(BaseAcquisitionHandler):
         cache_root = output_dir / "_nex_ncss_cache"
         cache_root.mkdir(parents=True, exist_ok=True)
         ensemble_datasets: list[Any] = []
+        missing_variables: list[str] = []
         for model_name in cfg_models:
             # Get the grid label for this model, default to 'gn' (native grid)
             grid_label = grid_labels.get(model_name, "gn")
@@ -86,31 +87,44 @@ class NEXGDDPCHandler(BaseAcquisitionHandler):
                     for var in variables:
                         var_cache_dir = cache_root / model_name / scenario_name / member / var
                         var_cache_dir.mkdir(parents=True, exist_ok=True)
+                        var_files_found = 0
+                        attempted_chunks = 0
                         for year in range(start_dt.year, scenario_end_dt.year + 1):
                             chunk_start = max(start_dt, dt.date(year, 1, 1))
                             chunk_end = min(scenario_end_dt, dt.date(year, 12, year_end_day))
                             if chunk_start > chunk_end: continue
-                            fname = f"{var}_day_{model_name}_{scenario_name}_{member}_{grid_label}_{year}_v2.0.nc"
-                            dataset_path = f"AMES/NEX/GDDP-CMIP6/{model_name}/{scenario_name}/{member}/{var}/{fname}"
-                            out_nc = var_cache_dir / f"{fname.replace('.nc', '')}_{chunk_start:%Y%m%d}-{chunk_end:%Y%m%d}.nc"
-                            if out_nc.exists():
-                                all_nc_files_for_ens.append(str(out_nc))
-                                continue
-                            params = {"var": var, "north": lat_max, "south": lat_min, "west": lon_min, "east": lon_max, "horizStride": 1, "time_start": f"{chunk_start.isoformat()}T12:00:00Z", "time_end": f"{chunk_end.isoformat()}T12:00:00Z", "accept": "netcdf4-classic"}
-                            try:
-                                resp = requests.get(f"{ncss_base}/{dataset_path}", params=params, stream=True, timeout=600)
-                                if resp.status_code == 200:
-                                    with open(out_nc, "wb") as f:
-                                        for chunk in resp.iter_content(chunk_size=1024*1024): f.write(chunk)
-                                    all_nc_files_for_ens.append(str(out_nc))
-                                else:
-                                    self.logger.warning(f"NCSS request failed with status {resp.status_code} for {var} {year}: {resp.text[:500]}")
-                            except Exception as e:  # noqa: BLE001 — preprocessing resilience
-                                self.logger.warning(f"NCSS failed for {var} {year}: {e}", exc_info=True)
+                            attempted_chunks += 1
+                            # Filenames on the server carry _v2.0, _v1.1, or no
+                            # suffix depending on model/variable; try each in turn
+                            # instead of hardcoding _v2.0 and silently dropping
+                            # the variable on 404.
+                            year_nc = self._fetch_year_chunk(
+                                ncss_base, var_cache_dir, var, model_name, scenario_name,
+                                member, grid_label, year, chunk_start, chunk_end,
+                                lat_min, lat_max, lon_min, lon_max)
+                            if year_nc is not None:
+                                all_nc_files_for_ens.append(str(year_nc))
+                                var_files_found += 1
+                            else:
+                                self.logger.warning(
+                                    f"NEX-GDDP-CMIP6: no file found for {var} "
+                                    f"{model_name}/{scenario_name}/{member} {year} "
+                                    f"(tried suffixes {', '.join(repr(s) for s in self.FILENAME_SUFFIXES)})")
+                        if attempted_chunks > 0 and var_files_found == 0:
+                            missing_variables.append(f"{model_name}/{scenario_name}/{member}/{var}")
                     if all_nc_files_for_ens:
                         ds_ens = xr.open_mfdataset(all_nc_files_for_ens, engine="netcdf4", combine="by_coords", parallel=False, data_vars='minimal', coords='minimal', compat='override').chunk({"time": -1})
                         ds_ens = ds_ens.expand_dims(ensemble=[len(ensemble_datasets)]).assign_coords(model=("ensemble", [model_name]), scenario=("ensemble", [scenario_name]), member=("ensemble", [member]))
                         ensemble_datasets.append(ds_ens)
+        if missing_variables:
+            # Silent partial forcing is worse than failure: a model fed a
+            # subset of its forcing variables produces garbage downstream.
+            raise RuntimeError(
+                "NEX-GDDP-CMIP6: no files could be downloaded for requested "
+                f"variable(s): {', '.join(missing_variables)}. "
+                "Cached files for the other variables were kept under "
+                f"{cache_root} for reuse on retry."
+            )
         if not ensemble_datasets:
             if cache_root.exists(): shutil.rmtree(cache_root)
             raise RuntimeError("NEX-GDDP-CMIP6: no data written.")
@@ -159,6 +173,18 @@ class NEXGDDPCHandler(BaseAcquisitionHandler):
             ds_all.encoding.pop("time", None)
         for var in ds_all.data_vars:
             ds_all[var].encoding.pop("calendar", None)
+        # NEX-GDDP-CMIP6 does not publish surface pressure; fabricate a constant
+        # airpres = p0 * exp(-z/H) because downstream models require the variable.
+        elev_cfg = self._get_config_value(lambda: None, default=None, dict_key='DOMAIN_MEAN_ELEV_M')
+        if elev_cfg is None:
+            self.logger.warning(
+                "DOMAIN_MEAN_ELEV_M is not set: the synthetic 'airpres' variable will be a "
+                "CONSTANT SEA-LEVEL pressure (101325 Pa) across the whole domain. For an "
+                "elevation-adjusted estimate, set DOMAIN_MEAN_ELEV_M (domain mean elevation "
+                "in metres) in your configuration."
+            )
+        p0, z_mean, scale_height = 101325.0, float(elev_cfg or 0.0), 8400.0
+        p_surf = p0 * np.exp(-z_mean / scale_height)
         month_starts = pd.date_range(time_vals[0].replace(day=1), time_vals[-1], freq="MS")
         for ms in month_starts:
             me = (ms + pd.offsets.MonthEnd(0))
@@ -166,8 +192,6 @@ class NEXGDDPCHandler(BaseAcquisitionHandler):
             if "time" not in ds_m.dims or ds_m.sizes["time"] == 0: continue
             if "ensemble" in ds_m.dims: ds_m = ds_m.isel(ensemble=0, drop=True)
             if "airpres" not in ds_m:
-                p0, z_mean, H = 101325.0, float(self._get_config_value(lambda: None, default=0.0, dict_key='DOMAIN_MEAN_ELEV_M')), 8400.0
-                p_surf = p0 * np.exp(-z_mean / H)
                 ds_m["airpres"] = xr.full_like(ds_m["tas"], p_surf, dtype="float32").assign_attrs(long_name="synthetic surface air pressure", units="Pa")
             month_path = output_dir / f"NEXGDDP_all_{ms.year:04d}{ms.month:02d}.nc"
             # Ensure time is written with standard calendar encoding
@@ -176,3 +200,40 @@ class NEXGDDPCHandler(BaseAcquisitionHandler):
         ds_all.close()
         if cache_root.exists(): shutil.rmtree(cache_root)
         return output_dir
+
+    def _fetch_year_chunk(
+        self, ncss_base: str, var_cache_dir: Path, var: str, model_name: str,
+        scenario_name: str, member: str, grid_label: str, year: int,
+        chunk_start: dt.date, chunk_end: dt.date,
+        lat_min: float, lat_max: float, lon_min: float, lon_max: float,
+    ) -> Path | None:
+        """Download one variable-year via NCSS, trying each filename suffix.
+
+        Returns the cached/downloaded NetCDF path, or None when every suffix
+        variant failed (404 or transport error).
+        """
+        params = {
+            "var": var, "north": lat_max, "south": lat_min,
+            "west": lon_min, "east": lon_max, "horizStride": 1,
+            "time_start": f"{chunk_start.isoformat()}T12:00:00Z",
+            "time_end": f"{chunk_end.isoformat()}T12:00:00Z",
+            "accept": "netcdf4-classic",
+        }
+        for suffix in self.FILENAME_SUFFIXES:
+            fname = f"{var}_day_{model_name}_{scenario_name}_{member}_{grid_label}_{year}{suffix}.nc"
+            dataset_path = f"AMES/NEX/GDDP-CMIP6/{model_name}/{scenario_name}/{member}/{var}/{fname}"
+            out_nc = var_cache_dir / f"{fname.replace('.nc', '')}_{chunk_start:%Y%m%d}-{chunk_end:%Y%m%d}.nc"
+            if out_nc.exists():
+                return out_nc
+            try:
+                resp = requests.get(f"{ncss_base}/{dataset_path}", params=params, stream=True, timeout=600)
+                if resp.status_code == 200:
+                    with open(out_nc, "wb") as f:
+                        for chunk in resp.iter_content(chunk_size=1024 * 1024):
+                            f.write(chunk)
+                    return out_nc
+                self.logger.debug(
+                    f"NCSS request failed with status {resp.status_code} for {fname}: {resp.text[:500]}")
+            except Exception as e:  # noqa: BLE001 — try the next suffix variant
+                self.logger.warning(f"NCSS failed for {fname}: {e}", exc_info=True)
+        return None

--- a/src/symfluence/data/acquisition/handlers/nldas.py
+++ b/src/symfluence/data/acquisition/handlers/nldas.py
@@ -41,22 +41,26 @@ from ..mixins import ChunkedDownloadMixin, RetryMixin, SpatialSubsetMixin
 # OPeNDAP base URL for NLDAS-2 at GES DISC
 _OPENDAP_BASE = "https://hydro1.gesdisc.eosdis.nasa.gov/opendap/NLDAS/NLDAS_FORA0125_H.2.0"
 
-# Core forcing variables for hydrological modelling
+# Core forcing variables for hydrological modelling.
+# NOTE: These are the NLDAS-2 v2.0 NetCDF variable names (ALMA convention).
+# The legacy GRIB-era names (TMP2m, SPFH2m, PRESsfc, ...) do NOT exist in the
+# v2.0 NetCDF files served at NLDAS_FORA0125_H.2.0 — requesting them returns
+# HTTP 400 from the OPeNDAP server.
 _DEFAULT_VARIABLES = [
-    'TMP2m',      # 2-m temperature (K)
-    'SPFH2m',     # 2-m specific humidity (kg/kg)
-    'PRESsfc',    # Surface pressure (Pa)
-    'UGRD10m',    # 10-m u-wind (m/s)
-    'VGRD10m',    # 10-m v-wind (m/s)
-    'DLWRFsfc',   # Downward longwave radiation (W/m2)
-    'DSWRFsfc',   # Downward shortwave radiation (W/m2)
-    'APCPsfc',    # Precipitation hourly total (kg/m2)
+    'Tair',       # 2-m air temperature (K)
+    'Qair',       # 2-m specific humidity (kg/kg)
+    'PSurf',      # Surface pressure (Pa)
+    'Wind_E',     # 10-m eastward wind (m/s)
+    'Wind_N',     # 10-m northward wind (m/s)
+    'LWdown',     # Downward longwave radiation (W/m2)
+    'SWdown',     # Downward shortwave radiation (W/m2)
+    'Rainf',      # Precipitation hourly total (kg/m2)
 ]
 
 _EXTENDED_VARIABLES = _DEFAULT_VARIABLES + [
-    'CAPE180_0mb',  # Convective available potential energy (J/kg)
-    'PEVAPsfc',     # Potential evaporation (kg/m2)
-    'CONVfract',    # Convective fraction (fraction)
+    'CAPE',         # Convective available potential energy (J/kg)
+    'PotEvap',      # Potential evaporation (kg/m2)
+    'CRainf_frac',  # Convective fraction (fraction)
 ]
 
 # NLDAS-2 grid parameters (0.125-degree CONUS grid)

--- a/src/symfluence/data/observation/handlers/smhi.py
+++ b/src/symfluence/data/observation/handlers/smhi.py
@@ -45,6 +45,17 @@ class SMHIStreamflowHandler(BaseObservationHandler):
         raw_file = raw_dir / f"smhi_{station_id}_raw.csv"
 
         if data_access == 'cloud':
+            # Idempotency guard (mirrors the WSC handler): acquire() is invoked
+            # twice in a single process_observed_data() run, and the SMHI
+            # corrected-archive endpoint returns the full ~73 MB station record
+            # on every call. Reuse the already-downloaded raw CSV unless
+            # FORCE_DOWNLOAD is set.
+            force_download = self._get_config_value(
+                lambda: self.config.data.force_download, default=False, dict_key='FORCE_DOWNLOAD'
+            )
+            if raw_file.exists() and not force_download:
+                self.logger.info(f"Using existing SMHI data: {raw_file}")
+                return raw_file
             return self._download_from_smhi(station_id, raw_file)
 
         if raw_file.exists():

--- a/src/symfluence/data/observation/handlers/wsc.py
+++ b/src/symfluence/data/observation/handlers/wsc.py
@@ -118,28 +118,52 @@ class WSCStreamflowHandler(BaseObservationHandler):
         base_url = "https://api.weather.gc.ca/collections/hydrometric-daily-mean/items"
         page_limit = 10000
 
+        # Server-side temporal filter (GeoMet OGC API syntax: datetime=START/END,
+        # inclusive). Pad the start by one day so boundary records are never lost
+        # to timezone offsets. Only fall back to the full station record when no
+        # experiment window is configured.
+        datetime_filter = None
+        if self.start_date is not None and self.end_date is not None \
+                and not pd.isna(self.start_date) and not pd.isna(self.end_date):
+            window_start = self.start_date - pd.Timedelta(days=1)
+            datetime_filter = (
+                f"{window_start.strftime('%Y-%m-%dT%H:%M:%SZ')}/"
+                f"{self.end_date.strftime('%Y-%m-%dT%H:%M:%SZ')}"
+            )
+
         try:
             all_rows = []
             offset = 0
+            number_matched = None
 
             while True:
                 params = {
                     'STATION_NUMBER': station_id,
                     'f': 'json',
                     'limit': page_limit,
-                    'offset': offset
+                    'offset': offset,
+                    # Stable ordering is REQUIRED for offset paging: without
+                    # sortby, GeoMet's backend ordering is unstable across
+                    # pages and rows are silently duplicated/dropped
+                    # (observed live: 9,243 duplicates on a 42k-record station).
+                    'sortby': 'DATE',
                 }
+                if datetime_filter:
+                    params['datetime'] = datetime_filter
 
                 response = requests.get(base_url, params=params, timeout=60)
                 response.raise_for_status()
 
                 data = response.json()
                 features = data.get('features', [])
+                if number_matched is None:
+                    number_matched = data.get('numberMatched')
 
                 if not features:
                     if offset == 0:
                         raise DataAcquisitionError(
                             f"No data found for WSC station {station_id} in GeoMet API"
+                            + (f" within window {datetime_filter}" if datetime_filter else "")
                         )
                     break
 
@@ -154,6 +178,25 @@ class WSCStreamflowHandler(BaseObservationHandler):
                     break
 
                 offset += page_limit
+
+            # Integrity guard: this is observation data feeding calibration, so
+            # a silently corrupted record set must hard-fail, never warn-and-continue.
+            if number_matched is not None and len(all_rows) != number_matched:
+                raise DataAcquisitionError(
+                    f"WSC GeoMet paging integrity check failed for station {station_id}: "
+                    f"collected {len(all_rows)} rows but the API reported "
+                    f"numberMatched={number_matched}. The server returned an "
+                    f"inconsistent page sequence; re-run the acquisition."
+                )
+
+            dates = [row.get('DATE') for row in all_rows]
+            n_duplicates = len(dates) - len(set(dates))
+            if n_duplicates > 0:
+                raise DataAcquisitionError(
+                    f"WSC GeoMet returned {n_duplicates} duplicate DATE values for "
+                    f"station {station_id}; the record set is corrupted. "
+                    f"Re-run the acquisition."
+                )
 
             df = pd.DataFrame(all_rows)
             df.to_csv(output_path, index=False)

--- a/src/symfluence/data/utils/variable_utils.py
+++ b/src/symfluence/data/utils/variable_utils.py
@@ -45,6 +45,31 @@ if TYPE_CHECKING:
     pass  # Type hints only
 
 
+# NLDAS-2 v2.0 NetCDF (ALMA convention) names as downloaded by the NLDAS
+# acquisition handler. Legacy GRIB-era spellings (TMP2m, ...) are included
+# for files acquired before the v2.0 migration. Shared by the NLDAS /
+# NLDAS2 / NLDAS-2 dataset aliases.
+_NLDAS_RENAME_MAP: Dict[str, str] = {
+    'Tair': 'air_temperature',
+    'Qair': 'specific_humidity',
+    'PSurf': 'surface_air_pressure',
+    'Wind_E': 'eastward_wind',
+    'Wind_N': 'northward_wind',
+    'LWdown': 'surface_downwelling_longwave_flux',
+    'SWdown': 'surface_downwelling_shortwave_flux',
+    'Rainf': 'precipitation_flux',
+    # Legacy GRIB spellings (pre-v2.0 NetCDF migration)
+    'TMP2m': 'air_temperature',
+    'SPFH2m': 'specific_humidity',
+    'PRESsfc': 'surface_air_pressure',
+    'UGRD10m': 'eastward_wind',
+    'VGRD10m': 'northward_wind',
+    'DLWRFsfc': 'surface_downwelling_longwave_flux',
+    'DSWRFsfc': 'surface_downwelling_shortwave_flux',
+    'APCPsfc': 'precipitation_flux',
+}
+
+
 def _get_cfif_mappings():
     """Lazy load CFIF mappings to avoid circular imports."""
     from symfluence.data.preprocessing.cfif.variables import (
@@ -184,6 +209,9 @@ class VariableStandardizer:
             'UGRD_10maboveground': 'eastward_wind',
             'VGRD_10maboveground': 'northward_wind',
         },
+        'NLDAS': _NLDAS_RENAME_MAP,
+        'NLDAS2': _NLDAS_RENAME_MAP,
+        'NLDAS-2': _NLDAS_RENAME_MAP,
         'NWM3_RETROSPECTIVE': {
             'RAINRATE': 'precipitation_flux',
             'T2D': 'air_temperature',

--- a/tests/unit/data/acquisition/test_em_earth_handler.py
+++ b/tests/unit/data/acquisition/test_em_earth_handler.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Unit tests for the EM-Earth S3 acquisition handler.
+
+Pins the four fixes from the 2026-06 parity-validation sweep:
+
+1. PermissionError (an OSError subclass) was swallowed by the generic
+   ``except (OSError, ...)``, surfacing 48 silent 403s as a misleading
+   "No EM-Earth data downloaded".
+2. ``anon=True`` was hardcoded — now configurable via EM_EARTH_S3_ANON.
+3. The handler read EM_EARTH_REGION_FOLDER and could insert a region path
+   component; the live bucket has NO region subfolders, so the component
+   is dropped entirely.
+4. All 12 months of every year were probed regardless of the requested
+   window, and post-2019 windows silently produced nothing (the record
+   ends 2019-12).
+"""
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from symfluence.core.exceptions import DataAcquisitionError
+from symfluence.data.acquisition.handlers.em_earth import EMEarthAcquirer
+
+pytestmark = [pytest.mark.unit, pytest.mark.data]
+
+
+def _make_config(tmp_path, start='2018-06-05 00:00', end='2018-06-20 00:00'):
+    return {
+        'SYMFLUENCE_DATA_DIR': str(tmp_path),
+        'SYMFLUENCE_CODE_DIR': str(tmp_path),
+        'DOMAIN_NAME': 'test_domain',
+        'EXPERIMENT_ID': 'test_exp',
+        'EXPERIMENT_TIME_START': start,
+        'EXPERIMENT_TIME_END': end,
+        'DOMAIN_DEFINITION_METHOD': 'lumped',
+        'SUB_GRID_DISCRETIZATION': 'lumped',
+        'FORCING_DATASET': 'EM-EARTH',
+        'HYDROLOGICAL_MODEL': 'SUMMA',
+        'FORCING_TIME_STEP_SIZE': 86400,
+        'BOUNDING_BOX_COORDS': '52/-116/50/-114',
+    }
+
+
+def _make_handler(tmp_path, **kwargs):
+    cfg = _make_config(tmp_path, **{k: v for k, v in kwargs.items() if k in ('start', 'end')})
+    cfg.update({k: v for k, v in kwargs.items() if k not in ('start', 'end')})
+    return EMEarthAcquirer(cfg, logging.getLogger('test_em_earth'))
+
+
+class TestPermissionError:
+    def test_permission_error_raises_actionable_message(self, tmp_path):
+        """A 403 from the bucket must surface as DataAcquisitionError, not be
+        swallowed into 'No EM-Earth data downloaded'."""
+        handler = _make_handler(tmp_path)
+        mock_fs = MagicMock()
+        mock_fs.exists.side_effect = PermissionError('Access Denied')
+        with patch(
+            'symfluence.data.acquisition.handlers.em_earth.s3fs.S3FileSystem',
+            return_value=mock_fs,
+        ):
+            with pytest.raises(DataAcquisitionError, match='frdr-dfdr.ca'):
+                handler.download(tmp_path / 'out')
+
+
+class TestAnonConfigurable:
+    def test_anon_defaults_to_true(self, tmp_path):
+        handler = _make_handler(tmp_path)
+        mock_fs = MagicMock()
+        mock_fs.exists.return_value = False
+        with patch(
+            'symfluence.data.acquisition.handlers.em_earth.s3fs.S3FileSystem',
+            return_value=mock_fs,
+        ) as mock_s3:
+            with pytest.raises(DataAcquisitionError):
+                handler.download(tmp_path / 'out')
+        mock_s3.assert_called_once_with(anon=True)
+
+    def test_anon_false_uses_credential_chain(self, tmp_path):
+        handler = _make_handler(tmp_path, EM_EARTH_S3_ANON=False)
+        mock_fs = MagicMock()
+        mock_fs.exists.return_value = False
+        with patch(
+            'symfluence.data.acquisition.handlers.em_earth.s3fs.S3FileSystem',
+            return_value=mock_fs,
+        ) as mock_s3:
+            with pytest.raises(DataAcquisitionError):
+                handler.download(tmp_path / 'out')
+        mock_s3.assert_called_once_with(anon=False)
+
+
+class TestKeyConstruction:
+    def test_keys_have_no_region_component(self, tmp_path):
+        """Bucket keys are emearth/nc/<product>/<var>/<fname> directly —
+        the live bucket has no region subfolders (verified via live LIST)."""
+        handler = _make_handler(tmp_path)
+        mock_fs = MagicMock()
+        mock_fs.exists.return_value = False
+        with patch(
+            'symfluence.data.acquisition.handlers.em_earth.s3fs.S3FileSystem',
+            return_value=mock_fs,
+        ):
+            with pytest.raises(DataAcquisitionError):
+                handler.download(tmp_path / 'out')
+
+        probed = [call.args[0] for call in mock_fs.exists.call_args_list]
+        assert (
+            'emearth/nc/deterministic_raw_daily/prcp/'
+            'EM_Earth_deterministic_daily_prcp_201806.nc'
+        ) in probed
+        for key in probed:
+            parts = key.split('/')
+            # emearth / nc / deterministic_raw_daily / <var> / <fname>
+            assert len(parts) == 5, f"unexpected key shape (region folder?): {key}"
+
+
+class TestWindowHandling:
+    def test_only_requested_months_probed(self, tmp_path):
+        """A 16-day window in one month must probe exactly one key per variable."""
+        handler = _make_handler(tmp_path)
+        mock_fs = MagicMock()
+        mock_fs.exists.return_value = False
+        with patch(
+            'symfluence.data.acquisition.handlers.em_earth.s3fs.S3FileSystem',
+            return_value=mock_fs,
+        ):
+            with pytest.raises(DataAcquisitionError):
+                handler.download(tmp_path / 'out')
+
+        probed = [call.args[0] for call in mock_fs.exists.call_args_list]
+        assert len(probed) == 4  # prcp, tmean, trange, tdew x 1 month
+        assert all(key.endswith('_201806.nc') for key in probed)
+
+    def test_window_spanning_months_probes_each_month(self, tmp_path):
+        handler = _make_handler(
+            tmp_path, start='2018-05-20 00:00', end='2018-07-05 00:00')
+        mock_fs = MagicMock()
+        mock_fs.exists.return_value = False
+        with patch(
+            'symfluence.data.acquisition.handlers.em_earth.s3fs.S3FileSystem',
+            return_value=mock_fs,
+        ):
+            with pytest.raises(DataAcquisitionError):
+                handler.download(tmp_path / 'out')
+        probed = [call.args[0] for call in mock_fs.exists.call_args_list]
+        assert len(probed) == 12  # 4 vars x 3 months (May, Jun, Jul)
+
+    def test_window_after_record_end_fails_loudly(self, tmp_path):
+        """The record ends 2019-12: a fully out-of-record window must raise a
+        clear error, not silently produce nothing."""
+        handler = _make_handler(
+            tmp_path, start='2021-01-01 00:00', end='2021-12-31 00:00')
+        mock_fs = MagicMock()
+        with patch(
+            'symfluence.data.acquisition.handlers.em_earth.s3fs.S3FileSystem',
+            return_value=mock_fs,
+        ):
+            with pytest.raises(DataAcquisitionError, match='entirely outside'):
+                handler.download(tmp_path / 'out')
+        mock_fs.exists.assert_not_called()
+
+    def test_window_before_record_start_fails_loudly(self, tmp_path):
+        handler = _make_handler(
+            tmp_path, start='1900-01-01 00:00', end='1910-12-31 00:00')
+        mock_fs = MagicMock()
+        with patch(
+            'symfluence.data.acquisition.handlers.em_earth.s3fs.S3FileSystem',
+            return_value=mock_fs,
+        ):
+            with pytest.raises(DataAcquisitionError, match='entirely outside'):
+                handler.download(tmp_path / 'out')
+        mock_fs.exists.assert_not_called()

--- a/tests/unit/data/acquisition/test_mswep_paths.py
+++ b/tests/unit/data/acquisition/test_mswep_paths.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Unit tests for MSWEP remote path construction.
+
+Pins the fix for the path bug found by the 2026-06 parity-validation sweep:
+the handler inserted a spurious ``{year}/`` subfolder and mangled the
+3-hourly filename. Per the official GloH2O V3.16 docs the layout is
+``{VERSION}/{Past|Past_nogauge|NRT}/{Hourly|3hourly|Daily|Monthly}/`` with
+filenames ``YYYYDOY.HH.nc`` (3-hourly) / ``YYYYDOY.nc`` (daily) and NO
+per-year subfolders; worked example ``MSWEP_V315/Past/Hourly/2020116.18.nc``.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from symfluence.data.acquisition.handlers.mswep import MSWEPAcquirer
+
+pytestmark = [pytest.mark.unit, pytest.mark.data]
+
+
+def _make_handler(tmp_path, start, end, **extra):
+    cfg = {
+        'SYMFLUENCE_DATA_DIR': str(tmp_path),
+        'SYMFLUENCE_CODE_DIR': str(tmp_path),
+        'DOMAIN_NAME': 'test_domain',
+        'EXPERIMENT_ID': 'test_exp',
+        'EXPERIMENT_TIME_START': start,
+        'EXPERIMENT_TIME_END': end,
+        'DOMAIN_DEFINITION_METHOD': 'lumped',
+        'SUB_GRID_DISCRETIZATION': 'lumped',
+        'FORCING_DATASET': 'MSWEP',
+        'HYDROLOGICAL_MODEL': 'SUMMA',
+        'FORCING_TIME_STEP_SIZE': 10800,
+        'BOUNDING_BOX_COORDS': '52/-116/50/-114',
+    }
+    cfg.update(extra)
+    return MSWEPAcquirer(cfg, logging.getLogger('test_mswep'))
+
+
+class TestFileListConstruction:
+    def test_3hourly_matches_documented_worked_example(self, tmp_path):
+        """2020-04-25 is DOY 116; hour 18 must yield Past/3hourly/2020116.18.nc
+        (the docs' worked example uses the Hourly folder but the same
+        YYYYDOY.HH.nc filename convention)."""
+        handler = _make_handler(tmp_path, '2020-04-25 00:00', '2020-04-25 23:00')
+        files = handler._generate_file_list('3hourly', 'Past')
+
+        paths = [f['relative_path'] for f in files]
+        assert 'Past/3hourly/2020116.18.nc' in paths
+        assert len(paths) == 8  # one day, 3-hourly
+        for p in paths:
+            assert '/2020/' not in p, f"spurious per-year subfolder in {p}"
+
+    def test_daily_no_year_subfolder(self, tmp_path):
+        handler = _make_handler(tmp_path, '2020-04-25 00:00', '2020-04-26 23:00')
+        files = handler._generate_file_list('daily', 'Past')
+
+        paths = [f['relative_path'] for f in files]
+        assert paths == ['Past/Daily/2020116.nc', 'Past/Daily/2020117.nc']
+
+    def test_monthly_layout(self, tmp_path):
+        handler = _make_handler(tmp_path, '2020-04-01 00:00', '2020-05-15 00:00')
+        files = handler._generate_file_list('monthly', 'Past')
+
+        paths = [f['relative_path'] for f in files]
+        assert paths == ['Past/Monthly/202004.nc', 'Past/Monthly/202005.nc']
+
+
+class TestVersionFolder:
+    def test_default_version_is_v316(self, tmp_path):
+        handler = _make_handler(tmp_path, '2020-04-25 00:00', '2020-04-25 23:00')
+        assert handler._get_gdrive_folder() == 'MSWEP_V316'
+
+    def test_version_config_overridable(self, tmp_path):
+        handler = _make_handler(
+            tmp_path, '2020-04-25 00:00', '2020-04-25 23:00', MSWEP_VERSION='V315')
+        assert handler._get_gdrive_folder() == 'MSWEP_V315'
+
+    def test_unknown_version_falls_back_to_prefix(self, tmp_path):
+        handler = _make_handler(
+            tmp_path, '2020-04-25 00:00', '2020-04-25 23:00', MSWEP_VERSION='V999')
+        assert handler._get_gdrive_folder() == 'MSWEP_V999'

--- a/tests/unit/data/acquisition/test_nex_gddp_acquirer.py
+++ b/tests/unit/data/acquisition/test_nex_gddp_acquirer.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Unit tests for the NEX-GDDP-CMIP6 acquisition handler hardening.
+
+Pins the fixes from the 2026-06 parity-validation sweep:
+
+1. The handler hardcoded a ``_v2.0`` filename suffix and, on 404, silently
+   dropped the variable — producing partial forcing with no error. Now it
+   falls back ``_v2.0`` -> ``_v1.1`` -> unsuffixed and raises when any
+   requested variable yields zero files.
+2. Dead code (discarded strftime results) removed.
+3. When DOMAIN_MEAN_ELEV_M is unset, the fabricated ``airpres`` is a constant
+   sea-level 101325 Pa — a prominent warning is now emitted.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from symfluence.data.acquisition.handlers.nex_gddp import NEXGDDPCHandler
+
+pytestmark = [pytest.mark.unit, pytest.mark.data]
+
+
+def _make_config(tmp_path, **extra):
+    cfg = {
+        'SYMFLUENCE_DATA_DIR': str(tmp_path),
+        'SYMFLUENCE_CODE_DIR': str(tmp_path),
+        'DOMAIN_NAME': 'test_domain',
+        'EXPERIMENT_ID': 'test_exp',
+        'EXPERIMENT_TIME_START': '2010-01-01 00:00',
+        'EXPERIMENT_TIME_END': '2010-01-31 00:00',
+        'DOMAIN_DEFINITION_METHOD': 'lumped',
+        'SUB_GRID_DISCRETIZATION': 'lumped',
+        'FORCING_DATASET': 'NEX-GDDP-CMIP6',
+        'HYDROLOGICAL_MODEL': 'SUMMA',
+        'FORCING_TIME_STEP_SIZE': 86400,
+        'BOUNDING_BOX_COORDS': '52/-116/50/-114',
+        'NEX_MODELS': ['ACCESS-CM2'],
+        'NEX_SCENARIOS': ['historical'],
+        'NEX_VARIABLES': ['tas'],
+        'NEX_ENSEMBLES': ['r1i1p1f1'],
+    }
+    cfg.update(extra)
+    return cfg
+
+
+def _make_handler(tmp_path, **extra):
+    return NEXGDDPCHandler(_make_config(tmp_path, **extra), logging.getLogger('test_nex'))
+
+
+def _mock_response(status_code, content=b''):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = 'not found' if status_code != 200 else ''
+    resp.iter_content.return_value = [content]
+    return resp
+
+
+class TestSuffixFallbackChain:
+    def test_falls_back_v20_v11_unsuffixed(self, tmp_path):
+        """404 on _v2.0 and _v1.1 must fall through to the unsuffixed name."""
+        handler = _make_handler(tmp_path)
+        cache = tmp_path / 'cache'
+        cache.mkdir()
+        responses = [_mock_response(404), _mock_response(404), _mock_response(200, b'NCDF')]
+        with patch('symfluence.data.acquisition.handlers.nex_gddp.requests.get',
+                   side_effect=responses) as mock_get:
+            import datetime as dt
+            result = handler._fetch_year_chunk(
+                'https://ncss.example/grid', cache, 'tas', 'ACCESS-CM2', 'historical',
+                'r1i1p1f1', 'gn', 2010, dt.date(2010, 1, 1), dt.date(2010, 12, 31),
+                50.0, 52.0, -116.0, -114.0)
+
+        assert result is not None
+        assert result.exists()
+        urls = [call.args[0] for call in mock_get.call_args_list]
+        assert urls[0].endswith('_2010_v2.0.nc')
+        assert urls[1].endswith('_2010_v1.1.nc')
+        assert urls[2].endswith('_2010.nc')
+
+    def test_returns_none_when_all_suffixes_fail(self, tmp_path):
+        handler = _make_handler(tmp_path)
+        cache = tmp_path / 'cache'
+        cache.mkdir()
+        with patch('symfluence.data.acquisition.handlers.nex_gddp.requests.get',
+                   return_value=_mock_response(404)) as mock_get:
+            import datetime as dt
+            result = handler._fetch_year_chunk(
+                'https://ncss.example/grid', cache, 'tas', 'ACCESS-CM2', 'historical',
+                'r1i1p1f1', 'gn', 2010, dt.date(2010, 1, 1), dt.date(2010, 12, 31),
+                50.0, 52.0, -116.0, -114.0)
+
+        assert result is None
+        assert mock_get.call_count == 3
+
+    def test_cached_file_short_circuits(self, tmp_path):
+        handler = _make_handler(tmp_path)
+        cache = tmp_path / 'cache'
+        cache.mkdir()
+        cached = cache / 'tas_day_ACCESS-CM2_historical_r1i1p1f1_gn_2010_v2.0_20100101-20101231.nc'
+        cached.write_bytes(b'NCDF')
+        with patch('symfluence.data.acquisition.handlers.nex_gddp.requests.get') as mock_get:
+            import datetime as dt
+            result = handler._fetch_year_chunk(
+                'https://ncss.example/grid', cache, 'tas', 'ACCESS-CM2', 'historical',
+                'r1i1p1f1', 'gn', 2010, dt.date(2010, 1, 1), dt.date(2010, 12, 31),
+                50.0, 52.0, -116.0, -114.0)
+        assert result == cached
+        mock_get.assert_not_called()
+
+
+class TestMissingVariableAggregation:
+    def test_download_raises_when_variable_gets_zero_files(self, tmp_path):
+        """All-404 must raise, not silently produce partial/empty forcing."""
+        handler = _make_handler(tmp_path, NEX_VARIABLES=['tas', 'pr'])
+        with patch('symfluence.data.acquisition.handlers.nex_gddp.requests.get',
+                   return_value=_mock_response(404)):
+            with pytest.raises(RuntimeError, match='tas|pr'):
+                handler.download(tmp_path / 'out')
+
+
+def _write_synthetic_year(path: Path, year: int):
+    """Write a tiny NEX-GDDP-style tas file covering January of the year."""
+    times = pd.date_range(f'{year}-01-01T12:00:00', f'{year}-01-31T12:00:00', freq='D')
+    lats = np.array([50.5, 51.0])
+    lons = np.array([-115.5, -115.0])
+    tas = 270.0 + np.random.default_rng(0).standard_normal(
+        (len(times), len(lats), len(lons))).astype('float32')
+    ds = xr.Dataset(
+        {'tas': (('time', 'lat', 'lon'), tas)},
+        coords={'time': times, 'lat': lats, 'lon': lons},
+    )
+    ds.to_netcdf(path)
+
+
+class TestSyntheticPressureWarning:
+    def _run_download(self, tmp_path, caplog, **extra):
+        handler = _make_handler(tmp_path, **extra)
+        out_dir = tmp_path / 'out'
+        out_dir.mkdir()
+
+        def fake_fetch(ncss_base, var_cache_dir, var, model_name, scenario_name,
+                       member, grid_label, year, chunk_start, chunk_end,
+                       lat_min, lat_max, lon_min, lon_max):
+            path = var_cache_dir / f'{var}_{year}.nc'
+            if not path.exists():
+                _write_synthetic_year(path, year)
+            return path
+
+        with patch.object(NEXGDDPCHandler, '_fetch_year_chunk', side_effect=fake_fetch):
+            with caplog.at_level(logging.WARNING):
+                handler.download(out_dir)
+        return out_dir
+
+    def test_warns_and_uses_sea_level_constant_when_elevation_unset(self, tmp_path, caplog):
+        out_dir = self._run_download(tmp_path, caplog)
+        warnings = '\n'.join(
+            r.getMessage() for r in caplog.records if r.levelno == logging.WARNING)
+        assert 'DOMAIN_MEAN_ELEV_M' in warnings
+        assert 'SEA-LEVEL' in warnings
+
+        monthly = sorted(out_dir.glob('NEXGDDP_all_*.nc'))
+        assert monthly, 'no monthly outputs written'
+        with xr.open_dataset(monthly[0]) as ds:
+            assert float(ds['airpres'].mean()) == pytest.approx(101325.0)
+
+    def test_no_warning_when_elevation_configured(self, tmp_path, caplog):
+        out_dir = self._run_download(tmp_path, caplog, DOMAIN_MEAN_ELEV_M=1000.0)
+        warnings = '\n'.join(
+            r.getMessage() for r in caplog.records if r.levelno == logging.WARNING)
+        assert 'SEA-LEVEL' not in warnings
+
+        monthly = sorted(out_dir.glob('NEXGDDP_all_*.nc'))
+        with xr.open_dataset(monthly[0]) as ds:
+            expected = 101325.0 * np.exp(-1000.0 / 8400.0)
+            assert float(ds['airpres'].mean()) == pytest.approx(expected, rel=1e-4)

--- a/tests/unit/data/acquisition/test_nldas_variables.py
+++ b/tests/unit/data/acquisition/test_nldas_variables.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Pin the NLDAS-2 v2.0 NetCDF variable names used by the acquisition handler.
+
+The 2026-06 parity-validation sweep found the handler requesting legacy
+GRIB-era names (TMP2m, SPFH2m, ...) that do not exist in the NLDAS-2 v2.0
+NetCDF files at GES DISC — every OPeNDAP subset request returned HTTP 400.
+The v2.0 names below were confirmed live against the dataset DDS.
+"""
+from __future__ import annotations
+
+import pytest
+
+from symfluence.data.acquisition.handlers.nldas import (
+    _DEFAULT_VARIABLES,
+    _EXTENDED_VARIABLES,
+)
+from symfluence.data.utils.variable_utils import VariableStandardizer
+
+pytestmark = [pytest.mark.unit, pytest.mark.data]
+
+_LEGACY_GRIB_NAMES = {
+    'TMP2m', 'SPFH2m', 'PRESsfc', 'UGRD10m', 'VGRD10m',
+    'DLWRFsfc', 'DSWRFsfc', 'APCPsfc', 'CAPE180_0mb', 'PEVAPsfc', 'CONVfract',
+}
+
+
+def test_default_variables_are_v20_netcdf_names():
+    assert _DEFAULT_VARIABLES == [
+        'Tair', 'Qair', 'PSurf', 'Wind_E', 'Wind_N',
+        'LWdown', 'SWdown', 'Rainf',
+    ]
+
+
+def test_extended_variables_are_v20_netcdf_names():
+    assert _EXTENDED_VARIABLES == _DEFAULT_VARIABLES + [
+        'CAPE', 'PotEvap', 'CRainf_frac',
+    ]
+
+
+def test_no_legacy_grib_names_remain():
+    assert not _LEGACY_GRIB_NAMES & set(_EXTENDED_VARIABLES)
+
+
+@pytest.mark.parametrize('alias', ['NLDAS', 'NLDAS2', 'NLDAS-2', 'nldas'])
+def test_rename_map_covers_all_default_variables(alias):
+    """Downstream variable standardization must accept the acquired names."""
+    rename_map = VariableStandardizer().get_rename_map(alias)
+    for var in _DEFAULT_VARIABLES:
+        assert var in rename_map, f"{var} missing from {alias} rename map"
+
+
+def test_rename_map_targets_standard_names():
+    rename_map = VariableStandardizer().get_rename_map('NLDAS')
+    assert rename_map['Tair'] == 'air_temperature'
+    assert rename_map['Rainf'] == 'precipitation_flux'
+    assert rename_map['SWdown'] == 'surface_downwelling_shortwave_flux'
+    assert rename_map['LWdown'] == 'surface_downwelling_longwave_flux'
+    assert rename_map['PSurf'] == 'surface_air_pressure'
+    assert rename_map['Qair'] == 'specific_humidity'
+    assert rename_map['Wind_E'] == 'eastward_wind'
+    assert rename_map['Wind_N'] == 'northward_wind'

--- a/tests/unit/data/observation/test_smhi_streamflow_handler.py
+++ b/tests/unit/data/observation/test_smhi_streamflow_handler.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Unit tests for the SMHI streamflow handler idempotency guard.
+
+acquire() is invoked twice per process_observed_data() run; without the
+skip-if-raw-exists guard the handler re-downloaded the full ~73 MB
+corrected-archive on every call.
+"""
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from symfluence.data.observation.handlers.smhi import SMHIStreamflowHandler
+
+pytestmark = [pytest.mark.unit, pytest.mark.data]
+
+
+def _make_config(tmp_path, **extra):
+    cfg = {
+        'SYMFLUENCE_DATA_DIR': str(tmp_path),
+        'SYMFLUENCE_CODE_DIR': str(tmp_path),
+        'DOMAIN_NAME': 'test_domain',
+        'EXPERIMENT_ID': 'test_exp',
+        'EXPERIMENT_TIME_START': '2015-01-01 00:00',
+        'EXPERIMENT_TIME_END': '2015-12-31 00:00',
+        'DOMAIN_DEFINITION_METHOD': 'lumped',
+        'SUB_GRID_DISCRETIZATION': 'lumped',
+        'FORCING_DATASET': 'ERA5',
+        'HYDROLOGICAL_MODEL': 'SUMMA',
+        'FORCING_TIME_STEP_SIZE': 3600,
+        'BOUNDING_BOX_COORDS': '60/14/59/15',
+        'STATION_ID': '2357',
+        'DATA_ACCESS': 'cloud',
+    }
+    cfg.update(extra)
+    return cfg
+
+
+def _raw_file(handler):
+    return handler.project_observations_dir / 'streamflow' / 'raw_data' / 'smhi_2357_raw.csv'
+
+
+def test_existing_raw_file_skips_download(tmp_path):
+    handler = SMHIStreamflowHandler(_make_config(tmp_path), logging.getLogger('test_smhi'))
+    raw = _raw_file(handler)
+    raw.parent.mkdir(parents=True, exist_ok=True)
+    raw.write_text('date,discharge_m3s,quality_code\n2015-01-01,1.0,G\n')
+
+    with patch.object(handler, '_download_from_smhi') as mock_dl:
+        result = handler.acquire()
+
+    mock_dl.assert_not_called()
+    assert result == raw
+
+
+def test_missing_raw_file_downloads(tmp_path):
+    handler = SMHIStreamflowHandler(_make_config(tmp_path), logging.getLogger('test_smhi'))
+    raw = _raw_file(handler)
+
+    with patch.object(handler, '_download_from_smhi', return_value=raw) as mock_dl:
+        result = handler.acquire()
+
+    mock_dl.assert_called_once()
+    assert result == raw
+
+
+def test_force_download_overrides_guard(tmp_path):
+    handler = SMHIStreamflowHandler(
+        _make_config(tmp_path, FORCE_DOWNLOAD=True), logging.getLogger('test_smhi'))
+    raw = _raw_file(handler)
+    raw.parent.mkdir(parents=True, exist_ok=True)
+    raw.write_text('date,discharge_m3s,quality_code\n2015-01-01,1.0,G\n')
+
+    with patch.object(handler, '_download_from_smhi', return_value=raw) as mock_dl:
+        handler.acquire()
+
+    mock_dl.assert_called_once()

--- a/tests/unit/data/observation/test_wsc_streamflow_handler.py
+++ b/tests/unit/data/observation/test_wsc_streamflow_handler.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Unit tests for the WSC streamflow handler GeoMet acquisition path.
+
+Pins the fix for the silent-data-corruption bug found by the 2026-06
+parity-validation sweep: ``_download_from_geomet`` paged the GeoMet OGC API
+with ``offset`` but no ``sortby``, and the backend ordering is unstable —
+observed live as 9,243 duplicated rows / 9,243 silently missing rows on a
+42k-record station. The fix adds ``sortby=DATE``, a server-side ``datetime``
+window filter, and a hard integrity guard (numberMatched + duplicate DATEs).
+"""
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from symfluence.core.exceptions import DataAcquisitionError
+from symfluence.data.observation.handlers.wsc import WSCStreamflowHandler
+
+pytestmark = [pytest.mark.unit, pytest.mark.data]
+
+
+@pytest.fixture
+def mock_config(tmp_path):
+    return {
+        'SYMFLUENCE_DATA_DIR': str(tmp_path),
+        'SYMFLUENCE_CODE_DIR': str(tmp_path),
+        'DOMAIN_NAME': 'test_domain',
+        'EXPERIMENT_ID': 'test_exp',
+        'EXPERIMENT_TIME_START': '2023-06-01 00:00',
+        'EXPERIMENT_TIME_END': '2023-06-15 00:00',
+        'DOMAIN_DEFINITION_METHOD': 'lumped',
+        'SUB_GRID_DISCRETIZATION': 'lumped',
+        'FORCING_DATASET': 'ERA5',
+        'HYDROLOGICAL_MODEL': 'SUMMA',
+        'FORCING_TIME_STEP_SIZE': 3600,
+        'BOUNDING_BOX_COORDS': '52/-116/50/-114',
+        'STATION_ID': '05BB001',
+    }
+
+
+@pytest.fixture
+def handler(mock_config):
+    return WSCStreamflowHandler(mock_config, logging.getLogger('test_wsc'))
+
+
+def _geomet_response(dates, number_matched=None):
+    """Build a mock GeoMet items response carrying the given DATE values."""
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = {
+        'features': [
+            {'properties': {'DATE': d, 'DISCHARGE': 1.0, 'STATION_NUMBER': '05BB001'}}
+            for d in dates
+        ],
+        'numberMatched': number_matched if number_matched is not None else len(dates),
+        'numberReturned': len(dates),
+    }
+    return resp
+
+
+class TestGeoMetRequestParams:
+    def test_sortby_and_datetime_window_sent(self, handler, tmp_path):
+        """Every page request must carry sortby=DATE and the experiment window."""
+        dates = ['2023-06-01', '2023-06-02', '2023-06-03']
+        with patch('symfluence.data.observation.handlers.wsc.requests.get') as mock_get:
+            mock_get.return_value = _geomet_response(dates)
+            handler._download_from_geomet('05BB001', tmp_path / 'out.csv')
+
+        assert mock_get.call_count == 1
+        params = mock_get.call_args.kwargs.get('params') or mock_get.call_args.args[1]
+        assert params['sortby'] == 'DATE'
+        # Window is padded by one day at the start (boundary/timezone safety)
+        assert params['datetime'] == '2023-05-31T00:00:00Z/2023-06-15T00:00:00Z'
+        assert params['STATION_NUMBER'] == '05BB001'
+
+    def test_no_datetime_filter_when_dates_unconfigured(self, handler, tmp_path):
+        """Full-record behaviour is preserved when no window is configured."""
+        handler.start_date = None
+        handler.end_date = None
+        with patch('symfluence.data.observation.handlers.wsc.requests.get') as mock_get:
+            mock_get.return_value = _geomet_response(['2023-06-01'])
+            handler._download_from_geomet('05BB001', tmp_path / 'out.csv')
+
+        params = mock_get.call_args.kwargs.get('params') or mock_get.call_args.args[1]
+        assert 'datetime' not in params
+        assert params['sortby'] == 'DATE'
+
+
+class TestIntegrityGuard:
+    def test_number_matched_mismatch_raises(self, handler, tmp_path):
+        """Row count != numberMatched must hard-fail, not warn-and-continue."""
+        dates = ['2023-06-01', '2023-06-02']
+        with patch('symfluence.data.observation.handlers.wsc.requests.get') as mock_get:
+            mock_get.return_value = _geomet_response(dates, number_matched=5)
+            with pytest.raises(DataAcquisitionError, match='numberMatched'):
+                handler._download_from_geomet('05BB001', tmp_path / 'out.csv')
+
+    def test_duplicate_dates_raise(self, handler, tmp_path):
+        """Duplicate DATE values indicate unstable paging and must hard-fail."""
+        dates = ['2023-06-01', '2023-06-02', '2023-06-02']
+        with patch('symfluence.data.observation.handlers.wsc.requests.get') as mock_get:
+            mock_get.return_value = _geomet_response(dates)
+            with pytest.raises(DataAcquisitionError, match='duplicate DATE'):
+                handler._download_from_geomet('05BB001', tmp_path / 'out.csv')
+
+    def test_clean_response_writes_csv(self, handler, tmp_path):
+        dates = ['2023-06-01', '2023-06-02', '2023-06-03']
+        out = tmp_path / 'out.csv'
+        with patch('symfluence.data.observation.handlers.wsc.requests.get') as mock_get:
+            mock_get.return_value = _geomet_response(dates)
+            result = handler._download_from_geomet('05BB001', out)
+
+        assert result == out
+        assert out.exists()
+        import pandas as pd
+        df = pd.read_csv(out)
+        assert len(df) == 3
+        assert df['DATE'].is_unique

--- a/tools/quality/broad_exception_allowlist.txt
+++ b/tools/quality/broad_exception_allowlist.txt
@@ -189,7 +189,7 @@ src/symfluence/data/acquisition/handlers/modis_lst.py:MODISLSTAcquirer._get_appe
 src/symfluence/data/acquisition/handlers/modis_lst.py:MODISLSTAcquirer._submit_task:except Exception as e:  # noqa: BLE001 — preprocessing resilience
 src/symfluence/data/acquisition/handlers/mswep.py:MSWEPAcquirer._rclone_copy_batch:except Exception as e:  # noqa: BLE001
 src/symfluence/data/acquisition/handlers/mswep.py:MSWEPAcquirer._verify_rclone_access:except Exception as e:  # noqa: BLE001
-src/symfluence/data/acquisition/handlers/nex_gddp.py:NEXGDDPCHandler.download:except Exception as e:  # noqa: BLE001 — preprocessing resilience
+src/symfluence/data/acquisition/handlers/nex_gddp.py:NEXGDDPCHandler._fetch_year_chunk:except Exception as e:  # noqa: BLE001 — try the next suffix variant
 src/symfluence/data/acquisition/handlers/nldas.py:NLDASAcquirer._download_day:except Exception as e:  # noqa: BLE001
 src/symfluence/data/acquisition/handlers/nldas.py:NLDASAcquirer._get_authenticated_session:except Exception:  # noqa: BLE001
 src/symfluence/data/acquisition/handlers/openet.py:OpenETAcquirer._request_timeseries:except Exception as e:  # noqa: BLE001 — preprocessing resilience


### PR DESCRIPTION
## Summary

A live parity-validation sweep (native handlers vs the community CFS/CSFS packages, same upstream endpoints) surfaced six bugs in the native data handlers. Two are severe:

1. **WSC silent data corruption** (`observation/handlers/wsc.py`): GeoMet pagination used `offset` with no `sortby`; backend ordering is unstable, observed live to return 9,243 duplicate rows with ~9,243 records silently missing (everything after 2017-02-06) on a 42k-record station, clean on retry. Now: `sortby=DATE`, a server-side `datetime` window filter from the experiment dates (full record only when no dates configured), and a hard integrity guard — row count vs `numberMatched` mismatch or duplicate dates raises `DataAcquisitionError` instead of silently feeding corrupted observations to calibration.
2. **NLDAS-2 broken by default** (`acquisition/handlers/nldas.py`): default variable lists used legacy GRIB names (`TMP2m`, …) that don't exist in v2.0 NetCDF — every hourly request returned HTTP 400 (live-confirmed both ways). Now the v2.0 CF names (`Tair`, `Qair`, `PSurf`, `Wind_E`, `Wind_N`, `LWdown`, `SWdown`, `Rainf`; extended: `CAPE`, `PotEvap`, `CRainf_frac`). Also added the missing NLDAS rename map to `variable_utils.py` (there was none — standardization would have failed even with correct downloads).

Plus:
3. **EM-Earth** (`handlers/em_earth.py`): `PermissionError` was swallowed by `except OSError` (48 silent 403s observed live) — now raises actionably with the FRDR dataset link; `anon` configurable via `EM_EARTH_S3_ANON`; dropped the nonexistent region path component (bucket has no region folders — the code also read a config key, `EM_EARTH_REGION_FOLDER`, that doesn't exist in the schema); month probing now bounded by the requested window, with a loud failure for windows outside the 1950–2019 record.
4. **NEX-GDDP** (`handlers/nex_gddp.py`): hardcoded `_v2.0` filename suffix silently dropped variables on 404 — now falls back `_v2.0`→`_v1.1`→unsuffixed and raises when any requested variable yields zero files; removed dead code; prominent warning when `airpres` is fabricated as constant sea-level pressure (`DOMAIN_MEAN_ELEV_M` unset).
5. **SMHI**: `acquire()` re-downloaded the full ~73 MB archive every call — added the same skip-if-raw-exists guard WSC uses, honoring `FORCE_DOWNLOAD`.
6. **MSWEP** (`handlers/mswep.py`): Drive paths had a spurious `{year}/` subfolder and wrong filename form vs the official GloH2O V3.16 layout (`{VERSION}/{Past|NRT}/{3hourly|Daily}/YYYYDOY[.HH].nc`); default version folder now `MSWEP_V316` (overridable via `MSWEP_VERSION`). Not live-validated (needs an rclone Drive remote); path construction unit-tested against the documented worked example.

## Validation

- **Live WSC**: station 05BB001, 2023-06 window → 16 rows, 16 unique dates, count == `numberMatched`.
- **Live NLDAS**: single-hour GES DISC subset with the new defaults → HTTP 200, all 8 variables parsed.
- **36 new unit tests** across six test files; `tests/unit/data/`: 2180 passed. The 6 failures in `test_attribute_profiles.py` pre-exist on pristine `develop` (profile/test drift: `full` has 18 datasets, test asserts 17) — unrelated, left for a separate fix.
- ruff + mypy clean on all changed files; all pre-commit hooks green.

> Repo and code assistance from [Claude](https://claude.ai) (Anthropic).