### PR TITLE
fix(nex-gddp): let the acquisition-stage synthetic airpres survive standardization

### DIFF
--- a/src/symfluence/data/preprocessing/dataset_handlers/nex_gddp_utils.py
+++ b/src/symfluence/data/preprocessing/dataset_handlers/nex_gddp_utils.py
@@ -158,15 +158,19 @@ class NEXGDDPCMIP6Handler(BaseDatasetHandler):
         # ---- Air pressure ----
         # NEX-GDDP-CMIP6 publishes {pr, tas, tasmax, tasmin, huss, hurs,
         # rlds, rsds, sfcWind} — notably NOT surface pressure. SUMMA
-        # requires airpres, so when ps is absent we synthesize a
-        # physically-grounded estimate from the International Standard
-        # Atmosphere (ISA): first back-compute an equivalent altitude
-        # from mean 2m air temperature via the 6.5 K/km tropospheric
-        # lapse rate, then apply the ISA pressure-altitude relation.
-        # This is climatological and does NOT capture synoptic pressure
-        # variability, but it is physically consistent and avoids the
-        # older "fill with 101325 Pa everywhere" default that was
-        # physically unrealistic for high-elevation basins.
+        # requires a pressure field, so precedence is:
+        #   1. a real 'ps' or the acquisition-stage synthetic 'airpres'
+        #      (elevation-adjusted via DOMAIN_MEAN_ELEV_M) — both arrive
+        #      here renamed to 'surface_air_pressure' and pass through;
+        #   2. otherwise synthesize a physically-grounded estimate from
+        #      the International Standard Atmosphere (ISA): back-compute
+        #      an equivalent altitude from mean 2m air temperature via
+        #      the 6.5 K/km tropospheric lapse rate, then apply the ISA
+        #      pressure-altitude relation.
+        # Both synthetic routes are climatological and do NOT capture
+        # synoptic pressure variability, but they are physically
+        # consistent and avoid the older "fill with 101325 Pa
+        # everywhere" default that was unrealistic for elevated basins.
         if "surface_air_pressure" in ds.data_vars:
             ap = ds["surface_air_pressure"].astype("float32")
             ap = xr.where(np.isfinite(ap), ap, np.nan)

--- a/src/symfluence/data/utils/variable_utils.py
+++ b/src/symfluence/data/utils/variable_utils.py
@@ -205,12 +205,17 @@ class VariableStandardizer:
             'rsds': 'surface_downwelling_shortwave_flux',
             'sfcWind': 'wind_speed',
             'ps': 'surface_air_pressure',
+            # NEX-GDDP publishes no surface pressure; the acquisition handler
+            # synthesizes 'airpres' (elevation-adjusted via DOMAIN_MEAN_ELEV_M)
+            # and it must survive standardization rather than be re-derived.
+            'airpres': 'surface_air_pressure',
         },
         'NEX-GDDP-CMIP6': {
             'pr': 'precipitation_flux',
             'tas': 'air_temperature',
             'huss': 'specific_humidity',
             'ps': 'surface_air_pressure',
+            'airpres': 'surface_air_pressure',
             'rlds': 'surface_downwelling_longwave_flux',
             'rsds': 'surface_downwelling_shortwave_flux',
             'sfcWind': 'wind_speed',
@@ -641,7 +646,8 @@ class VariableHandler:
             'huss': {'standard_name': 'specific_humidity', 'units': '1'},
             'rlds': {'standard_name': 'surface_downwelling_longwave_flux', 'units': 'W/m^2'},
             'rsds': {'standard_name': 'surface_downwelling_shortwave_flux', 'units': 'W/m^2'},
-            'sfcWind': {'standard_name': 'wind_speed', 'units': 'm/s'}
+            'sfcWind': {'standard_name': 'wind_speed', 'units': 'm/s'},
+            'airpres': {'standard_name': 'surface_air_pressure', 'units': 'Pa'}
         },
         'GWF-I': {
             'PSFC': {'standard_name': 'surface_air_pressure', 'units': 'Pa'},

--- a/tests/unit/data/test_nex_gddp_pressure_synthesis.py
+++ b/tests/unit/data/test_nex_gddp_pressure_synthesis.py
@@ -101,6 +101,30 @@ def test_synthesized_pressure_tracks_altitude(caplog):
         f"colder T should yield lower P (higher altitude); got warm={p_warm:.0f}, cold={p_cold:.0f}"
 
 
+def test_acquisition_synthetic_airpres_passes_through(caplog):
+    """The acquisition handler fabricates a constant 'airpres'
+    (elevation-adjusted via DOMAIN_MEAN_ELEV_M). It must survive
+    standardization as surface_air_pressure — not be dropped and
+    re-derived by the ISA fallback, which uses a different formula
+    and ignores the user-set elevation."""
+    h = _make_handler()
+    ds = _make_ds_without_pressure(t_mean_K=285.0)
+    p_acq = 84000.0  # ~1500 m via the acquisition handler's p0*exp(-z/H)
+    ds["airpres"] = xr.full_like(ds["tas"], p_acq).assign_attrs(
+        long_name="synthetic surface air pressure", units="Pa"
+    )
+    caplog.set_level(logging.WARNING)
+    ds_out = h.process_dataset(ds)
+
+    assert "surface_air_pressure" in ds_out.data_vars
+    p = ds_out["surface_air_pressure"].values
+    assert np.allclose(p[np.isfinite(p)], p_acq), \
+        "acquisition-stage airpres must pass through unchanged, not be re-synthesized"
+    warn = "\n".join(r.getMessage() for r in caplog.records if r.levelno == logging.WARNING)
+    assert "synthesizing from mean air temperature" not in warn, \
+        "ISA fallback must not fire when a pressure field is already present"
+
+
 def test_degenerate_temperature_falls_back_to_sea_level(caplog):
     """If mean T is unphysical (e.g. all-NaN input) we can't infer
     altitude — fall back to sea-level P0 with a clear warning so the


### PR DESCRIPTION
## Problem

The NEX-GDDP acquisition handler fabricates a constant `airpres` variable (elevation-adjusted via `DOMAIN_MEAN_ELEV_M`) because NEX-GDDP-CMIP6 publishes no surface pressure. But the `NEX-GDDP`/`NEX-GDDP-CMIP6` rename maps only knew `ps`, so the synthetic was never renamed to `surface_air_pressure`, fell out of the `keep_vars` subset in `process_dataset`, and was silently re-derived by the ISA fallback — a different formula (`altitude inferred from mean air temperature`) that ignores the user-set elevation. Two synthesis sites, two answers.

This is the residual wart behind the missing-`surface_air_pressure` SUMMA preprocessing failure reported on the Paradise SNOTEL CMIP6 ensemble runs (the hard failure itself was fixed by the ISA fallback in `e31c0bf9`; this PR makes the two synthesis paths agree and honors `DOMAIN_MEAN_ELEV_M`).

## Change

- Add `'airpres': 'surface_air_pressure'` to both NEX-GDDP rename maps (and the NEX-GDDP attribute map) in `variable_utils.py`, so the acquisition-stage synthetic passes through standardization via the existing passthrough branch.
- Update the pressure-section comment in `nex_gddp_utils.py` to state the precedence: real `ps` / acquisition synthetic → ISA fallback only when no pressure field arrives at all.
- Regression test: a constant acquisition-style `airpres` must survive `process_dataset` unchanged, and the ISA fallback warning must not fire.

## Testing

- All 2117 `tests/unit/data/` tests pass; ruff + mypy clean via pre-commit.

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).