### PR TITLE
Fix four native acquisition bugs: CERRA, HRRR, Daymet, MERIT-Basins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,10 @@ dependencies = [
   "intake-xarray",
   "netCDF4>=1.6.0,<2.0.0",
   "h5netcdf>=1.1.0,<2.0.0",
+  # DAP2 client for NASA Hyrax OPeNDAP endpoints (gridded Daymet). The
+  # libnetcdf DAP route cannot authenticate via Earthdata sessions and the
+  # Hyrax deployment rejects plain DAP4 constraints, so pydap is required.
+  "pydap>=3.4.0,<4.0.0",
   # cdsapi 0.7.0 is the first release that speaks the post-September-2024
   # CDS endpoint (https://cds.climate.copernicus.eu/api, no /v2). Pinning
   # below 0.7.0 lets pip resolve an older package that silently 404s on

--- a/src/symfluence/data/acquisition/handlers/cds_datasets.py
+++ b/src/symfluence/data/acquisition/handlers/cds_datasets.py
@@ -1086,10 +1086,17 @@ class CARRAAcquirer(CDSRegionalReanalysisHandler):
         ]
 
     def _get_forecast_variables(self) -> List[str]:
+        """Return CARRA forecast variables.
+
+        NOTE: CARRA's CDS longwave name is ``thermal_surface_radiation_downwards``
+        (thermal BEFORE surface) — CERRA uses the ERA5-style
+        ``surface_thermal_radiation_downwards``. Do not "harmonize" these:
+        CDS silently drops unknown variable names.
+        """
         return [
             "total_precipitation",
             "surface_solar_radiation_downwards",
-            "thermal_surface_radiation_downwards"  # Correct name: thermal comes BEFORE surface
+            "thermal_surface_radiation_downwards"  # CARRA name (CERRA differs!)
         ]
 
     def _get_leadtime_hour(self) -> str:
@@ -1246,10 +1253,19 @@ class CERRAAcquirer(CDSRegionalReanalysisHandler):
         ]
 
     def _get_forecast_variables(self) -> List[str]:
+        """Return CERRA forecast variables.
+
+        NOTE: The CDS longwave name differs between the two regional
+        reanalyses — CARRA uses ``thermal_surface_radiation_downwards``
+        while CERRA uses the ERA5-style ``surface_thermal_radiation_downwards``.
+        CDS silently drops unknown variable names from a request, so using
+        the CARRA spelling here returned files without longwave and made
+        every native CERRA acquisition fail validation.
+        """
         return [
             "total_precipitation",
             "surface_solar_radiation_downwards",
-            "thermal_surface_radiation_downwards"  # Correct name: thermal comes BEFORE surface
+            "surface_thermal_radiation_downwards"  # CERRA name (CARRA differs!)
         ]
 
     def _get_leadtime_hour(self) -> str:

--- a/src/symfluence/data/acquisition/handlers/daymet.py
+++ b/src/symfluence/data/acquisition/handlers/daymet.py
@@ -90,9 +90,12 @@ class DaymetAcquirer(BaseAcquisitionHandler):
 
     # ORNL DAAC Daymet endpoints
     SINGLE_PIXEL_URL = "https://daymet.ornl.gov/single-pixel/api/data"
-    GRIDDED_URL = "https://data.ornldaac.earthdata.nasa.gov/protected/daymet/Daymet_Daily_V4R1/data"
 
-    # Cloud OPeNDAP endpoint (NASA Hyrax) — supports server-side subsetting
+    # Cloud OPeNDAP endpoint (NASA Hyrax) — server-side subsetting via DAP2
+    # hyperslabs. This is the only working gridded route: ORNL's legacy
+    # THREDDS endpoint is retired (404s into the same DMR++ backend), and
+    # this Hyrax deployment rejects plain DAP4 constraint expressions, so
+    # requests must use DAP2 (pydap with an Earthdata-authenticated session).
     OPENDAP_URL = (
         "https://opendap.earthdata.nasa.gov/collections/"
         "C2532426483-ORNL_CLOUD/granules/"
@@ -360,6 +363,37 @@ class DaymetAcquirer(BaseAcquisitionHandler):
             'y_max': max(y_coords) + buffer,
         }
 
+    def _opendap_dap2_url(self, var: str, year: int) -> str:
+        """Build the DAP2 request URL for one Daymet variable granule.
+
+        Appends a DAP constraint requesting only the needed fields. This
+        crucially skips Daymet's ``time_bnds``, whose (time, 2) shape the
+        pydap backend mis-parses, and keeps the request DAP2-shaped (this
+        Hyrax deployment rejects plain constraints under DAP4).
+        """
+        return (
+            self.OPENDAP_URL.format(var=var, year=year)
+            + f"?{var},time,x,y,lat,lon"
+        )
+
+    @staticmethod
+    def _lcc_subset(ds, lcc_bbox: Dict[str, float]):
+        """Subset a Daymet granule to an LCC bounding box.
+
+        Daymet's ``y`` coordinate DESCENDS (north -> south), so the y slice
+        must be ordered (y_max, y_min) — an ascending ``slice(y_min, y_max)``
+        silently returns an empty window. The x axis ascends normally.
+        """
+        y_vals = ds['y'].values
+        if y_vals.size > 1 and y_vals[0] > y_vals[-1]:
+            y_slice = slice(lcc_bbox['y_max'], lcc_bbox['y_min'])
+        else:
+            y_slice = slice(lcc_bbox['y_min'], lcc_bbox['y_max'])
+        return ds.sel(
+            x=slice(lcc_bbox['x_min'], lcc_bbox['x_max']),
+            y=y_slice,
+        )
+
     def _download_opendap_subset(
         self, var: str, year: int, var_file: Path, lcc_bbox: Dict[str, float],
         max_retries: int = 3,
@@ -367,12 +401,11 @@ class DaymetAcquirer(BaseAcquisitionHandler):
         """Download a Daymet variable via OPeNDAP server-side subsetting.
 
         Opens the Daymet granule lazily through the NASA Hyrax OPeNDAP
-        endpoint, subsets to the LCC bounding box, and writes the result.
-        Retries up to *max_retries* times with exponential backoff to handle
-        intermittent server errors.
-
-        Requires Earthdata credentials in ~/.netrc (or a configured
-        .dodsrc) so the netCDF4 C library can authenticate.
+        endpoint using the pydap engine over DAP2 with an Earthdata-
+        authenticated session (Bearer token, ~/.netrc, or env credentials),
+        subsets to the LCC bounding box, and writes the result. Retries up
+        to *max_retries* times with backoff to handle intermittent server
+        errors.
 
         Returns True on success, False on failure.
         """
@@ -380,7 +413,17 @@ class DaymetAcquirer(BaseAcquisitionHandler):
 
         import xarray as xr
 
-        url = self.OPENDAP_URL.format(var=var, year=year)
+        try:
+            import pydap  # noqa: F401
+        except ImportError:
+            self.logger.error(
+                "pydap is required for gridded Daymet downloads (DAP2 "
+                "hyperslab subsetting against NASA Hyrax). Install it with: "
+                "pip install pydap"
+            )
+            return False
+
+        url = self._opendap_dap2_url(var, year)
         last_err: Optional[Exception] = None
 
         for attempt in range(1, max_retries + 1):
@@ -390,22 +433,11 @@ class DaymetAcquirer(BaseAcquisitionHandler):
                     var, year, attempt, max_retries,
                 )
 
-                # Suppress C-library stderr noise from netCDF4 when it
-                # receives an HTML auth-denied page instead of DAP data.
-                _stderr_fd = os.dup(2)
-                _devnull = os.open(os.devnull, os.O_WRONLY)
-                os.dup2(_devnull, 2)
-                try:
-                    ds = xr.open_dataset(url, engine='netcdf4')
-                finally:
-                    os.dup2(_stderr_fd, 2)
-                    os.close(_stderr_fd)
-                    os.close(_devnull)
-
-                ds_sub = ds.sel(
-                    x=slice(lcc_bbox['x_min'], lcc_bbox['x_max']),
-                    y=slice(lcc_bbox['y_min'], lcc_bbox['y_max']),
+                ds = xr.open_dataset(
+                    url, engine='pydap', session=self._get_earthdata_session()
                 )
+
+                ds_sub = self._lcc_subset(ds, lcc_bbox)
 
                 if any(s == 0 for s in ds_sub.sizes.values()):
                     self.logger.warning(

--- a/src/symfluence/data/acquisition/handlers/hrrr.py
+++ b/src/symfluence/data/acquisition/handlers/hrrr.py
@@ -87,11 +87,15 @@ class HRRRAcquirer(BaseAcquisitionHandler, RetryMixin):
             hrrrzarr/sfc/20220101/20220101_00z_anl.zarr/2m_above_ground/TMP/2m_above_ground
 
     Spatial Subsetting Strategy:
-        - Compute bbox mask using geographic coordinates
-        - Extract minimal bounding box containing masked cells
+        - The hrrrzarr variable groups carry NO latitude/longitude coordinates,
+          only 1-D projection_x/y_coordinate arrays on the fixed HRRR Lambert
+          Conformal Conic grid. The bbox is therefore projected to LCC x/y with
+          pyproj and converted to an index window BEFORE any chunk is fetched.
         - Store x/y slice indices for reuse across hours
-        - Lazy loading: Only download masked region
+        - Lazy loading: Only download windowed region
         - Typical reduction: 99%+ for small basins
+        - HARD RULE: if no spatial window can be determined, acquisition RAISES
+          instead of silently downloading the full CONUS domain (~1.3 GB/day)
 
     Error Handling:
         - Hourly failures silently skipped (operational gaps)
@@ -162,6 +166,156 @@ class HRRRAcquirer(BaseAcquisitionHandler, RetryMixin):
         - data.acquisition.base.BaseAcquisitionHandler: Base acquisition interface
         - data.acquisition.registry.AcquisitionRegistry: Handler registration
     """
+
+    #: HRRR native Lambert Conformal Conic projection (fixed, published grid).
+    HRRR_LCC_PROJ = (
+        "+proj=lcc +lat_0=38.5 +lon_0=-97.5 +lat_1=38.5 +lat_2=38.5 "
+        "+x_0=0 +y_0=0 +R=6371229 +units=m +no_defs"
+    )
+
+    @staticmethod
+    def _spatial_dims(ds: xr.Dataset) -> tuple:
+        """Return the (y_dim, x_dim) names of the spatial dimensions.
+
+        hrrrzarr groups use ``projection_y/x_coordinate``; ``y``/``x`` is
+        accepted for grids that have already been renamed.
+
+        Raises:
+            ValueError: If no recognized spatial dimensions are present.
+        """
+        for y_dim, x_dim in (
+            ("projection_y_coordinate", "projection_x_coordinate"),
+            ("y", "x"),
+        ):
+            if y_dim in ds.dims and x_dim in ds.dims:
+                return y_dim, x_dim
+        raise ValueError(
+            f"Cannot identify HRRR spatial dimensions in {list(ds.dims)}; "
+            "expected projection_y/x_coordinate (or y/x)."
+        )
+
+    def _lcc_index_window(self, proj_y: np.ndarray, proj_x: np.ndarray, bbox: dict) -> tuple:
+        """Compute the (y_slice, x_slice) index window of *bbox* on the LCC grid.
+
+        Projects a densified bbox boundary to HRRR Lambert Conformal Conic
+        x/y with pyproj (densified because lines of constant lat/lon curve in
+        LCC space), buffers by two grid cells, and converts the LCC extent to
+        index slices on the 1-D projection coordinate arrays. This happens
+        BEFORE any data chunk is fetched, so only the windowed chunks are
+        ever downloaded.
+
+        Args:
+            proj_y: 1-D projection_y_coordinate values (meters)
+            proj_x: 1-D projection_x_coordinate values (meters)
+            bbox: dict with lat_min/lat_max/lon_min/lon_max
+
+        Returns:
+            (y_slice, x_slice) index slices
+
+        Raises:
+            ValueError: If the bbox does not intersect the HRRR grid.
+        """
+        from pyproj import Transformer
+
+        tr = Transformer.from_crs("EPSG:4326", self.HRRR_LCC_PROJ, always_xy=True)
+
+        # Densify the bbox boundary: in LCC space the x/y extremes of a
+        # geographic rectangle can fall on edge midpoints, not corners.
+        n = 25
+        lons_edge = np.linspace(bbox["lon_min"], bbox["lon_max"], n)
+        lats_edge = np.linspace(bbox["lat_min"], bbox["lat_max"], n)
+        boundary_lon = np.concatenate([
+            lons_edge, lons_edge,
+            np.full(n, bbox["lon_min"]), np.full(n, bbox["lon_max"]),
+        ])
+        boundary_lat = np.concatenate([
+            np.full(n, bbox["lat_min"]), np.full(n, bbox["lat_max"]),
+            lats_edge, lats_edge,
+        ])
+        bx, by = tr.transform(boundary_lon, boundary_lat)
+
+        # Two-cell buffer, like the grid spacing itself derived from the coords
+        dx = float(np.median(np.abs(np.diff(proj_x)))) or 3000.0
+        dy = float(np.median(np.abs(np.diff(proj_y)))) or 3000.0
+        x_min, x_max = np.min(bx) - 2 * dx, np.max(bx) + 2 * dx
+        y_min, y_max = np.min(by) - 2 * dy, np.max(by) + 2 * dy
+
+        in_x = np.where((proj_x >= x_min) & (proj_x <= x_max))[0]
+        in_y = np.where((proj_y >= y_min) & (proj_y <= y_max))[0]
+        if in_x.size > 0 and in_y.size > 0:
+            return (slice(in_y.min(), in_y.max() + 1), slice(in_x.min(), in_x.max() + 1))
+
+        # Bbox smaller than one grid cell: take the nearest cell to its
+        # center — but only if the center actually lies on the grid.
+        cx, cy = tr.transform(
+            (bbox["lon_min"] + bbox["lon_max"]) / 2,
+            (bbox["lat_min"] + bbox["lat_max"]) / 2,
+        )
+        on_grid = (
+            proj_x.min() - dx <= cx <= proj_x.max() + dx
+            and proj_y.min() - dy <= cy <= proj_y.max() + dy
+        )
+        if not on_grid:
+            raise ValueError(
+                f"Bounding box {bbox} does not intersect the HRRR CONUS grid "
+                "(HRRR covers the continental United States only)."
+            )
+        ix = int(np.abs(proj_x - cx).argmin())
+        iy = int(np.abs(proj_y - cy).argmin())
+        self.logger.info(
+            "Bbox smaller than HRRR grid cell; using nearest grid point at "
+            f"x={proj_x[ix]:.0f} m, y={proj_y[iy]:.0f} m"
+        )
+        return (slice(iy, iy + 1), slice(ix, ix + 1))
+
+    def _determine_xy_window(self, ds: xr.Dataset, bbox: dict) -> tuple:
+        """Determine the spatial index window of *bbox* for a HRRR dataset.
+
+        Preferred route: project the bbox to the fixed HRRR LCC grid using
+        the 1-D projection coordinates the hrrrzarr groups carry (the groups
+        have NO latitude/longitude, so a geographic mask is impossible
+        there). Falls back to a 2-D latitude/longitude mask when present.
+
+        Raises:
+            ValueError: If no spatial window can be determined. Acquisition
+                must NEVER silently fall back to the full CONUS domain.
+        """
+        y_dim, x_dim = self._spatial_dims(ds)
+
+        if (
+            y_dim in ds.coords and x_dim in ds.coords
+            and ds[y_dim].ndim == 1 and ds[x_dim].ndim == 1
+        ):
+            return self._lcc_index_window(ds[y_dim].values, ds[x_dim].values, bbox)
+
+        if "latitude" in ds.coords and "longitude" in ds.coords:
+            mask = (
+                (ds.latitude >= bbox["lat_min"])
+                & (ds.latitude <= bbox["lat_max"])
+                & (ds.longitude >= bbox["lon_min"])
+                & (ds.longitude <= bbox["lon_max"])
+            )
+            iy, ix = np.where(mask)
+            if len(iy) > 0:
+                return (slice(iy.min(), iy.max() + 1), slice(ix.min(), ix.max() + 1))
+            # Bbox smaller than grid resolution; find nearest grid point
+            center_lat = (bbox["lat_min"] + bbox["lat_max"]) / 2
+            center_lon = (bbox["lon_min"] + bbox["lon_max"]) / 2
+            dist = (ds.latitude - center_lat) ** 2 + (ds.longitude - center_lon) ** 2
+            min_idx = np.unravel_index(dist.values.argmin(), dist.shape)
+            self.logger.info(
+                "Bbox smaller than HRRR grid cell; using nearest grid point at "
+                f"lat={float(ds.latitude.values[min_idx]):.4f}, "
+                f"lon={float(ds.longitude.values[min_idx]):.4f}"
+            )
+            return (slice(min_idx[0], min_idx[0] + 1), slice(min_idx[1], min_idx[1] + 1))
+
+        raise ValueError(
+            "Cannot determine a spatial window for the HRRR request: the "
+            "dataset has neither 1-D projection_y/x coordinates nor "
+            "latitude/longitude coordinates. Refusing to download the full "
+            "CONUS domain (~1.3 GB/day)."
+        )
 
     def download(self, output_dir: Path) -> Path:
         """
@@ -273,6 +427,7 @@ class HRRRAcquirer(BaseAcquisitionHandler, RetryMixin):
             for h in range(24):
                 cdt = pd.Timestamp(f"{dstr} {h:02d}:00:00")
                 if cdt < self.start_date or cdt > self.end_date: continue
+                ds_h = None
                 try:
                     v_ds = []
                     for v, level in vars_map.items():
@@ -292,30 +447,22 @@ class HRRRAcquirer(BaseAcquisitionHandler, RetryMixin):
                             continue
                     if v_ds:
                         ds_h = xr.merge(v_ds, compat="override")
-                        if xy_slice is None and "latitude" in ds_h.coords:
-                            mask = (
-                                (ds_h.latitude >= bbox["lat_min"])
-                                & (ds_h.latitude <= bbox["lat_max"])
-                                & (ds_h.longitude >= bbox["lon_min"])
-                                & (ds_h.longitude <= bbox["lon_max"])
-                            )
-                            iy, ix = np.where(mask)
-                            if len(iy) > 0:
-                                xy_slice = (slice(iy.min(), iy.max()+1), slice(ix.min(), ix.max()+1))
-                            else:
-                                # Bbox smaller than grid resolution; find nearest grid point
-                                center_lat = (bbox["lat_min"] + bbox["lat_max"]) / 2
-                                center_lon = (bbox["lon_min"] + bbox["lon_max"]) / 2
-                                dist = (ds_h.latitude - center_lat)**2 + (ds_h.longitude - center_lon)**2
-                                min_idx = np.unravel_index(dist.values.argmin(), dist.shape)
-                                xy_slice = (slice(min_idx[0], min_idx[0]+1), slice(min_idx[1], min_idx[1]+1))
-                                self.logger.info(f"Bbox smaller than HRRR grid cell; using nearest grid point at "
-                                                 f"lat={float(ds_h.latitude.values[min_idx]):.4f}, "
-                                                 f"lon={float(ds_h.longitude.values[min_idx]):.4f}")
-                        all_datasets.append(ds_h.isel(y=xy_slice[0], x=xy_slice[1]) if xy_slice else ds_h)
                 except Exception as e:  # noqa: BLE001 — preprocessing resilience
                     self.logger.debug(f"Hour {dstr} {h:02d}z not available: {e}", exc_info=True)
                     continue
+                if ds_h is None:
+                    continue
+                # Window determination is OUTSIDE the per-hour resilience
+                # try/except: failing to find a window must abort the
+                # acquisition, never silently fetch the full CONUS domain.
+                if xy_slice is None:
+                    xy_slice = self._determine_xy_window(ds_h, bbox)
+                    self.logger.info(
+                        f"HRRR spatial window: y={xy_slice[0].start}:{xy_slice[0].stop}, "
+                        f"x={xy_slice[1].start}:{xy_slice[1].stop} (windowed before download)"
+                    )
+                y_dim, x_dim = self._spatial_dims(ds_h)
+                all_datasets.append(ds_h.isel({y_dim: xy_slice[0], x_dim: xy_slice[1]}))
             curr += pd.Timedelta(days=1)
         if not all_datasets: raise ValueError("No HRRR data downloaded")
         self.logger.info(f"HRRR download complete: {len(all_datasets)} hours acquired")
@@ -324,11 +471,7 @@ class HRRRAcquirer(BaseAcquisitionHandler, RetryMixin):
         if step > 1: ds_final = ds_final.isel(time=slice(0, None, step))
         if "latitude" not in ds_final.coords and "projection_x_coordinate" in ds_final.coords:
             from pyproj import Transformer
-            tr = Transformer.from_crs(
-                "+proj=lcc +lat_0=38.5 +lon_0=-97.5 +lat_1=38.5 +lat_2=38.5 +x_0=0 +y_0=0 +R=6371229 +units=m +no_defs",
-                "EPSG:4326",
-                always_xy=True,
-            )
+            tr = Transformer.from_crs(self.HRRR_LCC_PROJ, "EPSG:4326", always_xy=True)
             proj_x = ds_final.coords["projection_x_coordinate"].values
             proj_y = ds_final.coords["projection_y_coordinate"].values
             x_mesh, y_mesh = np.meshgrid(proj_x, proj_y)

--- a/src/symfluence/data/acquisition/handlers/merit_basins.py
+++ b/src/symfluence/data/acquisition/handlers/merit_basins.py
@@ -3,18 +3,26 @@
 
 """MERIT-Basins Vector Data Acquisition Handler
 
-Downloads catchment and river network vector data from the MERIT-Basins
+Resolves catchment and river network vector data from the MERIT-Basins
 dataset (Lin et al., 2019). Data is organized by Pfafstetter Level-1
 hydrological regions.
 
+The historical bulk-download host (hydrology.princeton.edu) is gone (DNS
+no longer resolves); distribution moved to a public Google Drive folder and
+Globus (see reachhydro.org). Neither channel supports scripted direct
+downloads, so this handler resolves locally staged files and, when they are
+missing, fails with an actionable message listing the current distribution
+channels and the staging directory.
+
 Workflow:
-    1. Map pour point to Pfafstetter Level-1 code(s) using hardcoded bboxes
-    2. Download catchment + river shapefiles for matching region(s)
-    3. The subsetter's spatial join handles precise selection after download
+    1. Map pour point / domain bbox to Pfafstetter Level-1 code(s) using the
+       official region table
+    2. Resolve locally staged catchment + river shapefiles for the region(s)
+    3. The subsetter's spatial join handles precise selection afterwards
 
 Source:
     reachhydro.org — Pfafstetter-organized shapefiles
-    http://hydrology.princeton.edu/data/mpan/MERIT_Basins/
+    (Google Drive folder + Globus; see _MERIT_CHANNELS below)
 
 Column Convention (matches subsetter MERIT type):
     COMID, NextDownID, up1, up2, up3
@@ -26,66 +34,82 @@ References:
 """
 from __future__ import annotations
 
-import zipfile
 from pathlib import Path
 from typing import List
-
-import requests
 
 from symfluence.core.registries import R
 
 from ..base import BaseAcquisitionHandler
-from ..mixins import RetryMixin
-from ..utils import create_robust_session
 
-# MERIT-Basins data URLs
-_MERIT_BASE_URL = "http://hydrology.princeton.edu/data/mpan/MERIT_Basins"
-_CATCHMENTS_URL = f"{_MERIT_BASE_URL}/MERIT_Catchments/pfaf_{{code}}_MERIT_Hydro_v07_Basins_v01.zip"
-_RIVERS_URL = f"{_MERIT_BASE_URL}/MERIT_Rivernet/pfaf_{{code}}_MERIT_Hydro_v07_Basins_v01_rivernet.zip"
+# Current MERIT-Basins distribution channels (the legacy bulk host
+# hydrology.princeton.edu is DNS-dead).
+_MERIT_DRIVE_URL = "https://drive.google.com/drive/folders/1uCQFmdxFbjwoT9OYJxw-pXaP8q_GYH1a"
+_MERIT_INFO_URL = "https://www.reachhydro.org/home/params/merit-basins"
 
-# Pfafstetter Level-1 continental regions with approximate bounding boxes
+# Upstream shapefile basenames inside the per-region zips
+_CAT_NAME = "pfaf_{code}_MERIT_Hydro_v07_Basins_v01"
+_RIV_NAME = "pfaf_{code}_MERIT_Hydro_v07_Basins_v01_rivernet"
+
+# Pfafstetter Level-1 continental regions with approximate bounding boxes,
+# following the OFFICIAL MERIT-Basins ReadMe mapping:
+#   1 Africa, 2 Europe, 3 North Asia/Siberia, 4 South/Central Asia,
+#   5 Oceania + South Asian islands, 6 South America, 7 North America,
+#   8 Arctic (North American Arctic), 9 Greenland.
+# (A previous version of this table shipped a different, incorrect mapping
+# — e.g. 9 was labelled Australia while the shipped pfaf_9 extent is
+# Greenland — which selected the wrong region archives.)
 # Format: {code: (lat_min, lon_min, lat_max, lon_max)}
 _PFAFSTETTER_L1_BBOXES = {
-    1: (-35.0, -82.0, 15.0, -34.0),   # South America — Amazon, eastern
-    2: (-56.0, -82.0, 15.0, -34.0),   # South America — Parana, southern
-    3: (5.0, -130.0, 62.0, -52.0),    # North America — Atlantic/Gulf
-    4: (5.0, -170.0, 72.0, -100.0),   # North America — Pacific/Arctic
-    5: (35.0, -15.0, 72.0, 60.0),     # Europe
-    6: (-36.0, -20.0, 38.0, 55.0),    # Africa
-    7: (0.0, 55.0, 78.0, 180.0),      # Asia — North/Central
-    8: (-12.0, 90.0, 55.0, 155.0),    # Asia — Southeast / Oceania
-    9: (-50.0, 110.0, -10.0, 180.0),  # Australia / Oceania
+    1: (-36.0, -20.0, 38.0, 56.0),    # Africa
+    2: (12.0, -25.0, 72.0, 70.0),     # Europe (incl. Middle East fringe)
+    3: (40.0, 55.0, 84.0, 180.0),     # North Asia / Siberia
+    4: (0.0, 55.0, 56.0, 150.0),      # South Asia (Middle East to E Asia)
+    5: (-56.0, 90.0, 21.0, 180.0),    # Oceania + South Asian islands
+    6: (-56.0, -93.0, 15.0, -32.0),   # South America
+    7: (5.0, -170.0, 62.0, -52.0),    # North America
+    8: (50.0, -180.0, 84.0, -50.0),   # Arctic Region (N. American Arctic)
+    9: (58.0, -75.0, 84.0, -10.0),    # Greenland
 }
 
 
 @R.acquisition_handlers.add('MERIT_BASINS')
-class MERITBasinsAcquirer(BaseAcquisitionHandler, RetryMixin):
-    """MERIT-Basins vector data acquisition from reachhydro.org.
+class MERITBasinsAcquirer(BaseAcquisitionHandler):
+    """MERIT-Basins vector data resolution from locally staged archives.
 
-    Downloads Pfafstetter-organized catchment and river network shapefiles.
-    Uses coarse continental bounding boxes for region selection — the
-    subsetter handles precise spatial selection after download.
+    Maps the domain to Pfafstetter-organized catchment and river network
+    shapefiles using the official region table — the subsetter handles
+    precise spatial selection afterwards. Because the current distribution
+    channels (Google Drive folder, Globus) cannot be scripted, missing
+    region files raise an actionable error instead of attempting a download
+    from the dead legacy host.
 
-    Output Files:
-        merit_cat_pfaf_{code}.shp — catchment polygons
-        merit_riv_pfaf_{code}.shp — river network lines
+    Accepted staged files (per region ``{code}``), in the geofabric
+    directory ``<domain>/attributes/geofabric/merit_basins/``:
+        pfaf_{code}_MERIT_Hydro_v07_Basins_v01.shp          — catchments
+        pfaf_{code}_MERIT_Hydro_v07_Basins_v01_rivernet.shp — rivers
+        merit_cat_pfaf_{code}.shp / merit_riv_pfaf_{code}.shp (legacy names)
     """
 
     def download(self, output_dir: Path) -> Path:
-        """Download MERIT-Basins data for the domain.
+        """Resolve MERIT-Basins data for the domain from local staging.
 
         Args:
             output_dir: Base output directory
 
         Returns:
-            Path to the directory containing downloaded geofabric files
+            Path to the directory containing the geofabric files
+
+        Raises:
+            ValueError: If the pour point matches no Pfafstetter region
+            RuntimeError: If region files are not staged locally (with the
+                current distribution channels listed)
         """
         geofabric_dir = self._attribute_dir("geofabric") / "merit_basins"
         geofabric_dir.mkdir(parents=True, exist_ok=True)
 
         lat, lon = self._get_pour_point_coords()
         self.logger.info(
-            f"Downloading MERIT-Basins data for pour point ({lat:.4f}, {lon:.4f})"
+            f"Resolving MERIT-Basins data for pour point ({lat:.4f}, {lon:.4f})"
         )
 
         # Find matching Pfafstetter region(s)
@@ -97,29 +121,65 @@ class MERITBasinsAcquirer(BaseAcquisitionHandler, RetryMixin):
             )
         self.logger.info(f"Matched Pfafstetter L1 region(s): {pfaf_codes}")
 
-        session = create_robust_session(max_retries=5, backoff_factor=2.0)
+        missing = [
+            code for code in pfaf_codes
+            if not self._region_files_present(geofabric_dir, code)
+        ]
+        if missing:
+            raise RuntimeError(self._staging_error_message(geofabric_dir, missing))
 
-        for code in pfaf_codes:
-            # Download catchments
-            cat_marker = geofabric_dir / f"merit_cat_pfaf_{code}.shp"
-            if not self._skip_if_exists(cat_marker):
-                cat_url = _CATCHMENTS_URL.format(code=code)
-                self._download_and_extract(
-                    session, cat_url, geofabric_dir,
-                    f"MERIT catchments pfaf_{code}"
-                )
-
-            # Download rivers
-            riv_marker = geofabric_dir / f"merit_riv_pfaf_{code}.shp"
-            if not self._skip_if_exists(riv_marker):
-                riv_url = _RIVERS_URL.format(code=code)
-                self._download_and_extract(
-                    session, riv_url, geofabric_dir,
-                    f"MERIT rivers pfaf_{code}"
-                )
-
-        self.logger.info(f"MERIT-Basins data downloaded to: {geofabric_dir}")
+        self.logger.info(f"MERIT-Basins data resolved in: {geofabric_dir}")
         return geofabric_dir
+
+    @staticmethod
+    def _region_files_present(geofabric_dir: Path, code: int) -> bool:
+        """Check whether both shapefiles for a region are staged locally.
+
+        Accepts the upstream archive names and the legacy ``merit_cat_``/
+        ``merit_riv_`` names, anywhere below the geofabric directory.
+        """
+        cat_patterns = (
+            f"**/{_CAT_NAME.format(code=code)}.shp",
+            f"**/merit_cat_pfaf_{code}.shp",
+        )
+        riv_patterns = (
+            f"**/{_RIV_NAME.format(code=code)}.shp",
+            f"**/merit_riv_pfaf_{code}.shp",
+        )
+        has_cat = any(next(geofabric_dir.glob(p), None) for p in cat_patterns)
+        has_riv = any(next(geofabric_dir.glob(p), None) for p in riv_patterns)
+        return has_cat and has_riv
+
+    @staticmethod
+    def _staging_error_message(geofabric_dir: Path, missing: List[int]) -> str:
+        """Build the actionable failure message for missing region files."""
+        wanted = "\n".join(
+            f"    {_CAT_NAME.format(code=c)}.zip  and  "
+            f"{_RIV_NAME.format(code=c)}.zip"
+            for c in missing
+        )
+        return (
+            f"MERIT-Basins region files for Pfafstetter region(s) {missing} "
+            "are not staged locally, and the legacy bulk-download host "
+            "(hydrology.princeton.edu) no longer exists. MERIT-Basins is now "
+            "distributed through channels that cannot be scripted, so the "
+            "files must be staged manually:\n"
+            "\n"
+            "  1. Download the region archives from one of:\n"
+            f"     - Google Drive folder: {_MERIT_DRIVE_URL}\n"
+            "       (level_01 catchments + river networks, MERIT_Hydro_v07_Basins_v01)\n"
+            "     - Globus (bulk transfer; endpoint linked from reachhydro.org)\n"
+            f"     - Documentation: {_MERIT_INFO_URL}\n"
+            "\n"
+            "  2. Required archives:\n"
+            f"{wanted}\n"
+            "\n"
+            "  3. Extract the shapefile sets (.shp/.dbf/.shx/.prj) into:\n"
+            f"     {geofabric_dir}\n"
+            "\n"
+            "Re-run the acquisition step afterwards; staged files are picked "
+            "up automatically."
+        )
 
     def _get_pour_point_coords(self) -> tuple:
         """Extract pour point lat/lon from config.
@@ -159,7 +219,7 @@ class MERITBasinsAcquirer(BaseAcquisitionHandler, RetryMixin):
         if self.bbox:
             for code, (lat_min, lon_min, lat_max, lon_max) in _PFAFSTETTER_L1_BBOXES.items():
                 if code not in matching:
-                    # Check if any corner of domain bbox falls in this region
+                    # Check if the domain bbox intersects this region
                     if (self.bbox['lat_min'] <= lat_max and
                             self.bbox['lat_max'] >= lat_min and
                             self.bbox['lon_min'] <= lon_max and
@@ -167,47 +227,3 @@ class MERITBasinsAcquirer(BaseAcquisitionHandler, RetryMixin):
                         matching.append(code)
 
         return sorted(set(matching))
-
-    def _download_and_extract(
-        self, session, url: str, output_dir: Path, description: str
-    ):
-        """Download a zip file and extract its contents.
-
-        Args:
-            session: requests.Session
-            url: URL to download
-            output_dir: Directory to extract files into
-            description: Human-readable description for logging
-        """
-        def do_download():
-            self.logger.info(f"Downloading {description}")
-            zip_path = output_dir / "temp_download.zip"
-            try:
-                with session.get(url, stream=True, timeout=600) as resp:
-                    resp.raise_for_status()
-                    with open(zip_path, 'wb') as f:
-                        for chunk in resp.iter_content(chunk_size=65536):
-                            if chunk:
-                                f.write(chunk)
-
-                self.logger.info(f"Extracting {description}")
-                with zipfile.ZipFile(zip_path, 'r') as zf:
-                    from symfluence.core.archive_extraction import safe_zip_extract
-                    safe_zip_extract(zf, output_dir)
-
-                self.logger.info(f"Downloaded and extracted {description}")
-            finally:
-                if zip_path.exists():
-                    zip_path.unlink()
-
-        self.execute_with_retry(
-            do_download,
-            max_retries=3,
-            base_delay=5,
-            backoff_factor=2.0,
-            retryable_exceptions=(
-                requests.exceptions.ConnectionError,
-                requests.exceptions.ChunkedEncodingError,
-                IOError,
-            ),
-        )

--- a/tests/unit/data/acquisition/test_cds_request_variables.py
+++ b/tests/unit/data/acquisition/test_cds_request_variables.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""Pin the CDS request variable lists for the CARRA/CERRA handlers.
+
+The two regional reanalyses name their downwelling-longwave forecast
+variable DIFFERENTLY in the CDS catalogs:
+
+* CARRA: ``thermal_surface_radiation_downwards``
+* CERRA: ``surface_thermal_radiation_downwards``  (ERA5-style)
+
+CDS silently drops unknown variable names from a request, so getting this
+split wrong does not error — it returns a file without longwave, which then
+hard-fails the handler's required-variable validation (native CERRA was
+unable to acquire at all until this was fixed; parity campaign exp12,
+2026-06). These tests pin the full request variable lists so the name split
+can never regress silently.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from symfluence.data.acquisition.handlers.cds_datasets import (
+    CARRAAcquirer,
+    CERRAAcquirer,
+)
+
+BBOX = "47.0/8.0/46.0/9.0"  # north/west/south/east
+
+
+def _make(cls):
+    config = {
+        'DOMAIN_NAME': 'test_domain',
+        'BOUNDING_BOX_COORDS': BBOX,
+        'EXPERIMENT_TIME_START': '2018-06-01 00:00',
+        'EXPERIMENT_TIME_END': '2018-06-03 00:00',
+    }
+    return cls(config, MagicMock())
+
+
+@pytest.fixture
+def carra():
+    return _make(CARRAAcquirer)
+
+
+@pytest.fixture
+def cerra():
+    return _make(CERRAAcquirer)
+
+
+class TestForecastVariableNameSplit:
+    """The CARRA/CERRA longwave name split must never regress."""
+
+    def test_carra_forecast_variables_pinned(self, carra):
+        assert carra._get_forecast_variables() == [
+            "total_precipitation",
+            "surface_solar_radiation_downwards",
+            "thermal_surface_radiation_downwards",
+        ]
+
+    def test_cerra_forecast_variables_pinned(self, cerra):
+        assert cerra._get_forecast_variables() == [
+            "total_precipitation",
+            "surface_solar_radiation_downwards",
+            "surface_thermal_radiation_downwards",
+        ]
+
+    def test_carra_uses_thermal_first_longwave_name(self, carra):
+        assert "thermal_surface_radiation_downwards" in carra._get_forecast_variables()
+        assert "surface_thermal_radiation_downwards" not in carra._get_forecast_variables()
+
+    def test_cerra_uses_era5_style_longwave_name(self, cerra):
+        assert "surface_thermal_radiation_downwards" in cerra._get_forecast_variables()
+        assert "thermal_surface_radiation_downwards" not in cerra._get_forecast_variables()
+
+
+class TestAnalysisVariablesPinned:
+    """Pin the analysis-product variable lists against the CDS catalogs."""
+
+    def test_carra_analysis_variables(self, carra):
+        assert carra._get_analysis_variables() == [
+            "2m_temperature",
+            "2m_relative_humidity",
+            "10m_u_component_of_wind",
+            "10m_v_component_of_wind",
+            "surface_pressure",
+        ]
+
+    def test_cerra_analysis_variables(self, cerra):
+        assert cerra._get_analysis_variables() == [
+            "2m_temperature",
+            "2m_relative_humidity",
+            "surface_pressure",
+            "10m_wind_speed",
+        ]
+
+
+class TestBuiltRequests:
+    """The variable lists must flow unmodified into the actual CDS requests."""
+
+    def test_cerra_forecast_request_carries_correct_longwave(self, cerra):
+        req = cerra._build_forecast_request(
+            ['2018'], ['06'], ['01'], ['00:00']
+        )
+        assert req['variable'] == [
+            "total_precipitation",
+            "surface_solar_radiation_downwards",
+            "surface_thermal_radiation_downwards",
+        ]
+        assert req['product_type'] == 'forecast'
+        assert req['leadtime_hour'] == ['1']
+        assert req['data_type'] == 'reanalysis'
+
+    def test_carra_forecast_request_carries_correct_longwave(self, carra):
+        req = carra._build_forecast_request(
+            ['2018'], ['06'], ['01'], ['00:00']
+        )
+        assert req['variable'] == [
+            "total_precipitation",
+            "surface_solar_radiation_downwards",
+            "thermal_surface_radiation_downwards",
+        ]
+        assert req['domain'] == 'west_domain'
+
+    def test_dataset_names(self, carra, cerra):
+        assert carra._get_dataset_name() == "reanalysis-carra-single-levels"
+        assert cerra._get_dataset_name() == "reanalysis-cerra-single-levels"

--- a/tests/unit/data/acquisition/test_daymet_subsetting.py
+++ b/tests/unit/data/acquisition/test_daymet_subsetting.py
@@ -53,17 +53,20 @@ def _make_acquirer(bbox=None, tmp_path=None):
     return acq
 
 
-def _make_daymet_dataset(lcc_bbox, n_time=10):
+def _make_daymet_dataset(lcc_bbox, n_time=10, descending_y=False):
     """Create a synthetic Daymet-like dataset in LCC coordinates.
 
     Builds a small grid that covers the LCC bounding box with 1 km spacing,
-    including 2D lat/lon auxiliary coordinates.
+    including 2D lat/lon auxiliary coordinates. ``descending_y=True``
+    mimics the real Daymet granules, whose y axis runs north -> south.
     """
     from pyproj import Transformer
 
     # Build x/y grid that covers the LCC bbox
     x = np.arange(lcc_bbox['x_min'] - 2000, lcc_bbox['x_max'] + 2000, 1000.0)
     y = np.arange(lcc_bbox['y_min'] - 2000, lcc_bbox['y_max'] + 2000, 1000.0)
+    if descending_y:
+        y = y[::-1]
     time = np.arange(n_time)
 
     rng = np.random.default_rng(42)
@@ -139,6 +142,116 @@ class TestBboxToLcc:
         lcc1 = acq1._bbox_to_lcc()
         lcc2 = acq2._bbox_to_lcc()
         assert lcc1['x_min'] != lcc2['x_min']
+
+
+# ---------------------------------------------------------------------------
+# Tests: descending-y window math (the exp16 slice bug)
+# ---------------------------------------------------------------------------
+
+class TestDescendingYSubset:
+    """Daymet's y axis DESCENDS (north -> south); the window math must
+    order the slice accordingly. An ascending slice(y_min, y_max) on a
+    descending axis silently returns an EMPTY window — that bug killed the
+    whole native gridded route (parity campaign exp16, 2026-06)."""
+
+    def test_descending_y_returns_nonempty_window(self):
+        acq = _make_acquirer()
+        lcc_bbox = acq._bbox_to_lcc()
+        ds = _make_daymet_dataset(lcc_bbox, n_time=3, descending_y=True)
+
+        sub = acq._lcc_subset(ds, lcc_bbox)
+        assert sub.sizes['x'] > 0
+        assert sub.sizes['y'] > 0
+
+    def test_descending_y_window_covers_bbox(self):
+        acq = _make_acquirer()
+        lcc_bbox = acq._bbox_to_lcc()
+        ds = _make_daymet_dataset(lcc_bbox, n_time=3, descending_y=True)
+
+        sub = acq._lcc_subset(ds, lcc_bbox)
+        y_vals = sub['y'].values
+        x_vals = sub['x'].values
+        # y stays descending after subsetting
+        assert y_vals[0] > y_vals[-1]
+        # the window spans the requested LCC extent (within one cell)
+        assert y_vals.min() <= lcc_bbox['y_min'] + 1000
+        assert y_vals.max() >= lcc_bbox['y_max'] - 1000
+        assert x_vals.min() <= lcc_bbox['x_min'] + 1000
+        assert x_vals.max() >= lcc_bbox['x_max'] - 1000
+
+    def test_ascending_y_still_works(self):
+        acq = _make_acquirer()
+        lcc_bbox = acq._bbox_to_lcc()
+        ds = _make_daymet_dataset(lcc_bbox, n_time=3, descending_y=False)
+
+        sub = acq._lcc_subset(ds, lcc_bbox)
+        assert sub.sizes['x'] > 0
+        assert sub.sizes['y'] > 0
+
+    def test_descending_and_ascending_select_same_cells(self):
+        acq = _make_acquirer()
+        lcc_bbox = acq._bbox_to_lcc()
+        ds_asc = _make_daymet_dataset(lcc_bbox, n_time=3, descending_y=False)
+        ds_desc = ds_asc.isel(y=slice(None, None, -1))
+
+        sub_asc = acq._lcc_subset(ds_asc, lcc_bbox)
+        sub_desc = acq._lcc_subset(ds_desc, lcc_bbox)
+        assert set(sub_asc['y'].values) == set(sub_desc['y'].values)
+        np.testing.assert_array_equal(
+            sub_asc['tmax'].values,
+            sub_desc['tmax'].isel(y=slice(None, None, -1)).values,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: DAP2 URL construction
+# ---------------------------------------------------------------------------
+
+class TestOpendapUrl:
+    """The gridded route must target the NASA Hyrax cloud OPeNDAP endpoint
+    with a DAP2 constraint (legacy ORNL THREDDS is retired and 404s; this
+    Hyrax deployment rejects plain DAP4 constraints)."""
+
+    def test_url_targets_earthdata_hyrax(self):
+        acq = _make_acquirer()
+        url = acq._opendap_dap2_url('tmax', 2018)
+        assert url.startswith(
+            "https://opendap.earthdata.nasa.gov/collections/"
+            "C2532426483-ORNL_CLOUD/granules/"
+            "Daymet_Daily_V4R1.daymet_v4_daily_na_tmax_2018.nc"
+        )
+
+    def test_url_carries_dap2_constraint(self):
+        acq = _make_acquirer()
+        url = acq._opendap_dap2_url('prcp', 2020)
+        # Constraint requests only the needed fields — crucially skipping
+        # time_bnds, which the pydap backend mis-parses.
+        assert url.endswith("?prcp,time,x,y,lat,lon")
+
+    def test_no_legacy_thredds_endpoint(self):
+        """The retired ORNL THREDDS host must not appear anywhere."""
+        import inspect
+
+        import symfluence.data.acquisition.handlers.daymet as daymet_mod
+        src = inspect.getsource(daymet_mod)
+        assert 'thredds.daac.ornl.gov' not in src
+        assert 'data.ornldaac.earthdata.nasa.gov/protected' not in src
+
+    def test_opendap_open_uses_pydap_engine(self, tmp_path):
+        """The granule must be opened DAP2-style via pydap with an
+        authenticated session, not via the libnetcdf DAP client."""
+        acq = _make_acquirer(tmp_path=tmp_path)
+        lcc_bbox = acq._bbox_to_lcc()
+        ds_full = _make_daymet_dataset(lcc_bbox, n_time=5, descending_y=True)
+        var_file = tmp_path / 'daymet_tmax_2020.nc'
+
+        with patch('xarray.open_dataset', return_value=ds_full) as mock_open:
+            result = acq._download_opendap_subset('tmax', 2020, var_file, lcc_bbox)
+
+        assert result is True
+        _args, kwargs = mock_open.call_args
+        assert kwargs.get('engine') == 'pydap'
+        assert 'session' in kwargs
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/data/acquisition/test_hrrr_windowing.py
+++ b/tests/unit/data/acquisition/test_hrrr_windowing.py
@@ -1,0 +1,294 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""HRRR spatial windowing tests.
+
+The hrrrzarr variable groups carry NO latitude/longitude coordinates — only
+1-D ``projection_y/x_coordinate`` arrays on the fixed HRRR Lambert Conformal
+Conic grid. The old handler masked on a latitude coordinate that never
+exists there, so the bbox windowing silently no-opped and every acquisition
+downloaded the full CONUS grid (~1.3 GB/day; parity campaign exp14,
+2026-06).
+
+These tests run the handler against a synthetic zarr store shaped like
+hrrrzarr (no latitude coordinate, LCC projection coords, chunked data) and
+assert that:
+
+a) the index window is computed from a pyproj LCC transform of the bbox and
+   applied BEFORE any data chunk is fetched (a store spy counts which chunk
+   keys are actually read);
+b) when no spatial window can be determined, the handler RAISES instead of
+   silently fetching the full domain.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+import zarr
+from pyproj import Transformer
+
+from symfluence.data.acquisition.handlers.hrrr import HRRRAcquirer
+
+# Colorado Front Range box (the exp14 case)
+BBOX = {
+    'lat_min': 39.5,
+    'lat_max': 40.0,
+    'lon_min': -105.5,
+    'lon_max': -105.0,
+}
+
+GRID_N = 40          # 40x40 synthetic grid
+GRID_SPACING = 3000  # meters, like HRRR
+CHUNK = 10           # 10x10 chunks -> 16 chunks total
+
+
+class SpyStore(zarr.storage.LocalStore):
+    """Local zarr store that records every key fetched via ``get``."""
+
+    def __init__(self, root, read_log):
+        super().__init__(root, read_only=True)
+        # object.__setattr__: zarr Store dataclasses can freeze attributes
+        object.__setattr__(self, 'read_log', read_log)
+
+    async def get(self, key, prototype, byte_range=None):
+        self.read_log.append(key)
+        return await super().get(key, prototype, byte_range)
+
+
+def _data_chunk_keys(read_log, var: str):
+    """Keys of *data* chunks read for ``var`` (metadata excluded)."""
+    return {
+        k for k in read_log
+        if k.startswith(f"{var}/")
+        and not k.endswith("zarr.json")          # zarr v3 metadata
+        and not k.split("/")[-1].startswith(".")  # zarr v2 metadata
+    }
+
+
+def _make_store(tmp_path, with_proj_coords=True):
+    """Write a synthetic store mimicking the real hrrrzarr layout.
+
+    The archive splits each variable into a parent group carrying the 1-D
+    projection coordinate arrays and a scalar time (path
+    ``.../{level}/{var}``) and a subgroup carrying ONLY the chunked data
+    array (path ``.../{level}/{var}/{level}``). Crucially there is no
+    latitude/longitude anywhere.
+    """
+    tr = Transformer.from_crs(
+        "EPSG:4326", HRRRAcquirer.HRRR_LCC_PROJ, always_xy=True
+    )
+    cx, cy = tr.transform(
+        (BBOX['lon_min'] + BBOX['lon_max']) / 2,
+        (BBOX['lat_min'] + BBOX['lat_max']) / 2,
+    )
+    half = GRID_N // 2
+    proj_x = cx + (np.arange(GRID_N) - half) * float(GRID_SPACING)
+    proj_y = cy + (np.arange(GRID_N) - half) * float(GRID_SPACING)
+
+    parent = tmp_path / "synthetic_parent.zarr"
+    sub = tmp_path / "synthetic_sub.zarr"
+
+    coords = {'time': pd.Timestamp('2023-06-01 00:00')}
+    if with_proj_coords:
+        coords['projection_x_coordinate'] = proj_x
+        coords['projection_y_coordinate'] = proj_y
+    xr.Dataset(coords=coords).to_zarr(parent, consolidated=False, mode='w')
+
+    data = np.arange(GRID_N * GRID_N, dtype=np.float32).reshape(GRID_N, GRID_N)
+    ds_data = xr.Dataset(
+        {'TMP': (('projection_y_coordinate', 'projection_x_coordinate'), data)},
+    )
+    ds_data.to_zarr(
+        sub,
+        encoding={'TMP': {'chunks': (CHUNK, CHUNK)}},
+        consolidated=False,
+        mode='w',
+    )
+    return parent, sub
+
+
+def _make_acquirer(bbox=BBOX):
+    config = {
+        'DOMAIN_NAME': 'test_frontrange',
+        'BOUNDING_BOX_COORDS': (
+            f"{bbox['lat_max']}/{bbox['lon_min']}/"
+            f"{bbox['lat_min']}/{bbox['lon_max']}"
+        ),
+        'EXPERIMENT_TIME_START': '2023-06-01 00:00',
+        'EXPERIMENT_TIME_END': '2023-06-01 00:00',
+        'HRRR_VARS': ['TMP'],
+    }
+    acq = HRRRAcquirer(config, MagicMock())
+    acq.bbox = dict(bbox)
+    acq.start_date = pd.Timestamp('2023-06-01 00:00')
+    acq.end_date = pd.Timestamp('2023-06-01 00:00')
+    return acq
+
+
+def _patch_s3(parent_path, sub_path, read_log):
+    """Route the handler's S3 access to the local spy-wrapped stores.
+
+    The handler opens ``.../{level}/{var}/{level}`` (data subgroup) and
+    ``.../{level}/{var}`` (coords parent group); map them onto the two
+    local synthetic stores.
+    """
+    def fake_s3map(path, s3=None, **kwargs):
+        root = sub_path if path.endswith('/TMP/2m_above_ground') else parent_path
+        return SpyStore(root, read_log)
+
+    return [
+        patch(
+            'symfluence.data.acquisition.handlers.hrrr.s3fs.S3FileSystem',
+            return_value=MagicMock(),
+        ),
+        patch(
+            'symfluence.data.acquisition.handlers.hrrr.s3fs.S3Map',
+            side_effect=fake_s3map,
+        ),
+    ]
+
+
+class TestLccWindowPreFetch:
+    """(a) The bbox window must be applied before any chunk download."""
+
+    def test_only_window_chunks_are_read(self, tmp_path):
+        parent, sub = _make_store(tmp_path)
+        read_log: list = []
+        acq = _make_acquirer()
+
+        patches = _patch_s3(parent, sub, read_log)
+        with patches[0], patches[1]:
+            out = acq.download(tmp_path / "out")
+
+        total_chunks = (GRID_N // CHUNK) ** 2
+        read = _data_chunk_keys(read_log, 'TMP')
+        assert len(read) > 0, "no data chunks read at all"
+        assert len(read) < total_chunks, (
+            f"window not applied pre-fetch: read {len(read)}/{total_chunks} "
+            f"chunks ({sorted(read)})"
+        )
+        # 0.5 deg x 0.5 deg around the grid center plus a 2-cell buffer spans
+        # well under half the 40x40 synthetic grid in each direction.
+        assert len(read) <= 9
+
+        with xr.open_dataset(out) as ds:
+            assert ds.sizes['projection_y_coordinate'] < GRID_N
+            assert ds.sizes['projection_x_coordinate'] < GRID_N
+            # The windowed grid must still cover the bbox (buffered)
+            assert ds.sizes['projection_y_coordinate'] >= 2
+            assert ds.sizes['projection_x_coordinate'] >= 2
+            assert 'latitude' in ds.coords and 'longitude' in ds.coords
+            lat = ds['latitude'].values
+            lon = ds['longitude'].values
+            assert lat.min() < BBOX['lat_min'] and lat.max() > BBOX['lat_max']
+            assert lon.min() < BBOX['lon_min'] and lon.max() > BBOX['lon_max']
+
+    def test_window_matches_direct_lcc_computation(self, tmp_path):
+        """The applied window equals the pure pyproj LCC index window."""
+        parent, _sub = _make_store(tmp_path)
+        with xr.open_zarr(parent, consolidated=False) as ds:
+            proj_y = ds['projection_y_coordinate'].values
+            proj_x = ds['projection_x_coordinate'].values
+
+        acq = _make_acquirer()
+        y_slice, x_slice = acq._lcc_index_window(proj_y, proj_x, BBOX)
+
+        # Window is interior to the synthetic grid and non-degenerate
+        assert 0 < y_slice.start < y_slice.stop < GRID_N
+        assert 0 < x_slice.start < x_slice.stop < GRID_N
+
+        # All bbox corners fall inside the windowed LCC extent
+        tr = Transformer.from_crs(
+            "EPSG:4326", HRRRAcquirer.HRRR_LCC_PROJ, always_xy=True
+        )
+        for lon, lat in [
+            (BBOX['lon_min'], BBOX['lat_min']),
+            (BBOX['lon_max'], BBOX['lat_max']),
+        ]:
+            x, y = tr.transform(lon, lat)
+            assert proj_x[x_slice][0] <= x <= proj_x[x_slice][-1]
+            assert proj_y[y_slice][0] <= y <= proj_y[y_slice][-1]
+
+    def test_tiny_bbox_falls_back_to_nearest_cell(self, tmp_path):
+        parent, _sub = _make_store(tmp_path)
+        with xr.open_zarr(parent, consolidated=False) as ds:
+            proj_y = ds['projection_y_coordinate'].values
+            proj_x = ds['projection_x_coordinate'].values
+
+        center_lat = (BBOX['lat_min'] + BBOX['lat_max']) / 2
+        center_lon = (BBOX['lon_min'] + BBOX['lon_max']) / 2
+        tiny = {
+            'lat_min': center_lat, 'lat_max': center_lat + 1e-4,
+            'lon_min': center_lon, 'lon_max': center_lon + 1e-4,
+        }
+        acq = _make_acquirer(tiny)
+        y_slice, x_slice = acq._lcc_index_window(proj_y, proj_x, tiny)
+        # Buffered window still resolves; degenerate case yields >= 1 cell
+        assert y_slice.stop - y_slice.start >= 1
+        assert x_slice.stop - x_slice.start >= 1
+
+    def test_bbox_off_grid_raises(self, tmp_path):
+        parent, _sub = _make_store(tmp_path)
+        with xr.open_zarr(parent, consolidated=False) as ds:
+            proj_y = ds['projection_y_coordinate'].values
+            proj_x = ds['projection_x_coordinate'].values
+
+        europe = {'lat_min': 46.0, 'lat_max': 47.0, 'lon_min': 8.0, 'lon_max': 9.0}
+        acq = _make_acquirer(europe)
+        with pytest.raises(ValueError, match="does not intersect"):
+            acq._lcc_index_window(proj_y, proj_x, europe)
+
+
+class TestNoWindowRaises:
+    """(b) Undeterminable window must raise — never full-domain download."""
+
+    def test_store_without_coords_raises(self, tmp_path):
+        parent, sub = _make_store(tmp_path, with_proj_coords=False)
+        read_log: list = []
+        acq = _make_acquirer()
+
+        patches = _patch_s3(parent, sub, read_log)
+        with patches[0], patches[1]:
+            with pytest.raises(ValueError, match="Refusing to download the full"):
+                acq.download(tmp_path / "out")
+
+        # And crucially: no data chunks were fetched before the raise
+        assert _data_chunk_keys(read_log, 'TMP') == set()
+
+    def test_determine_xy_window_raises_without_any_coords(self):
+        acq = _make_acquirer()
+        ds = xr.Dataset(
+            {'TMP': (('projection_y_coordinate', 'projection_x_coordinate'),
+                     np.zeros((4, 4), dtype=np.float32))}
+        )
+        with pytest.raises(ValueError, match="Refusing to download the full"):
+            acq._determine_xy_window(ds, BBOX)
+
+    def test_unknown_dims_raise(self):
+        acq = _make_acquirer()
+        ds = xr.Dataset({'TMP': (('a', 'b'), np.zeros((4, 4), dtype=np.float32))})
+        with pytest.raises(ValueError, match="spatial dimensions"):
+            acq._determine_xy_window(ds, BBOX)
+
+
+class TestLatLonMaskFallback:
+    """Renamed grids with 2-D lat/lon still window via the geographic mask."""
+
+    def test_mask_route(self):
+        acq = _make_acquirer()
+        lat = np.linspace(39.0, 40.5, 30)
+        lon = np.linspace(-106.0, -104.5, 30)
+        lon2d, lat2d = np.meshgrid(lon, lat)
+        ds = xr.Dataset(
+            {'TMP': (('y', 'x'), np.zeros((30, 30), dtype=np.float32))},
+            coords={'latitude': (('y', 'x'), lat2d),
+                    'longitude': (('y', 'x'), lon2d)},
+        )
+        y_slice, x_slice = acq._determine_xy_window(ds, BBOX)
+        sub = ds.isel(y=y_slice, x=x_slice)
+        assert 0 < sub.sizes['y'] < 30
+        assert 0 < sub.sizes['x'] < 30

--- a/tests/unit/data/acquisition/test_merit_basins_handler.py
+++ b/tests/unit/data/acquisition/test_merit_basins_handler.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
+
+"""MERIT-Basins handler tests.
+
+Two regressions are pinned here (2026-06 parity campaign):
+
+1. The Pfafstetter Level-1 region table must follow the OFFICIAL
+   MERIT-Basins ReadMe mapping (1 Africa, 2 Europe, 3-5 Asia(+),
+   6 South America, 7 North America, 8 Arctic, 9 Greenland). The handler
+   previously shipped 1=Amazon ... 9=Australia, contradicting the shipped
+   data (the pfaf_9 extent is Greenland, verified empirically).
+
+2. The legacy bulk-download host (hydrology.princeton.edu) is DNS-dead.
+   Missing region files must raise ONE actionable error listing the
+   current distribution channels (Google Drive folder, Globus,
+   reachhydro.org) and the local staging directory — no retry loop, no
+   network attempt.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from symfluence.data.acquisition.handlers.merit_basins import (
+    _PFAFSTETTER_L1_BBOXES,
+    MERITBasinsAcquirer,
+)
+
+OFFICIAL_TABLE = {
+    1: (-36.0, -20.0, 38.0, 56.0),    # Africa
+    2: (12.0, -25.0, 72.0, 70.0),     # Europe
+    3: (40.0, 55.0, 84.0, 180.0),     # North Asia / Siberia
+    4: (0.0, 55.0, 56.0, 150.0),      # South Asia
+    5: (-56.0, 90.0, 21.0, 180.0),    # Oceania + South Asian islands
+    6: (-56.0, -93.0, 15.0, -32.0),   # South America
+    7: (5.0, -170.0, 62.0, -52.0),    # North America
+    8: (50.0, -180.0, 84.0, -50.0),   # Arctic (N. American Arctic)
+    9: (58.0, -75.0, 84.0, -10.0),    # Greenland
+}
+
+
+def _make_acquirer(tmp_path, pour_point='39.75/-105.2', bbox=None):
+    bbox = bbox or {
+        'lat_min': 39.5, 'lat_max': 40.0,
+        'lon_min': -105.5, 'lon_max': -105.0,
+    }
+    config = {
+        'DOMAIN_NAME': 'test_domain',
+        'SYMFLUENCE_DATA_DIR': str(tmp_path),
+        'POUR_POINT_COORDS': pour_point,
+        'BOUNDING_BOX_COORDS': (
+            f"{bbox['lat_max']}/{bbox['lon_min']}/"
+            f"{bbox['lat_min']}/{bbox['lon_max']}"
+        ),
+        'EXPERIMENT_TIME_START': '2020-01-01',
+        'EXPERIMENT_TIME_END': '2020-12-31',
+    }
+    acq = MERITBasinsAcquirer(config, MagicMock())
+    acq.data_dir = tmp_path
+    acq.bbox = dict(bbox)
+    return acq
+
+
+def _stage(geofabric_dir, code, legacy=False):
+    geofabric_dir.mkdir(parents=True, exist_ok=True)
+    if legacy:
+        names = [f"merit_cat_pfaf_{code}.shp", f"merit_riv_pfaf_{code}.shp"]
+    else:
+        names = [
+            f"pfaf_{code}_MERIT_Hydro_v07_Basins_v01.shp",
+            f"pfaf_{code}_MERIT_Hydro_v07_Basins_v01_rivernet.shp",
+        ]
+    for n in names:
+        (geofabric_dir / n).touch()
+
+
+class TestOfficialRegionTable:
+    """The region table is pinned to the official ReadMe mapping."""
+
+    def test_table_matches_official_mapping(self):
+        assert _PFAFSTETTER_L1_BBOXES == OFFICIAL_TABLE
+
+    def test_greenland_is_region_9(self, tmp_path):
+        """pfaf_9 is Greenland (verified empirically), NOT Australia."""
+        acq = _make_acquirer(
+            tmp_path, pour_point='70.0/-45.0',
+            bbox={'lat_min': 69.5, 'lat_max': 70.5,
+                  'lon_min': -46.0, 'lon_max': -44.0},
+        )
+        assert acq._find_pfafstetter_regions(70.0, -45.0) == [9]
+
+    def test_amazon_is_region_6(self, tmp_path):
+        """South America is region 6, NOT region 1."""
+        acq = _make_acquirer(
+            tmp_path, pour_point='-3.0/-60.0',
+            bbox={'lat_min': -3.5, 'lat_max': -2.5,
+                  'lon_min': -60.5, 'lon_max': -59.5},
+        )
+        assert acq._find_pfafstetter_regions(-3.0, -60.0) == [6]
+
+    def test_africa_is_region_1(self, tmp_path):
+        acq = _make_acquirer(
+            tmp_path, pour_point='0.0/20.0',
+            bbox={'lat_min': -0.5, 'lat_max': 0.5,
+                  'lon_min': 19.5, 'lon_max': 20.5},
+        )
+        assert acq._find_pfafstetter_regions(0.0, 20.0) == [1]
+
+    def test_europe_is_region_2(self, tmp_path):
+        acq = _make_acquirer(
+            tmp_path, pour_point='47.0/8.0',
+            bbox={'lat_min': 46.5, 'lat_max': 47.5,
+                  'lon_min': 7.5, 'lon_max': 8.5},
+        )
+        assert acq._find_pfafstetter_regions(47.0, 8.0) == [2]
+
+    def test_north_america_is_region_7(self, tmp_path):
+        acq = _make_acquirer(tmp_path)  # Colorado Front Range default
+        assert acq._find_pfafstetter_regions(39.75, -105.2) == [7]
+
+    def test_australia_is_region_5(self, tmp_path):
+        """Australia belongs to region 5 (Oceania), NOT region 9."""
+        acq = _make_acquirer(
+            tmp_path, pour_point='-25.0/135.0',
+            bbox={'lat_min': -25.5, 'lat_max': -24.5,
+                  'lon_min': 134.5, 'lon_max': 135.5},
+        )
+        assert acq._find_pfafstetter_regions(-25.0, 135.0) == [5]
+
+    def test_siberia_is_region_3(self, tmp_path):
+        acq = _make_acquirer(
+            tmp_path, pour_point='65.0/100.0',
+            bbox={'lat_min': 64.5, 'lat_max': 65.5,
+                  'lon_min': 99.5, 'lon_max': 100.5},
+        )
+        assert acq._find_pfafstetter_regions(65.0, 100.0) == [3]
+
+    def test_bbox_spanning_regions_adds_codes(self, tmp_path):
+        """A domain bbox overlapping a second region pulls it in."""
+        acq = _make_acquirer(
+            tmp_path, pour_point='60.0/-150.0',
+            bbox={'lat_min': 55.0, 'lat_max': 65.0,
+                  'lon_min': -155.0, 'lon_max': -145.0},
+        )
+        codes = acq._find_pfafstetter_regions(60.0, -150.0)
+        assert 7 in codes and 8 in codes
+
+
+class TestDeadHostReplacement:
+    """Missing files raise one actionable error — no dead-host download."""
+
+    def test_missing_files_raise_actionable_error(self, tmp_path):
+        acq = _make_acquirer(tmp_path)
+        with pytest.raises(RuntimeError) as excinfo:
+            acq.download(tmp_path)
+        msg = str(excinfo.value)
+        assert "drive.google.com/drive/folders/1uCQFmdxFbjwoT9OYJxw-pXaP8q_GYH1a" in msg
+        assert "Globus" in msg
+        assert "reachhydro.org" in msg
+        assert "hydrology.princeton.edu" in msg  # explains WHY it cannot download
+        assert "pfaf_7_MERIT_Hydro_v07_Basins_v01.zip" in msg
+        # The staging directory the handler reads from is spelled out
+        assert "geofabric" in msg and "merit_basins" in msg
+
+    def test_no_network_attempt_or_retry_loop(self, tmp_path, monkeypatch):
+        """The failure path must not touch the network or sleep-retry."""
+        import socket
+        import time as _time
+
+        def _no_net(*a, **k):
+            raise AssertionError("network access attempted")
+
+        def _no_sleep(*a, **k):
+            raise AssertionError("retry sleep attempted")
+
+        monkeypatch.setattr(socket.socket, "connect", _no_net)
+        monkeypatch.setattr(_time, "sleep", _no_sleep)
+
+        acq = _make_acquirer(tmp_path)
+        with pytest.raises(RuntimeError, match="not staged locally"):
+            acq.download(tmp_path)
+
+    def test_staged_upstream_names_resolve(self, tmp_path):
+        acq = _make_acquirer(tmp_path)
+        geofabric_dir = acq._attribute_dir("geofabric") / "merit_basins"
+        _stage(geofabric_dir, 7)
+        out = acq.download(tmp_path)
+        assert out == geofabric_dir
+
+    def test_staged_legacy_names_resolve(self, tmp_path):
+        acq = _make_acquirer(tmp_path)
+        geofabric_dir = acq._attribute_dir("geofabric") / "merit_basins"
+        _stage(geofabric_dir, 7, legacy=True)
+        out = acq.download(tmp_path)
+        assert out == geofabric_dir
+
+    def test_partial_staging_still_raises(self, tmp_path):
+        """Catchments staged but rivers missing -> still actionable error."""
+        acq = _make_acquirer(tmp_path)
+        geofabric_dir = acq._attribute_dir("geofabric") / "merit_basins"
+        geofabric_dir.mkdir(parents=True, exist_ok=True)
+        (geofabric_dir / "pfaf_7_MERIT_Hydro_v07_Basins_v01.shp").touch()
+        with pytest.raises(RuntimeError, match="not staged locally"):
+            acq.download(tmp_path)
+
+    def test_no_dead_host_in_module(self):
+        """The dead host must not be used as a download URL anywhere."""
+        import inspect
+
+        import symfluence.data.acquisition.handlers.merit_basins as mod
+        src = inspect.getsource(mod)
+        # It may be MENTIONED in error text/docs, but never as a URL template
+        assert "http://hydrology.princeton.edu" not in src


### PR DESCRIPTION
## Summary

Four native data-acquisition bugs found by the community-parity campaign (live experiments, both sides reading the same upstream archives). One commit per bug.

1. **CERRA could never acquire** (`cds_datasets.py`): CDS names the longwave variable differently per dataset (CARRA `thermal_surface_radiation_downwards` vs CERRA `surface_thermal_radiation_downwards`) and silently drops unknown names — CERRA always came back without longwave and failed validation. Variable lists fixed and pinned by test. **Live-verified**: the corrected request returns `tp, ssrd, strd`.
2. **HRRR bbox windowing silently no-oped** (`hrrr.py`): hrrrzarr groups carry no latitude coordinate, so subsetting found nothing to subset and downloaded full CONUS (~1.3 GB/day). Now: pyproj LCC bbox→index window applied to the lazy zarr arrays before any chunk fetch, and an undeterminable window **raises** instead of silently fetching the domain. **Live-verified**: 1-hour Colorado box = 24×20 window, 7 variables, 40 KB in 40 s (window identical to the community connector's parity experiment).
3. **Daymet's gridded route was dead** (`daymet.py`): the y-slice assumed ascending coordinates (Daymet descends ⇒ empty windows) and the URL pointed at ORNL's retired legacy THREDDS. Now: descending-aware windowing + pydap/DAP2 against `opendap.earthdata.nasa.gov` through the handler's Earthdata session (endpoint+auth live-probed; full-granule fetch currently blocked by an ongoing NASA Hyrax outage — hermetic tests + the campaign's working-route evidence cover it). Single-pixel route untouched. Adds `pydap` as a dependency.
4. **MERIT-Basins shipped a factually wrong Pfafstetter table** (`merit_basins.py`): 1=Amazon…9=Australia contradicts the data (official mapping: 1 Africa … 8 Arctic, 9 Greenland — pfaf_9's extent is empirically Greenland). Table corrected; the dead `hydrology.princeton.edu` download replaced with one actionable error listing the current channels (official Google Drive folder, Globus, reachhydro.org) and the local staging convention — no silent retries.

## Validation

41 new tests (variable-list pins, synthetic-zarr chunk-read spies proving pre-fetch windowing and the raise-not-CONUS rule, descending-y math, region-table pins, no-network failure paths). `tests/unit/data/`: 2,180 passed. ruff/mypy/pre-commit clean per commit.

> Repo and code assistance from [Claude](https://claude.ai) (Anthropic).