### PR TITLE
fix(hype): clone over https with retry to stop nightly flakes

### DIFF
--- a/src/symfluence/cli/services/tool_installer.py
+++ b/src/symfluence/cli/services/tool_installer.py
@@ -13,6 +13,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -789,6 +790,45 @@ class ToolInstaller(BaseService):
 
         return installation_results
 
+    def _clone_with_retry(
+        self,
+        clone_cmd: List[str],
+        build_env: Dict[str, str],
+        target_dir: Path,
+        attempts: int = 3,
+    ) -> None:
+        """
+        Run a ``git clone`` command, retrying transient network failures.
+
+        Upstreams hosted on flaky transports (notably SourceForge, which
+        intermittently rejects clones with "access denied or repository not
+        exported") fail sporadically rather than deterministically. A clone
+        that errors or times out is retried after a short backoff; any partial
+        checkout is removed first so each attempt starts from a clean target.
+        The final failure is re-raised so callers still surface a hard error.
+        """
+        last_exc: Optional[Exception] = None
+        for attempt in range(1, attempts + 1):
+            try:
+                subprocess.run(
+                    clone_cmd, capture_output=True, text=True, check=True,
+                    timeout=600, env=build_env,
+                )
+                return
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+                last_exc = e
+                # Remove any partial clone so the retry sees an empty target.
+                if target_dir.exists():
+                    shutil.rmtree(target_dir, ignore_errors=True)
+                if attempt < attempts:
+                    self._console.indent(
+                        f"Clone attempt {attempt}/{attempts} failed; retrying "
+                        f"in {attempt * 5}s..."
+                    )
+                    time.sleep(attempt * 5)
+        assert last_exc is not None  # loop runs at least once
+        raise last_exc
+
     def _clone_repository(
         self,
         repository_url: Optional[str],
@@ -853,10 +893,7 @@ class ToolInstaller(BaseService):
                 # and abort, so we avoid them on the excluded entries.
                 # Clone fetches the objects and sets HEAD but leaves the working
                 # tree (and, on every platform we've seen, the index) empty.
-                subprocess.run(
-                    clone_cmd, capture_output=True, text=True, check=True,
-                    timeout=600, env=build_env,
-                )
+                self._clone_with_retry(clone_cmd, build_env, target_dir)
                 # Build the index directly from HEAD's tree, dropping the excluded
                 # / NTFS-illegal paths BEFORE they ever enter the index. We cannot
                 # use read-tree/checkout: on Windows git they validate path
@@ -895,10 +932,7 @@ class ToolInstaller(BaseService):
                     "before checkout"
                 )
             else:
-                subprocess.run(
-                    clone_cmd, capture_output=True, text=True, check=True,
-                    timeout=600, env=build_env,
-                )
+                self._clone_with_retry(clone_cmd, build_env, target_dir)
             self._console.success("Clone successful")
 
             # Checkout specific commit hash if requested

--- a/src/symfluence/models/hype/build_instructions.py
+++ b/src/symfluence/models/hype/build_instructions.py
@@ -42,7 +42,10 @@ def get_hype_build_instructions():
         'config_exe_key': 'HYPE_EXE',
         'default_path_suffix': 'installs/hype/bin',
         'default_exe': 'hype',
-        'repository': 'git://git.code.sf.net/p/hype/code',
+        # https:// rather than the deprecated, unauthenticated git:// transport:
+        # SourceForge throttles/drops git:// connections, which flaked the nightly
+        # source builds with "access denied or repository not exported".
+        'repository': 'https://git.code.sf.net/p/hype/code',
         'branch': None,
         'install_dir': 'hype',
         'build_commands': [

--- a/tests/unit/cli/test_tool_installer.py
+++ b/tests/unit/cli/test_tool_installer.py
@@ -117,6 +117,53 @@ def test_clone_repository_sparse_excludes_paths(mock_external_tools, tmp_path):
     assert not (target / "src" / "pkg" / "network" / "test" / "fixtures" / "data.ncdf").exists()
 
 
+def test_clone_with_retry_recovers_from_transient_failure(mock_external_tools, tmp_path, monkeypatch):
+    """A clone that fails once (e.g. flaky SourceForge) is retried and succeeds.
+
+    The partial target is cleaned between attempts and the backoff sleep is
+    stubbed so the test stays fast.
+    """
+    import subprocess
+
+    from symfluence.cli.services import tool_installer as ti
+
+    target = tmp_path / "clone"
+    calls = {"n": 0}
+
+    def fake_run(cmd, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            # Simulate a partial clone left behind by the failed attempt.
+            target.mkdir(parents=True, exist_ok=True)
+            raise subprocess.CalledProcessError(128, cmd, stderr="access denied")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(ti.subprocess, "run", fake_run)
+    monkeypatch.setattr(ti.time, "sleep", lambda *_: None)
+
+    installer = ti.ToolInstaller(external_tools=mock_external_tools)
+    installer._clone_with_retry(["git", "clone", "x", str(target)], {}, target)
+
+    assert calls["n"] == 2  # failed once, succeeded on retry
+
+
+def test_clone_with_retry_reraises_after_exhausting_attempts(mock_external_tools, tmp_path, monkeypatch):
+    """When every attempt fails the last error is re-raised so install fails hard."""
+    import subprocess
+
+    from symfluence.cli.services import tool_installer as ti
+
+    def always_fail(cmd, *args, **kwargs):
+        raise subprocess.CalledProcessError(128, cmd, stderr="access denied")
+
+    monkeypatch.setattr(ti.subprocess, "run", always_fail)
+    monkeypatch.setattr(ti.time, "sleep", lambda *_: None)
+
+    installer = ti.ToolInstaller(external_tools=mock_external_tools)
+    with pytest.raises(subprocess.CalledProcessError):
+        installer._clone_with_retry(["git", "clone", "x", "y"], {}, tmp_path / "c", attempts=3)
+
+
 def test_install_fails_fast_when_required_tool_missing(mock_external_tools, tmp_path):
     """A tool with unmet `requires` should not proceed to build."""
     from symfluence.cli.services.tool_installer import ToolInstaller


### PR DESCRIPTION
## Problem

The nightly **ARM64 Source Build & Validate** and **Release Binaries** jobs on `main` were intermittently red. Both died on the *same* line — cloning HYPE:

```
Installing HYPE:  Cloning from: git://git.code.sf.net/p/hype/code
fatal: remote error: access denied or repository not exported: /p/hype/code
[ERROR] Tool installation failed for: hype
```

This is not a code regression — it's SourceForge throttling/dropping the deprecated, unauthenticated `git://` transport. `build_instructions.py` was byte-identical on `main` and `develop`, so a `develop`→`main` merge would not have fixed it; `develop` only looked green because SourceForge happened to be up when its nightly ran.

## Fix

- Switch the HYPE repository URL from `git://git.code.sf.net/p/hype/code` to `https://git.code.sf.net/p/hype/code`.
- Add `_clone_with_retry()` in the tool installer and route both clone paths (normal + deferred/sparse-checkout) through it. It retries transient `git clone` failures and timeouts (3 attempts, 5s/10s backoff), cleans up any partial checkout between attempts, and re-raises the final error so a genuine failure still fails hard.

## Tests

- New: transient-failure recovery (fail once → retry → succeed, with partial-clone cleanup).
- New: error is re-raised after attempts are exhausted.
- Existing `test_tool_installer.py` suite still passes (8 passed). `ruff` + `mypy` clean.

Repo and code assistance from [Claude](https://claude.ai) (Anthropic).