### PR TITLE
docs: move commercial-licensing detail to the docs site; README polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![PyPI version](https://badge.fury.io/py/symfluence.svg)](https://badge.fury.io/py/symfluence)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
-[![Documentation](https://img.shields.io/badge/docs-symfluence.org-brightgreen)](https://symfluence.org)
+[![Documentation](https://img.shields.io/badge/docs-readthedocs-brightgreen)](https://symfluence.readthedocs.io)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/symfluence-org/SYMFLUENCE/ci.yml?branch=main)](https://github.com/symfluence-org/SYMFLUENCE/actions)
-[![Tests](https://img.shields.io/badge/tests-99%20files-green)](tests/)
+[![Tests](https://img.shields.io/badge/tests-8000%2B-green)](tests/)
 
 ---
 
@@ -131,7 +131,7 @@ SYMFLUENCE/
 ## Branching Strategy
 - **main**: Stable releases only — every commit is a published version.
 - **develop**: Ongoing integration — merges from feature branches and then tested before release.
-- Feature branches: `feature/<description>`, PR to `develop`.
+- Feature branches: `feat/<description>`, PR to `develop`.
 
 ---
 
@@ -144,19 +144,15 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for:
 ---
 
 ## License
-Licensed under the GPL-3.0 License.
-See [LICENSE](LICENSE) for details.
+SYMFLUENCE is free and open-source software under **GPL-3.0-or-later**.
+See [LICENSE](LICENSE) for the full text.
 
-## Commercial Licensing
-SYMFLUENCE is free and open-source software under GPL-3.0-or-later.
-For organizations that require alternative licensing terms — including
-proprietary integration, redistribution without copyleft obligations,
-or operational deployment support — commercial licenses are available.
-
-For commercial licensing, derivative-platform inquiries, and the
-Foundation's dual-licensing policy, see [LICENSING.md](LICENSING.md).
-
-Contact: licensing@symfluence.org (licensing) · dev@symfluence.org (general)
+Commercial and dual-licensing options are available for organizations that
+need alternative terms (proprietary integration, redistribution without
+copyleft obligations, or operational deployment support). See the
+[licensing guide](https://symfluence.readthedocs.io/en/latest/licensing.html)
+for details, or the full [Licensing Policy](LICENSING.md). Inquiries:
+licensing@symfluence.org.
 
 ---
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -105,3 +105,10 @@
    developer_guide
    testing
    changelog
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Project
+   :hidden:
+
+   licensing

--- a/docs/source/licensing.rst
+++ b/docs/source/licensing.rst
@@ -1,0 +1,107 @@
+Licensing
+=========
+
+SYMFLUENCE is free and open-source software released under the
+**GNU General Public License, version 3 or later (GPL-3.0-or-later)**.
+This page explains what that means for typical users and describes the
+commercial / dual-licensing options administered by the SYMFLUENCE Foundation.
+
+.. note::
+
+   This page is a plain-language summary for users. The authoritative
+   instruments are the `LICENSE
+   <https://github.com/symfluence-org/SYMFLUENCE/blob/main/LICENSE>`_ file
+   (full GPL-3.0-or-later text) and the `Licensing Policy (LICENSING.md)
+   <https://github.com/symfluence-org/SYMFLUENCE/blob/main/LICENSING.md>`_.
+   If anything here conflicts with those documents, those documents control.
+
+Open-source use
+---------------
+
+Under GPL-3.0-or-later you may, at no charge:
+
+- Run SYMFLUENCE for any purpose, including commercial purposes.
+- Study and modify the source code.
+- Redistribute SYMFLUENCE and your modifications.
+- Build derivative works.
+
+In exchange, if you **distribute** SYMFLUENCE or a derivative work, you must do
+so under GPL-3.0-or-later, provide source code to recipients, and preserve the
+license notices.
+
+If you run SYMFLUENCE **internally** within your organization — for research,
+modeling, or operational purposes, without redistribution — GPL-3.0-or-later
+imposes no additional obligations on you.
+
+Dual licensing
+--------------
+
+SYMFLUENCE operates under a dual-licensing model:
+
+1. **Open-source license (GPL-3.0-or-later)** — available to everyone, under
+   the terms above.
+2. **Additional licenses administered by the SYMFLUENCE Foundation** —
+   available by agreement, for uses that are not compatible with
+   GPL-3.0-or-later obligations.
+
+The dual-licensing structure does **not** reduce the rights available under
+GPL-3.0-or-later — those rights remain available to everyone. There is no
+"community edition vs. enterprise edition": the GPL-3.0-or-later distribution
+is the canonical project, and any Foundation-administered license is simply a
+re-licensing of that same code under different terms (e.g. proprietary
+distribution, indemnification, or support obligations).
+
+When you may need a commercial license
+--------------------------------------
+
+Organizations typically need an additional (commercial) license when they:
+
+- Embed SYMFLUENCE into a **proprietary product**.
+- Operate it as part of a **commercial service** with licensing or
+  redistribution constraints.
+- Need **indemnification or support terms** that an open-source license
+  cannot provide.
+
+Derivative platforms and commercial wrappers
+--------------------------------------------
+
+If you are building a **platform, service, or product that incorporates
+SYMFLUENCE** — a cloud-hosted service, a bundled commercial product, a managed
+deployment, or a proprietary orchestration/interface layer — two things are
+true:
+
+- The GPL-3.0-or-later license **already governs** the SYMFLUENCE components
+  you use; obtain independent legal advice about how its obligations apply to
+  your architecture.
+- The Foundation strongly encourages engagement **during scoping, not after
+  development**. Licensing questions are far cheaper to resolve early.
+
+If your project is in the planning, proposal, or early-development stage,
+contact the Foundation at **licensing@symfluence.org** with a brief description
+of the platform, the role SYMFLUENCE plays, your expected distribution model,
+and your timeline. The Foundation typically responds within two weeks.
+
+Attribution
+-----------
+
+Beyond the notices GPL-3.0-or-later requires, the Foundation asks that
+platforms, publications, and institutional reports that rely on SYMFLUENCE:
+
+- **Name SYMFLUENCE explicitly** in technical documentation and published
+  system descriptions.
+- **Cite the companion papers** (Eythorsson et al., 2026a, 2026b, 2026c) in
+  peer-reviewed research and technical reports.
+- **Link to the canonical repository**
+  (https://github.com/symfluence-org/SYMFLUENCE) in online documentation.
+
+Contact
+-------
+
+- **Licensing / commercial inquiries:** licensing@symfluence.org
+- **Contributions and CLAs:** dev@symfluence.org
+- **Governance and maintainer questions:** see `GOVERNANCE.md
+  <https://github.com/symfluence-org/SYMFLUENCE/blob/main/GOVERNANCE.md>`_
+
+For the full policy — including the CLA basis for dual licensing and the role
+of the SYMFLUENCE Foundation — see the `Licensing Policy
+<https://github.com/symfluence-org/SYMFLUENCE/blob/main/LICENSING.md>`_.


### PR DESCRIPTION
## Summary

Tidy-up of the top-level README and licensing docs (prep for the paper submission / 1.0).

- **Move the commercial-licensing detail to the docs site.** New `docs/source/licensing.rst` (GPL-3.0 open-source use, the dual-licensing model, when a commercial license is needed, derivative-platform guidance, attribution, Foundation contacts), wired into the index under a new **Project** section. `LICENSING.md` stays the authoritative root instrument; the docs page summarizes and links to it.
- **Trim the README's Commercial Licensing block** to a short pointer to the new docs page.
- **Fix stale README facts:** docs badge/links → `readthedocs` as the canonical docs URL (symfluence.org is the front-facing facade); tests badge `99` → `8000+`; feature-branch convention `feature/` → `feat/`.

Docs-only; no code touched.

---
Repo and code assistance from [Claude](https://claude.ai) (Anthropic).