### PR TITLE
feat(noahmp): build + ship noah-owp-modular in the release bundle

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -344,7 +344,7 @@ jobs:
           echo "Default tools build completed"
 
           # Install experimental models for release
-          RELEASE_EXTRAS="vic swat prms mhm crhm wrfhydro watflood modflow parflow clmparflow pihm gsflow clm rhessys wmfire"
+          RELEASE_EXTRAS="vic swat prms mhm crhm wrfhydro watflood modflow parflow clmparflow pihm gsflow clm rhessys wmfire noahmp"
           for tool in $RELEASE_EXTRAS; do
             # CLM/CTSM is explicitly unsupported on Windows: its build pulls
             # external components via git-fleximod (which loops to a MemoryError
@@ -729,7 +729,7 @@ jobs:
           # parflow-clm. `pitremove` stands in for TauDEM's 13 utilities (if the
           # TauDEM build fails, none exist). Keep this list in sync with what the
           # build actually stages, or a tool can silently stop shipping unnoticed.
-          OPTIONAL_BINS="fuse ngen vic swat prms mhm crhm wrfhydro watflood mf6 parflow parflow-clm pitremove pihm gsflow clm rhessys hype mesh"
+          OPTIONAL_BINS="fuse ngen vic swat prms mhm crhm wrfhydro watflood mf6 parflow parflow-clm pitremove pihm gsflow clm rhessys hype mesh noah_owp_modular"
 
           for binary in $REQUIRED_BINS; do
             if [ -f "$BIN_DIR/$binary" ] || [ -f "$BIN_DIR/$binary.exe" ]; then

--- a/scripts/stage_release_artifacts.sh
+++ b/scripts/stage_release_artifacts.sh
@@ -366,6 +366,23 @@ else
 fi
 
 # ============================================================================
+# Stage NoahMP (noah-owp-modular)
+# ============================================================================
+print_info "Staging NoahMP..."
+
+NOAHMP_DIR="$INSTALLS_DIR/noah-owp-modular"
+if [ -d "$NOAHMP_DIR" ]; then
+    if stage_binary "$NOAHMP_DIR/run/noah_owp_modular.exe" "noah_owp_modular" "NoahMP"; then
+        :
+    else
+        print_warning "NoahMP binary not found"
+    fi
+    stage_license "$NOAHMP_DIR" "NoahMP"
+else
+    print_warning "NoahMP not installed"
+fi
+
+# ============================================================================
 # Stage VIC
 # ============================================================================
 print_info "Staging VIC..."

--- a/src/symfluence/models/noahmp/build_instructions.py
+++ b/src/symfluence/models/noahmp/build_instructions.py
@@ -45,24 +45,31 @@ if ! command -v nf-config &>/dev/null && ! command -v nc-config &>/dev/null; the
     exit 1
 fi
 
-# Configure (select appropriate config for platform)
+# Configure: pick the gfortran build config for the platform. (NB: the Linux
+# config must be gfortran.linux — NOT pgf90.linux, which targets the PGI/NVIDIA
+# compiler and breaks under gfortran.)
 if [ "$(uname)" = "Darwin" ]; then
-    # macOS gfortran
-    if [ -f "config/user_build_options.macos.gfortran" ]; then
-        cp config/user_build_options.macos.gfortran user_build_options
-    elif [ -f "config/user_build_options.bigsur.gfortran" ]; then
-        cp config/user_build_options.bigsur.gfortran user_build_options
-    else
-        echo "WARNING: No macOS config found, trying ./configure"
-        ./configure 2>/dev/null || true
-    fi
+    cp config/user_build_options.macos.gfortran user_build_options 2>/dev/null \
+        || cp config/user_build_options.bigsur.gfortran user_build_options 2>/dev/null \
+        || { echo "WARNING: No macOS gfortran config found, trying ./configure"; ./configure 2>/dev/null || true; }
+elif [ -f "config/user_build_options.gfortran.linux" ]; then
+    cp config/user_build_options.gfortran.linux user_build_options
 else
-    # Linux gfortran
-    if [ -f "config/user_build_options.pgf90.linux" ]; then
-        cp config/user_build_options.pgf90.linux user_build_options
-    else
-        ./configure 2>/dev/null || true
-    fi
+    ./configure 2>/dev/null || true
+fi
+
+# The shipped configs hardcode NetCDF (and sometimes compiler) paths for one
+# specific machine. Rewrite the NetCDF lines from nf-config/nc-config so the
+# build finds NetCDF wherever it actually lives: Debian/Ubuntu multiarch
+# (/usr/lib/<arch>-linux-gnu, which ${NETCDF}/lib misses) and Homebrew's split
+# netcdf / netcdf-fortran prefixes on macOS. Also normalise the compiler to the
+# one on PATH (the macOS config hardcodes an Intel-Homebrew gfortran path).
+if [ -f user_build_options ] && command -v nf-config >/dev/null 2>&1; then
+    _NF_INC="$(nf-config --includedir 2>/dev/null)"
+    _NF_LIBS="$(nf-config --flibs 2>/dev/null) $(nc-config --libs 2>/dev/null)"
+    perl -pi -e "s|^\s*NETCDFMOD\s*=.*|NETCDFMOD = -I${_NF_INC}|" user_build_options
+    perl -pi -e "s|^\s*NETCDFLIB\s*=.*|NETCDFLIB = ${_NF_LIBS}|" user_build_options
+    perl -pi -e "s|^\s*COMPILERF90\s*=.*|COMPILERF90 = gfortran|" user_build_options
 fi
 
 make clean 2>/dev/null || true


### PR DESCRIPTION
## Summary

Recovers a stranded commit that was left on `fix/binary-coverage` after that branch's PR (#210) had already merged — it builds and ships **noah-owp-modular** in the release artifacts, extending the cross-platform binary coverage from #210.

Touches `release-binaries.yml`, `scripts/stage_release_artifacts.sh`, and `models/noahmp/build_instructions.py`. Cherry-picked cleanly onto current develop; ruff passes and the module imports.

## Context
The commit never got its own PR because the branch was reused as scratch space post-merge. Recovering it here so the noah-owp-modular release bundling isn't lost.

---
Repo and code assistance from [Claude](https://claude.ai) (Anthropic).