### PR TITLE
docs: sync docs with current code; drop stale counts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ We welcome all contributions — from bug fixes and documentation improvements t
    ```bash
    python -m venv venv
    source venv/bin/activate
-   pip install -r requirements.txt
+   pip install -e ".[dev]"
    ```
 
 3. **Verify installation**
@@ -45,7 +45,7 @@ When creating new source files, include the standard SPDX header:
 
 ```python
 # SPDX-License-Identifier: GPL-3.0-or-later
-# Copyright 2024-2026 SYMFLUENCE Foundation <dev@symfluence.org>
+# Copyright (C) 2024-2026 SYMFLUENCE Team <dev@symfluence.org>
 ```
 
 ### Contributor License Agreement (CLA)
@@ -107,7 +107,7 @@ main          ← Protected, releases only (v0.6.0, v0.7.0, v1.0.0)
   ↓
 develop       ← Active development, merge here first
   ↓
-feature/*     ← Individual features
+feat/*        ← Individual features
 hotfix/*      ← Emergency fixes
 ```
 
@@ -119,12 +119,12 @@ git checkout develop
 git pull origin develop
 
 # Create your feature branch
-git checkout -b feature/my-feature
+git checkout -b feat/my-feature
 
 # Work, commit, push
 git add .
 git commit -m "Add feature description"
-git push -u origin feature/my-feature
+git push -u origin feat/my-feature
 
 # Open PR to merge into develop
 ```
@@ -254,13 +254,13 @@ Use concise, descriptive messages:
 
 1. **Create a feature branch**
    ```bash
-   git checkout -b feature/my-update
+   git checkout -b feat/my-update
    ```
 
 2. **Commit and push**
    ```bash
    git commit -m "Describe your change"
-   git push origin feature/my-update
+   git push origin feat/my-update
    ```
 
 3. **Open a Pull Request (PR)**

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -13,8 +13,9 @@ and [CLA.md](CLA.md), which covers intellectual property.
 SYMFLUENCE's architecture is designed around typed registry contracts that
 enable decentralized contribution without central gatekeeping. The value of the
 framework lies not in any single model or data handler but in the coherence of
-these contracts — the fact that 27 models, 68 data handlers, and 17
-optimization algorithms interoperate through shared interface definitions.
+these contracts — the fact that a broad and growing set of hydrological
+models, data handlers, and optimization algorithms interoperate through shared
+interface definitions.
 
 This governance document exists to protect that coherence as the contributor
 base grows. Architecture can enable coordination. It cannot sustain it. The
@@ -81,7 +82,7 @@ package that registers with SYMFLUENCE at install time. This includes:
   `model_manifest()`. A plugin may also ship its own **typed Pydantic
   configuration schema** (`model_manifest(config_schema=...)`), which the core
   validation pipeline consumes on equal footing with in-tree models — see
-  [ADR-0002](docs/adr/0002-plugins-may-ship-typed-config.md). See the six
+  [ADR-0002](docs/adr/0002-plugins-may-ship-typed-config.md). See the
   JAX-native packages (jHBV, jSACSMA, etc.) as reference implementations.
 - **New data handlers.** Implement the acquisition handler interface and
   register via decorator.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Documentation](https://img.shields.io/badge/docs-readthedocs-brightgreen)](https://symfluence.readthedocs.io)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/symfluence-org/SYMFLUENCE/ci.yml?branch=main)](https://github.com/symfluence-org/SYMFLUENCE/actions)
-[![Tests](https://img.shields.io/badge/tests-8000%2B-green)](tests/)
+[![Tests](https://img.shields.io/badge/tests-passing-green)](https://github.com/symfluence-org/SYMFLUENCE/actions)
 
 ---
 
@@ -54,7 +54,7 @@ symfluence workflow run --config my_config.yaml
 symfluence workflow steps setup_project calibrate_model
 
 # Define domain from pour point
-symfluence project pour-point 51.1722/-115.5717 --domain-name MyDomain --definition semidistributed
+symfluence project pour-point 51.1722/-115.5717 --domain-name MyDomain --definition delineate
 
 # Check workflow status
 symfluence workflow status
@@ -111,12 +111,17 @@ SYMFLUENCE/
 ├── src/symfluence/           # Main Python package
 │   ├── core/                 # Core system, configuration, mixins
 │   ├── cli/                  # Command-line interface
+│   ├── tui/                  # Terminal user interface
+│   ├── gui/                  # Graphical user interface
+│   ├── agent/                # Agentic / assistant integration
 │   ├── project/              # Project and workflow management
 │   ├── data/                 # Data acquisition and preprocessing
 │   ├── geospatial/           # Domain discretization and geofabric
-│   ├── models/               # Model integrations (SUMMA, FUSE, GR4J, etc.)
+│   ├── models/               # Model integrations (SUMMA, FUSE, GR, etc.)
+│   ├── coupling/             # Model coupling
 │   ├── optimization/         # Calibration algorithms (DDS, DE, PSO, NSGA-II)
 │   ├── evaluation/           # Performance metrics and evaluation
+│   ├── fews/                 # Delft-FEWS integration
 │   ├── reporting/            # Visualization and plotting
 │   └── resources/            # Configuration templates and base settings
 ├── examples/                 # Progressive tutorial examples

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -27,14 +27,21 @@ Basic Usage
    # Run complete workflow
    conf.run_workflow()
 
-   # Or run individual steps
-   conf.setup_project()
-   conf.define_domain()
-   conf.acquire_forcings()
-   conf.run_models()
+   # Or run a selected subset of steps (by canonical step name)
+   conf.run_individual_steps([
+       "setup_project",
+       "define_domain",
+       "acquire_forcings",
+       "run_model",
+   ])
 
 Step-by-Step Execution
 ----------------------
+
+The ``SYMFLUENCE`` facade does not expose one method per step. Drive the workflow
+through ``run_workflow()`` (everything) or ``run_individual_steps([...])`` (a
+selected, ordered subset). Pass canonical step names — run
+``symfluence workflow list-steps`` to see the authoritative list.
 
 .. code-block:: python
 
@@ -43,31 +50,33 @@ Step-by-Step Execution
    # Initialize
    conf = SYMFLUENCE("config.yaml")
 
-   # 1. Project Setup
-   conf.setup_project()
-   conf.create_pour_point()
+   # Run a curated subset, in order
+   conf.run_individual_steps([
+       # Project setup
+       "setup_project",
+       "create_pour_point",
+       # Domain definition
+       "acquire_attributes",
+       "define_domain",
+       "discretize_domain",
+       # Data acquisition + preprocessing
+       "process_observed_data",
+       "acquire_forcings",
+       "model_agnostic_preprocessing",
+       "build_model_ready_store",
+       # Model execution
+       "model_specific_preprocessing",
+       "run_model",
+       "postprocess_results",
+       # Calibration + analysis
+       "calibrate_model",
+       "run_benchmarking",
+       "run_sensitivity_analysis",
+   ])
 
-   # 2. Domain Definition
-   conf.acquire_attributes()
-   conf.define_domain()
-   conf.discretize_domain()
-
-   # 3. Data Acquisition
-   conf.process_observed_data()
-   conf.acquire_forcings()
-   conf.run_model_agnostic_preprocessing()
-
-   # 4. Model Execution
-   conf.preprocess_models()
-   conf.run_models()
-   conf.postprocess_results()
-
-   # 5. Calibration (optional)
-   conf.calibrate_model()
-
-   # 6. Analysis
-   conf.run_benchmarking()
-   conf.run_sensitivity_analysis()
+   # Inspect status / diagnostics
+   status = conf.get_workflow_status()
+   issues = conf.run_diagnostics_for_step("calibrate_model")
 
 Configuration Access
 --------------------
@@ -96,12 +105,16 @@ SYMFLUENCE (Main Class)
 
 The primary interface for all SYMFLUENCE operations.
 
-.. autoclass:: symfluence.core.system.SYMFLUENCE
+.. autoclass:: symfluence.project.system.SYMFLUENCE
    :members:
    :undoc-members:
    :show-inheritance:
 
 **Initialization:**
+
+The constructor accepts a config file path (``str``/``Path``) or a
+``SymfluenceConfig`` instance. To start from a dictionary, build a
+``SymfluenceConfig`` first.
 
 .. code-block:: python
 
@@ -115,9 +128,9 @@ The primary interface for all SYMFLUENCE operations.
    config = SymfluenceConfig.from_file("config.yaml")
    conf = SYMFLUENCE(config)
 
-   # From dictionary
+   # From dictionary (wrap it in SymfluenceConfig first)
    config_dict = {"DOMAIN_NAME": "test", ...}
-   conf = SYMFLUENCE(config_dict)
+   conf = SYMFLUENCE(SymfluenceConfig(**config_dict))
 
 **Core Methods:**
 
@@ -126,14 +139,14 @@ The primary interface for all SYMFLUENCE operations.
    # Full workflow execution
    conf.run_workflow(force_run=False)
 
+   # Run a selected, ordered subset of steps
+   conf.run_individual_steps(["setup_project", "define_domain"])
+
    # Workflow status
    status = conf.get_workflow_status()
-   # Returns: {
-   #   "total_steps": 15,
-   #   "completed_steps": 8,
-   #   "pending_steps": 7,
-   #   "step_details": [...]
-   # }
+
+   # Diagnostics for a single step (returns a list of issue strings)
+   issues = conf.run_diagnostics_for_step("calibrate_model")
 
 Manager Classes
 ===============
@@ -341,74 +354,97 @@ Manages workflow step execution and dependencies.
    # Get workflow status
    status = orchestrator.get_workflow_status()
 
-Model Registry
-==============
+Registry
+========
 
-The Model Registry enables plugin-style model integration.
+SYMFLUENCE uses a registry-based plugin system. Each kind of component
+(runners, preprocessors, postprocessors, optimizers, acquisition handlers, ...)
+has its own registry, exposed through the unified facade ``R``
+(``from symfluence.core.registries import R``). Models register all of their
+components in one place via ``model_manifest()``; one-off components use
+``R.<registry>.add()`` / ``add_lazy()``.
 
-.. automodule:: symfluence.models.registry
-   :members:
-   :undoc-members:
-   :show-inheritance:
+.. note::
 
-Registering Models
-------------------
+   The old ``ModelRegistry`` / ``OptimizerRegistry`` decorator API and the
+   ``symfluence.models.registry`` module were removed before 1.0. Use
+   ``model_manifest()`` and the ``R`` facade instead.
+
+Registering a Model
+-------------------
+
+Declare all components for a model in a single ``model_manifest()`` call (this is
+what each model's ``__init__.py`` does at import time):
 
 .. code-block:: python
 
-   from symfluence.models.registry import ModelRegistry
+   from symfluence.core.registry import model_manifest
 
-   # Register preprocessor
-   @ModelRegistry.register_preprocessor('MY_MODEL')
    class MyPreProcessor:
        def __init__(self, config, logger):
            self.config = config
            self.logger = logger
 
        def run_preprocessing(self):
-           # Preprocessing logic
-           pass
+           ...
 
-   # Register runner
-   @ModelRegistry.register_runner('MY_MODEL', method_name='run_my_model')
    class MyRunner:
        def __init__(self, config, logger, reporting_manager=None):
            self.config = config
            self.logger = logger
 
        def run_my_model(self):
-           # Model execution logic
-           pass
+           ...
 
-   # Register postprocessor
-   @ModelRegistry.register_postprocessor('MY_MODEL')
    class MyPostProcessor:
        def __init__(self, config, logger, reporting_manager=None):
            self.config = config
            self.logger = logger
 
        def extract_streamflow(self):
-           # Result extraction logic
-           pass
+           ...
 
-Querying Registry
------------------
+   model_manifest(
+       "MY_MODEL",
+       preprocessor=MyPreProcessor,
+       runner=MyRunner,
+       runner_method="run_my_model",
+       postprocessor=MyPostProcessor,
+   )
+
+For a one-off component (without a full manifest), add it to the relevant
+registry directly:
 
 .. code-block:: python
 
-   from symfluence.models.registry import ModelRegistry
+   from symfluence.core.registries import R
 
-   # List registered models
-   models = ModelRegistry.list_models()
-   # ['SUMMA', 'FUSE', 'GR', 'HYPE', 'NGEN', ...]
+   R.runners.add("MY_MODEL", MyRunner, runner_method="run_my_model")
+   # or register lazily by import path
+   R.preprocessors.add_lazy("MY_MODEL", "my_package.preprocessor:MyPreProcessor")
+
+Querying the Registry
+---------------------
+
+.. code-block:: python
+
+   from symfluence.core.registries import R
+
+   # List registered model runners
+   models = R.runners.keys()        # ['SUMMA', 'FUSE', 'GR', 'HYPE', 'NGEN', ...]
 
    # Get specific components
-   preprocessor_cls = ModelRegistry.get_preprocessor('SUMMA')
-   runner_cls = ModelRegistry.get_runner('SUMMA')
-   postprocessor_cls = ModelRegistry.get_postprocessor('SUMMA')
+   runner_cls = R.runners["SUMMA"]
+   preprocessor_cls = R.preprocessors.get("SUMMA")    # None if absent
+   postprocessor_cls = R.postprocessors.get("SUMMA")
 
-   # Check if model is registered
-   is_registered = ModelRegistry.is_registered('MY_MODEL')
+   # Check if a model runner is registered
+   is_registered = "MY_MODEL" in R.runners
+
+The same pattern applies to every component kind: ``R.optimizers``,
+``R.acquisition_handlers``, ``R.observation_handlers``, ``R.metrics``,
+``R.calibration_targets``, and so on. The live catalog is also available from
+the CLI via ``symfluence list``.
 
 Optimization API
 ================
@@ -433,7 +469,7 @@ via the ``run_dds()`` method.
 .. code-block:: python
 
    # DDS is invoked through model-specific optimizers
-   from symfluence.optimization import OptimizationManager
+   from symfluence.optimization.optimization_manager import OptimizationManager
 
    opt_manager = OptimizationManager(config, logger)
    results = opt_manager.calibrate_model()  # Uses algorithm from config
@@ -597,17 +633,17 @@ Reporting Manager
 
    rm = ReportingManager(config, logger)
 
-   # Generate domain map
-   rm.plot_domain_map()
+   # Visualize the domain
+   rm.visualize_domain()
 
-   # Generate hydrograph
-   rm.plot_hydrograph(observed, simulated)
+   # Visualize the discretized domain
+   rm.visualize_discretized_domain(discretization_method="elevation")
 
-   # Generate calibration convergence plot
-   rm.plot_calibration_convergence(results)
+   # Visualize optimization progress / convergence
+   rm.visualize_optimization_progress(history, output_dir, calibration_variable, metric)
 
-   # Generate sensitivity analysis plot
-   rm.visualize_sensitivity_analysis(sensitivity_results)
+   # Visualize sensitivity analysis results
+   rm.visualize_sensitivity_analysis(sensitivity_data, output_file)
 
 Configuration
 =============
@@ -682,7 +718,7 @@ Error Handling
 .. code-block:: python
 
    from symfluence.core.exceptions import (
-       SymfluenceError,           # Base exception
+       SYMFLUENCEError,           # Base exception
        ConfigurationError,        # Config issues
        DataAcquisitionError,      # Data download failures
        ModelExecutionError,       # Model run failures
@@ -695,7 +731,7 @@ Error Handling
        print(f"Configuration problem: {e}")
    except ModelExecutionError as e:
        print(f"Model failed: {e}")
-   except SymfluenceError as e:
+   except SYMFLUENCEError as e:
        print(f"General error: {e}")
 
 Advanced Usage
@@ -710,18 +746,18 @@ Custom Workflow
 
    conf = SYMFLUENCE("config.yaml")
 
-   # Run subset of steps
-   conf.setup_project()
-   conf.define_domain()
+   # Run a subset of steps in order
+   conf.run_individual_steps(["setup_project", "define_domain"])
 
-   # Skip to model execution (assumes data exists)
-   conf.preprocess_models()
-   conf.run_models()
+   # Skip to model execution (assumes data already exists)
+   conf.run_individual_steps([
+       "model_specific_preprocessing",
+       "run_model",
+       "postprocess_results",
+   ])
 
-   # Custom post-processing
-   results = conf.postprocess_results()
-
-   # Access internal managers
+   # Access internal managers (LazyManagerDict)
+   # keys: 'project', 'domain', 'data', 'model', 'analysis', 'optimization', 'reporting'
    model_mgr = conf.managers['model']
    data_mgr = conf.managers['data']
 
@@ -735,11 +771,13 @@ Parallel Execution
    # PARALLEL_CALIBRATION: true
 
    # Or programmatically
+   from symfluence.core.config import SymfluenceConfig
+
    config_dict['NUM_PROCESSES'] = 8
    config_dict['PARALLEL_CALIBRATION'] = True
 
-   conf = SYMFLUENCE(config_dict)
-   conf.calibrate_model()  # Uses parallel execution
+   conf = SYMFLUENCE(SymfluenceConfig(**config_dict))
+   conf.run_individual_steps(["calibrate_model"])  # Uses parallel execution
 
 Batch Processing
 ----------------

--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -14,7 +14,7 @@ SYMFLUENCE is built on a modular, manager-based architecture with clear separati
 **Core Principles:**
 
 - **Manager Pattern**: Subsystems coordinated through dedicated manager classes
-- **Registry Pattern**: Models self-register using decorators for plugin extensibility
+- **Registry Pattern**: Models self-register via ``model_manifest()`` for plugin extensibility
 - **Mixin Pattern**: Shared functionality distributed through composable mixins
 - **Typed Configuration**: Pydantic models for validation and type safety
 - **Lazy Loading**: Components instantiated on-demand for efficiency
@@ -45,7 +45,7 @@ System Architecture Diagram
            │                      │                      │
            ▼                      ▼                      ▼
    ┌───────────────┐      ┌───────────────┐      ┌───────────────┐
-   │  Acquisition  │      │ ModelRegistry │      │  Optimizers   │
+   │  Acquisition  │      │  R registry   │      │  Optimizers   │
    │   Services    │      │   (Plugin)    │      │  (DE/DDS/     │
    │               │      │               │      │   ADAM/PSO)   │
    └───────────────┘      └───────────────┘      └───────────────┘
@@ -73,10 +73,11 @@ Directory Structure
 
    symfluence/
    ├── core/                      # Core framework infrastructure
-   │   ├── system.py             # SYMFLUENCE main class (entry point)
    │   ├── base_manager.py       # Abstract base for all managers
+   │   ├── registry.py           # Registry + model_manifest()
+   │   ├── registries.py         # Unified registry facade (R)
    │   ├── config/               # Configuration system
-   │   │   ├── models.py         # SymfluenceConfig (Pydantic)
+   │   │   ├── models/           # SymfluenceConfig (Pydantic) package
    │   │   ├── transformers.py   # Flat ↔ nested conversion
    │   │   └── validators.py     # Custom validation rules
    │   ├── exceptions.py         # Custom exception hierarchy
@@ -84,6 +85,7 @@ Directory Structure
    │   └── mixins/               # Shared functionality mixins
    │
    ├── project/                   # Project & workflow management
+   │   ├── system.py             # SYMFLUENCE main class (entry point)
    │   ├── project_manager.py    # Directory structure setup
    │   ├── workflow_orchestrator.py  # Step execution engine
    │   ├── logging_manager.py    # Logging configuration
@@ -104,7 +106,6 @@ Directory Structure
    │
    ├── models/                    # Hydrological model integrations
    │   ├── model_manager.py      # Model execution coordinator
-   │   ├── registry.py           # Plugin registration system
    │   ├── base/                 # Base classes for model components
    │   │   ├── base_preprocessor.py
    │   │   ├── base_runner.py
@@ -431,7 +432,7 @@ Complete Workflow
    │                    4. MODEL PREPROCESSING                               │
    │                                                                         │
    │  ModelManager.preprocess(model_name)                                    │
-   │  ├── Registry lookup: ModelRegistry.get_preprocessor(model_name)        │
+   │  ├── Registry lookup: R.preprocessors[model_name]                       │
    │  ├── Instantiate: preprocessor = PreprocessorClass(config, logger)      │
    │  └── Execute: preprocessor.run_preprocessing()                          │
    │                                                                         │
@@ -445,8 +446,8 @@ Complete Workflow
    │                    5. MODEL EXECUTION                                   │
    │                                                                         │
    │  ModelManager.run_models()                                              │
-   │  ├── Registry lookup: ModelRegistry.get_runner(model_name)              │
-   │  ├── Get method: ModelRegistry.get_runner_method(model_name)            │
+   │  ├── Registry lookup: R.runners[model_name]                             │
+   │  ├── Get method: R.runners.meta(model_name)["runner_method"]            │
    │  ├── Instantiate: runner = RunnerClass(config, logger)                  │
    │  └── Execute: getattr(runner, method_name)()                            │
    │                                                                         │
@@ -460,7 +461,7 @@ Complete Workflow
    │                    6. POSTPROCESSING & EVALUATION                       │
    │                                                                         │
    │  ModelManager.postprocess(model_name)                                   │
-   │  ├── Registry lookup: ModelRegistry.get_postprocessor(model_name)       │
+   │  ├── Registry lookup: R.postprocessors[model_name]                      │
    │  ├── Extract streamflow from model outputs                              │
    │  └── Standardize to common format (CSV, NetCDF)                         │
    │                                                                         │
@@ -473,7 +474,7 @@ Complete Workflow
    ┌─────────────────────────────────────────────────────────────────────────┐
    │                    7. CALIBRATION (Optional)                            │
    │                                                                         │
-   │  OptimizationManager.run_calibration()                                  │
+   │  OptimizationManager.calibrate_model()                                  │
    │  ├── Initialize optimizer (DE, DDS, ADAM, PSO, NSGA-II)                 │
    │  ├── Create parameter manager for model                                 │
    │  ├── Spawn workers for parallel evaluation                              │
@@ -603,8 +604,8 @@ Hierarchical Structure
    # Flat dict (legacy format)
    flat = {'DOMAIN_NAME': 'my_basin', 'FORCING_DATASET': 'ERA5', ...}
 
-   # Converted to hierarchical
-   config = SymfluenceConfig.from_dict(flat)
+   # Converted to hierarchical (flat keys are accepted by the constructor)
+   config = SymfluenceConfig(**flat)
    config.domain.name  # 'my_basin'
    config.forcing.dataset  # 'ERA5'
    config.model.summa.spatial_mode  # 'distributed'
@@ -631,18 +632,23 @@ Exception Hierarchy
 
 .. code-block:: text
 
-   SymfluenceError                    # Base exception
+   SYMFLUENCEError                    # Base exception
    ├── ConfigurationError             # Invalid configuration
-   │   ├── ConfigValidationError      # Pydantic validation failure
-   │   └── ConfigFileError            # Missing/unreadable config file
-   ├── DataError                      # Data acquisition/processing issues
-   │   ├── DataAcquisitionError       # Failed to download
-   │   └── DataValidationError        # Invalid data format
-   ├── ModelError                     # Model execution issues
-   │   ├── ModelExecutionError        # Runtime failure
-   │   └── ModelConfigError           # Missing model files
-   └── OptimizationError              # Calibration issues
-       └── ConvergenceError           # Failed to converge
+   │   └── ConfigValidationError      # Pydantic/config validation failure
+   ├── DataAcquisitionError           # Failed to acquire/process data
+   ├── ModelExecutionError            # Model runtime failure
+   ├── GeospatialError                # Geospatial operation failure
+   │   ├── DiscretizationError        # HRU/GRU discretization failure
+   │   ├── ShapefileError             # Shapefile read/write failure
+   │   └── RasterProcessingError      # Raster processing failure
+   ├── OptimizationError              # Calibration / optimization issues
+   │   ├── WorkerExecutionError       # Worker subprocess failure
+   │   └── RetryExhaustedError        # Retries exhausted
+   ├── ValidationError                # Input validation failure
+   ├── FileOperationError             # File I/O failure
+   ├── CodeAnalysisError              # Static/code analysis failure
+   ├── EvaluationError                # Metric/evaluation failure
+   └── ReportingError                 # Reporting/visualization failure
 
 Context Manager Pattern
 -----------------------

--- a/docs/source/calibration.rst
+++ b/docs/source/calibration.rst
@@ -44,7 +44,7 @@ Common parameters for calibration:
 
 .. code-block:: yaml
 
-   SETTINGS_SUMMA_PARAMS_TO_CALIBRATE:
+   PARAMS_TO_CALIBRATE:
      - k_snow          # snow thermal conductivity
      - fcapil          # capillary fringe thickness
      - newSnowDenMin   # minimum new snow density
@@ -90,9 +90,8 @@ Robust global optimizer. Recommended for most applications.
    OPTIMIZATION_ALGORITHM: DE
    POPULATION_SIZE: 48
    NUMBER_OF_ITERATIONS: 30
-   DE_STRATEGY: best1bin
-   DE_MUTATION_FACTOR: 0.5
-   DE_CROSSOVER_PROB: 0.7
+   DE_SCALING_FACTOR: 0.5
+   DE_CROSSOVER_RATE: 0.9
 
 **Dynamically Dimensioned Search (DDS)**
 
@@ -113,9 +112,9 @@ Good for continuous optimization problems.
    OPTIMIZATION_ALGORITHM: PSO
    POPULATION_SIZE: 30
    NUMBER_OF_ITERATIONS: 50
-   PSO_INERTIA: 0.9
-   PSO_COGNITIVE: 2.0
-   PSO_SOCIAL: 2.0
+   PSO_INERTIA_WEIGHT: 0.7
+   PSO_COGNITIVE_PARAM: 1.5
+   PSO_SOCIAL_PARAM: 1.5
 
 **Multi-Objective (NSGA-II)**
 
@@ -124,7 +123,8 @@ For multiple competing objectives.
 .. code-block:: yaml
 
    OPTIMIZATION_ALGORITHM: NSGA-II
-   OPTIMIZATION_METRICS: [KGE, NSE, PBIAS]
+   NSGA2_PRIMARY_METRIC: KGE
+   NSGA2_SECONDARY_METRIC: NSE
    POPULATION_SIZE: 100
    NUMBER_OF_ITERATIONS: 50
 
@@ -144,60 +144,29 @@ Available metrics:
 - **PBIAS** — Percent Bias
 - **R2** — Coefficient of Determination
 
-**Multi-Objective**
+**Multi-Objective (NSGA-II / MOEA/D)**
+
+Multi-objective algorithms optimize two metrics simultaneously:
 
 .. code-block:: yaml
 
-   OPTIMIZATION_METRICS: [KGE, NSE, PBIAS]
-   MULTI_OBJECTIVE_WEIGHTS: [0.5, 0.3, 0.2]
+   OPTIMIZATION_ALGORITHM: NSGA-II
+   NSGA2_PRIMARY_METRIC: KGE
+   NSGA2_SECONDARY_METRIC: NSE
 
-**Custom Objectives**
+**Multivariate Objective**
 
-Define custom objective functions:
-
-.. code-block:: yaml
-
-   CUSTOM_OBJECTIVE: peak_weighted_kge
-   PEAK_WEIGHT_THRESHOLD: 0.9  # 90th percentile
-   PEAK_WEIGHT_FACTOR: 2.0
-
-Advanced Calibration
---------------------
-
-**Distributed Calibration**
-
-Calibrate spatially distributed parameters:
+Combine multiple target variables with per-variable weights and metrics:
 
 .. code-block:: yaml
 
-   DISTRIBUTED_CALIBRATION: true
-   SPATIAL_AGGREGATION: hru  # or 'basin', 'elevation_bands'
-   PARAMETER_REGIONALIZATION:
-     - elevation
-     - slope
-     - land_cover
-
-**Multi-Model Calibration**
-
-Calibrate multiple models simultaneously:
-
-.. code-block:: yaml
-
-   MODELS_TO_CALIBRATE: [SUMMA, FUSE]
-   ENSEMBLE_WEIGHTING: performance  # or 'equal', 'bayesian'
-
-**Temporal Calibration**
-
-Different parameters for different seasons:
-
-.. code-block:: yaml
-
-   TEMPORAL_CALIBRATION:
-     winter: [k_snow, newSnowDenMin]
-     summer: [theta_sat, vGn_alpha]
-   SEASON_DEFINITIONS:
-     winter: "12-01,03-31"
-     summer: "06-01,09-30"
+   OBJECTIVE_FUNCTION: MULTIVARIATE
+   OBJECTIVE_METRICS:
+     streamflow: KGE
+     swe: NSE
+   OBJECTIVE_WEIGHTS:
+     streamflow: 0.7
+     swe: 0.3
 
 Calibration Execution
 ---------------------
@@ -225,13 +194,13 @@ Calibration Execution
    sf = SYMFLUENCE('my_project.yaml')
 
    # Run calibration step
-   sf.run_calibration()
+   sf.run_individual_steps(['calibrate_model'])
 
    # Or run the optimization manager directly
-   from symfluence.optimization import OptimizationManager
+   from symfluence.optimization.optimization_manager import OptimizationManager
 
    opt_manager = OptimizationManager(config, logger)
-   results = opt_manager.run_optimization()
+   results = opt_manager.run_optimization_workflow()
 
    # Get best parameters from results
    best_params = results.get('best_parameters', {})
@@ -249,34 +218,17 @@ Calibration produces:
 - ``objective_history.png`` — Convergence plot
 - ``parameter_sensitivity.csv`` — Sensitivity analysis
 
-**Performance Metrics**
-
-.. code-block:: yaml
-
-   EVALUATION_METRICS:
-     - KGE
-     - NSE
-     - RMSE
-     - PBIAS
-     - R2
-     - peak_timing_error
-     - volume_error
-
 **Validation**
 
-Always validate on independent period:
-
-.. code-block:: yaml
-
-   VALIDATION_PERIOD: "2019-01-01,2019-12-31"
-   SPLIT_SAMPLE_TEST: true
+Performance on the independent ``EVALUATION_PERIOD`` is reported automatically
+alongside the calibration-period score using ``OPTIMIZATION_METRIC``.
 
 Best Practices
 --------------
 
 1. **Parameter Bounds**
 
-   Set realistic parameter ranges:
+   Override default parameter ranges where needed:
 
    .. code-block:: yaml
 
@@ -284,27 +236,13 @@ Best Practices
         k_snow: [0.01, 1.0]
         theta_sat: [0.3, 0.6]
 
-2. **Convergence Criteria**
+2. **Computational Efficiency**
+
+   Run trials in parallel across worker processes:
 
    .. code-block:: yaml
 
-      CONVERGENCE_TOLERANCE: 1e-6
-      STAGNATION_GENERATIONS: 10
-
-3. **Computational Efficiency**
-
-   .. code-block:: yaml
-
-      PARALLEL_CALIBRATION: true
-      N_CORES: 16
-      BATCH_SIZE: 8
-
-4. **Robustness Testing**
-
-   .. code-block:: yaml
-
-      MONTE_CARLO_RUNS: 100
-      BOOTSTRAP_VALIDATION: true
+      NUM_PROCESSES: 16
 
 Troubleshooting
 ---------------
@@ -313,16 +251,8 @@ Troubleshooting
 
 - **Slow convergence**: Increase population size or iterations
 - **Parameter bounds**: Check realistic ranges for your domain
-- **Memory issues**: Reduce batch size or use distributed computing
+- **Memory issues**: Reduce the number of parallel processes
 - **Poor performance**: Verify observation data quality
-
-**Debugging**
-
-.. code-block:: yaml
-
-   DEBUG_CALIBRATION: true
-   SAVE_INTERMEDIATE_RESULTS: true
-   PLOT_PARAMETER_EVOLUTION: true
 
 Example Workflows
 -----------------
@@ -345,13 +275,12 @@ Example Workflows
 
    CALIBRATION_PERIOD: "2010-01-01,2015-12-31"
    EVALUATION_PERIOD: "2016-01-01,2018-12-31"
-   VALIDATION_PERIOD: "2019-01-01,2021-12-31"
    PARAMS_TO_CALIBRATE: [alpha, beta, k_storage, qbrate_2c]
    OPTIMIZATION_ALGORITHM: NSGA-II
-   OPTIMIZATION_METRICS: [KGE, NSE, PBIAS]
+   NSGA2_PRIMARY_METRIC: KGE
+   NSGA2_SECONDARY_METRIC: NSE
    POPULATION_SIZE: 100
    NUMBER_OF_ITERATIONS: 100
-   SPLIT_SAMPLE_TEST: true
 
 ---
 

--- a/docs/source/cli_reference.rst
+++ b/docs/source/cli_reference.rst
@@ -16,7 +16,8 @@ Overview
 
 The CLI follows a two-level hierarchical structure:
 
-- **Level 1**: Command categories (workflow, project, binary, config, job, example, agent, gui, data)
+- **Level 1**: Command categories (workflow, project, binary, config, job, example, agent,
+  gui, tui, data, fews, list) plus the top-level ``doctor`` command
 - **Level 2**: Specific actions within each category
 
 Basic usage:
@@ -89,22 +90,27 @@ Execute a single workflow step.
 
 **Available Steps:**
 
-1. ``setup_project`` - Initialize project structure
-2. ``create_pour_point`` - Create pour point shapefile
-3. ``acquire_attributes`` - Download geospatial attributes
-4. ``define_domain`` - Define hydrological domain
-5. ``discretize_domain`` - Discretize into HRUs
-6. ``process_observed_data`` - Process observations
-7. ``acquire_forcings`` - Acquire meteorological forcing
-8. ``model_agnostic_preprocessing`` - Model-agnostic preprocessing
-9. ``model_specific_preprocessing`` - Model-specific setup
-10. ``run_model`` - Execute hydrological model
-11. ``calibrate_model`` - Run parameter calibration
-12. ``run_emulation`` - Run emulation optimization
-13. ``run_benchmarking`` - Run benchmarking analysis
-14. ``run_decision_analysis`` - Run decision analysis
-15. ``run_sensitivity_analysis`` - Run sensitivity analysis
-16. ``postprocess_results`` - Postprocess results
+The canonical step names, in execution order, are:
+
+- ``setup_project`` - Initialize project structure and shapefiles
+- ``create_pour_point`` - Create pour point shapefile from coordinates
+- ``acquire_attributes`` - Download and process geospatial attributes
+- ``define_domain`` - Define hydrological domain boundaries
+- ``discretize_domain`` - Discretize domain into HRUs or other units
+- ``process_observed_data`` - Process observational data (streamflow, etc.)
+- ``acquire_forcings`` - Acquire meteorological forcing data
+- ``model_agnostic_preprocessing`` - Model-agnostic preprocessing
+- ``build_model_ready_store`` - Build model-ready forcing/attributes/observations store
+- ``model_specific_preprocessing`` - Model-specific input setup
+- ``run_model`` - Execute the hydrological model
+- ``postprocess_results`` - Postprocess and finalize results
+- ``calibrate_model`` - Run calibration / parameter optimization
+- ``run_benchmarking`` - Run benchmarking analysis
+- ``run_decision_analysis`` - Run decision analysis for model comparison
+- ``run_sensitivity_analysis`` - Run sensitivity analysis
+
+This list (and the supported short aliases) can drift as the framework evolves;
+run ``symfluence workflow list-steps`` for the authoritative, up-to-date set.
 
 **Example:**
 
@@ -373,6 +379,32 @@ Validate system environment.
 
    symfluence config validate-env
 
+config update
+-------------
+
+Update / migrate a configuration file to the current schema.
+
+.. code-block:: bash
+
+   symfluence config update CONFIG_FILE [--interactive]
+
+config resolve
+--------------
+
+Resolve a configuration through the full 5-layer hierarchy and print the
+effective values (useful for debugging defaults, env overrides, and aliases).
+
+.. code-block:: bash
+
+   symfluence config resolve [--config CONFIG] [--flat] [--json] [--diff] [--section SECTION]
+
+**Options:**
+
+- ``--flat``: Print the flat (legacy) key form instead of nested
+- ``--json``: Emit JSON
+- ``--diff``: Show only values that differ from the defaults
+- ``--section SECTION``: Restrict output to a single config section
+
 Job Commands
 ============
 
@@ -446,31 +478,37 @@ List available example notebooks.
 Agent Commands
 ==============
 
-Interactive AI agent interface.
+Hand off to an installed coding-agent CLI (Claude Code, Codex, Gemini, ...) primed
+with the SYMFLUENCE skills. SYMFLUENCE does not ship its own language model — it
+detects an installed agent CLI, exposes the SYMFLUENCE skills to it, and replaces
+itself with that agent. See :doc:`agent_guide` for the full walkthrough.
 
-agent start
------------
+agent launch
+------------
 
-Start interactive AI agent mode.
-
-.. code-block:: bash
-
-   symfluence agent start [--config CONFIG] [--verbose]
-
-agent run
----------
-
-Execute a single agent prompt.
+Launch the agent. With no prompt it starts an interactive session; with a prompt
+it runs once and exits (handy in scripts).
 
 .. code-block:: bash
 
-   symfluence agent run PROMPT [--config CONFIG] [--verbose]
+   # Interactive session (run from your project directory)
+   symfluence agent launch
 
-**Example:**
+   # One-shot prompt
+   symfluence agent launch "add an MSWEP forcing data handler"
 
-.. code-block:: bash
+   # Forward extra flags to the underlying CLI after --
+   symfluence agent launch -- --model claude-sonnet-4-6
 
-   symfluence agent run "What is the current SUMMA configuration?" --config config.yaml
+CLI selection and skill exposure are controlled by environment variables
+(``SYMFLUENCE_AGENT_CLI``, ``SYMFLUENCE_NO_SKILLS``); see :doc:`agent_guide`.
+
+Deprecated aliases
+~~~~~~~~~~~~~~~~~~~
+
+``symfluence agent start`` and ``symfluence agent run PROMPT`` are deprecated aliases
+for ``agent launch`` (interactive and one-shot respectively) and will be removed in a
+future release. Their ``--config`` / ``--verbose`` flags are deprecated and ignored.
 
 GUI Commands
 ============
@@ -504,6 +542,24 @@ Start the SYMFLUENCE web interface.
 
    # Launch with a demo configuration
    symfluence gui launch --demo bow
+
+TUI Commands
+============
+
+Launch the interactive terminal user interface.
+
+tui launch
+----------
+
+Start the SYMFLUENCE interactive terminal UI.
+
+.. code-block:: bash
+
+   symfluence tui launch [--demo NAME] [--config CONFIG]
+
+**Options:**
+
+- ``--demo NAME``: Load a built-in demo (e.g., "bow" for Bow at Banff)
 
 Data Commands
 =============
@@ -570,6 +626,94 @@ Show details about a specific dataset.
 .. code-block:: bash
 
    symfluence data info era5
+
+List Commands
+=============
+
+Introspect the live registry and config schema to discover what is available
+right now (models, datasets, optimizers, config keys, etc.). Because the catalog
+is read from the registry, it never goes stale.
+
+list
+----
+
+.. code-block:: bash
+
+   # Show every catalog and its count
+   symfluence list
+
+   # List the entries for one kind
+   symfluence list KIND
+
+**Kinds:** ``models``, ``forcings``, ``observations``, ``optimizers``,
+``targets``, ``metrics``, ``presets``, ``templates``, ``steps``, ``config-keys``.
+
+**Examples:**
+
+.. code-block:: bash
+
+   symfluence list models
+   symfluence list forcings
+   symfluence list config-keys
+
+Doctor Command
+==============
+
+Run comprehensive system diagnostics (environment, path resolution, and binary
+checks). This is a top-level command (distinct from ``binary doctor``, which is
+scoped to installed binaries).
+
+.. code-block:: bash
+
+   symfluence doctor
+
+FEWS Commands
+=============
+
+Delft-FEWS General Adapter operations — run pre/post processing and launch
+openFEWS with SYMFLUENCE adapter support.
+
+fews pre
+--------
+
+Run the FEWS pre-adapter (import forcing, generate config).
+
+.. code-block:: bash
+
+   symfluence fews pre --run-info run_info.xml [--format {pi-xml,netcdf-cf}] [--id-map PATH] [--config CONFIG]
+
+fews post
+---------
+
+Run the FEWS post-adapter (export results, write diagnostics).
+
+.. code-block:: bash
+
+   symfluence fews post --run-info run_info.xml [--format {pi-xml,netcdf-cf}] [--id-map PATH] [--config CONFIG]
+
+fews run
+--------
+
+Run the full FEWS adapter cycle (pre -> model -> post).
+
+.. code-block:: bash
+
+   symfluence fews run --run-info run_info.xml [--format {pi-xml,netcdf-cf}] [--id-map PATH] [--config CONFIG]
+
+fews launch
+-----------
+
+Launch openFEWS with SYMFLUENCE adapter support.
+
+.. code-block:: bash
+
+   symfluence fews launch [--port PORT] [--no-browser] [--config CONFIG]
+
+**Options (pre/post/run):**
+
+- ``--run-info PATH``: Path to ``run_info.xml`` (required)
+- ``--format {pi-xml,netcdf-cf}``: Data exchange format (default: netcdf-cf)
+- ``--id-map PATH``: Variable ID mapping YAML file
 
 Exit Codes
 ==========

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,6 @@
 # Configuration file for the Sphinx documentation builder.
+from __future__ import annotations
+
 import os
 import sys
 
@@ -161,7 +163,7 @@ source_suffix = {
 }
 
 html_context = {
-    "github_user": "DarriEy",
+    "github_user": "symfluence-org",
     "github_repo": "SYMFLUENCE",
     "github_version": "main",
     "doc_path": "docs/source",

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -85,17 +85,10 @@ Forcing data and meteorological drivers are defined here.
 .. code-block:: yaml
 
    FORCING_DATASET: ERA5
-   FORCING_VARIABLES:
-     - airtemp
-     - windspd
-     - pptrate
-     - spechum
-     - SWRadAtm
-     - LWRadAtm
+   FORCING_VARIABLES: default            # comma-separated names, or "default"
    FORCING_TIME_STEP_SIZE: 3600
    APPLY_LAPSE_RATE: True
    LAPSE_RATE: -6.5
-   DATA_ACQUIRE: HPC                     # HPC | supplied | local
 
 Optional extensions:
 - **EM-Earth** integration for high-resolution precipitation/temperature downscaling
@@ -131,7 +124,7 @@ Select hydrologic and routing models, and configure per-model parameters.
 ### NextGen
 .. code-block:: yaml
 
-   NGEN_BMI_MODULES: [cfe, noah, pet]
+   NGEN_MODULES_SELECTED: "SLOTH,PET,CFE"
    NGEN_NOAH_PARAMS_TO_CALIBRATE: [bexp, dksat, psisat, refkdt]
    NGEN_ACTIVE_CATCHMENT_ID: 1002
 
@@ -373,9 +366,9 @@ Forcing Data Parameters
      - required
      - Forcing dataset source (ERA5, RDRS, CARRA, CERRA, CONUS404, etc.)
    * - FORCING_VARIABLES
-     - list
-     - dataset-specific
-     - List of meteorological variables to acquire
+     - string
+     - "default"
+     - Comma-separated meteorological variables to acquire, or "default"
    * - FORCING_TIME_STEP_SIZE
      - integer
      - 3600
@@ -392,14 +385,6 @@ Forcing Data Parameters
      - float
      - -6.5
      - Temperature lapse rate (°C/km)
-   * - DATA_ACQUIRE
-     - string
-     - "HPC"
-     - Data acquisition method (HPC, supplied, local)
-   * - FORCING_SHAPE_ID_NAME
-     - string
-     - "ID"
-     - Shapefile attribute for forcing station IDs
 
 Model Selection Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -500,7 +485,7 @@ GR Model Parameters
      - string
      - "auto"
      - Spatial configuration (lumped, distributed, auto)
-   * - GR_MODEL_VARIANT
+   * - GR_MODEL_TYPE
      - string
      - "GR4J"
      - GR model variant (GR4J, GR5J, GR6J)
@@ -520,18 +505,10 @@ HYPE Model Parameters
      - Type
      - Default
      - Description
-   * - HYPE_TIMESHIFT
-     - integer
-     - 0
-     - Time zone adjustment in hours
    * - HYPE_SPINUP_DAYS
      - integer
      - 365
      - Number of spinup days
-   * - HYPE_FRAC_THRESHOLD
-     - float
-     - 0.1
-     - Minimum class fraction to include
 
 mizuRoute Parameters
 ~~~~~~~~~~~~~~~~~~~~
@@ -608,25 +585,13 @@ Calibration Parameters
      - integer
      - 100
      - Maximum optimization iterations
-   * - PERTURBATION_FACTOR
-     - float
-     - 0.2
-     - DDS perturbation factor (0-1)
-   * - MUTATION_RATE
-     - float
-     - 0.5
-     - DE mutation rate
-   * - CROSSOVER_RATE
-     - float
-     - 0.7
-     - DE crossover rate
    * - CALIBRATION_TIMESTEP
      - string
      - "daily"
      - Timestep for calibration evaluation (daily, hourly)
 
-Output and Visualization Parameters
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Output Parameters
+~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
@@ -640,22 +605,6 @@ Output and Visualization Parameters
      - string
      - auto
      - Custom output directory (default: project_dir)
-   * - SAVE_INTERMEDIATE_RESULTS
-     - boolean
-     - True
-     - Save intermediate workflow outputs
-   * - GENERATE_PLOTS
-     - boolean
-     - True
-     - Generate visualization plots
-   * - PLOT_FORMAT
-     - string
-     - "png"
-     - Plot file format (png, pdf, svg)
-   * - PLOT_DPI
-     - integer
-     - 300
-     - Plot resolution in DPI
 
 Path Parameters
 ~~~~~~~~~~~~~~~
@@ -672,10 +621,6 @@ Path Parameters
      - string
      - auto
      - Path to catchment shapefile
-   * - CATCHMENT_NAME
-     - string
-     - auto
-     - Catchment shapefile name
    * - RIVER_NETWORK_SHP_PATH
      - string
      - auto
@@ -712,14 +657,6 @@ HPC Parameters
      - string
      - "8G"
      - Memory allocation per job
-   * - SETTINGS_SUMMA_PARTITION
-     - string
-     - "compute"
-     - SLURM partition name
-   * - USE_SLURM
-     - boolean
-     - False
-     - Enable SLURM job submission
 
 ---
 
@@ -753,98 +690,6 @@ Validation and Best Practices
 
 Experimental Model Parameters
 -----------------------------
-
-CFuse Parameters (Experimental)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. warning::
-
-   CFuse is experimental. API may change without notice.
-
-.. list-table::
-   :header-rows: 1
-   :widths: 30 15 15 40
-
-   * - Parameter
-     - Type
-     - Default
-     - Description
-   * - CFUSE_MODEL_STRUCTURE
-     - string
-     - "prms"
-     - Model structure (prms, sacramento, topmodel, vic, arno)
-   * - CFUSE_SPATIAL_MODE
-     - string
-     - "auto"
-     - Spatial mode (lumped, distributed, auto)
-   * - CFUSE_ENABLE_SNOW
-     - boolean
-     - true
-     - Enable snow processes
-   * - CFUSE_WARMUP_DAYS
-     - integer
-     - 365
-     - Spinup period in days
-   * - CFUSE_USE_NATIVE_GRADIENTS
-     - boolean
-     - true
-     - Use Enzyme AD for gradients
-   * - CFUSE_USE_GRADIENT_CALIBRATION
-     - boolean
-     - true
-     - Use gradient-based optimization
-   * - CFUSE_CALIBRATION_METRIC
-     - string
-     - "KGE"
-     - Objective function (KGE, NSE)
-   * - CFUSE_DEVICE
-     - string
-     - "cpu"
-     - PyTorch device (cpu, cuda)
-
-JFuse Parameters (Experimental)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. warning::
-
-   JFuse is experimental. API may change without notice.
-
-.. list-table::
-   :header-rows: 1
-   :widths: 30 15 15 40
-
-   * - Parameter
-     - Type
-     - Default
-     - Description
-   * - JFUSE_MODEL_CONFIG_NAME
-     - string
-     - "prms_gradient"
-     - Model configuration (prms_gradient, max_gradient, etc.)
-   * - JFUSE_SPATIAL_MODE
-     - string
-     - "auto"
-     - Spatial mode (lumped, distributed, auto)
-   * - JFUSE_JIT_COMPILE
-     - boolean
-     - true
-     - Enable JAX JIT compilation
-   * - JFUSE_USE_GPU
-     - boolean
-     - false
-     - Use GPU acceleration
-   * - JFUSE_WARMUP_DAYS
-     - integer
-     - 365
-     - Spinup period in days
-   * - JFUSE_USE_GRADIENT_CALIBRATION
-     - boolean
-     - true
-     - Use gradient-based optimization
-   * - JFUSE_CALIBRATION_METRIC
-     - string
-     - "KGE"
-     - Objective function (KGE, NSE)
 
 WM-Fire Parameters (RHESSys Fire Module)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/developer_guide.rst
+++ b/docs/source/developer_guide.rst
@@ -45,7 +45,7 @@ SYMFLUENCE follows a modular, manager-based architecture with clear separation o
 **Design Patterns**
 
 1. **Manager Pattern**: Each major subsystem has a manager class that coordinates operations
-2. **Registry Pattern**: Models self-register using decorators (see :doc:`api`)
+2. **Registry Pattern**: Models self-register via ``model_manifest()`` and the unified ``R`` facade (see :doc:`api`)
 3. **Mixin Pattern**: Common functionality shared through mixins
 4. **Typed Configuration**: Pydantic models for configuration validation
 
@@ -495,7 +495,8 @@ Use Google-style docstrings:
 
    # Local imports
    from symfluence.core.base_manager import BaseManager
-   from symfluence.models.registry import ModelRegistry
+   from symfluence.core.registries import R
+   from symfluence.core.registry import model_manifest
 
 ---
 
@@ -508,7 +509,7 @@ Key points:
 
 - Uses Pydantic for type validation
 - Immutable configuration objects
-- Typed configuration models in ``src/symfluence/core/config/models.py``
+- Typed configuration models in the ``src/symfluence/core/config/models/`` package
 - Legacy dict support for backward compatibility
 
 ---

--- a/docs/source/docker.rst
+++ b/docs/source/docker.rst
@@ -15,9 +15,9 @@ Method Matrix
 -------------
 
 All install paths build successfully on both ``linux/amd64`` and
-``linux/arm64``. Numbers count model binaries produced by
-``symfluence binary install`` (out of 12, except npm which bundles a different
-prebuilt set).
+``linux/arm64``. Build status reflects the model binaries produced by
+``symfluence binary install`` (npm bundles a different prebuilt set). Run
+``symfluence binary validate`` inside a built image for the exact set available.
 
 .. list-table::
    :header-rows: 1
@@ -29,37 +29,37 @@ prebuilt set).
      - Dockerfile.fixed
    * - pip
      - ``python:3.11-slim-bookworm``
-     - builds; 11/12 :sup:`1`
-     - builds; 11/12 :sup:`1`
+     - builds :sup:`1`
+     - builds :sup:`1`
    * - uv
      - ``python:3.11-slim-bookworm``
-     - builds; 11/12 :sup:`1`
-     - builds; 11/12 :sup:`1`
+     - builds :sup:`1`
+     - builds :sup:`1`
    * - uv-tool
      - ``python:3.11-slim-bookworm``
-     - builds; 11/12 :sup:`1`
-     - builds; 11/12 :sup:`1`
+     - builds :sup:`1`
+     - builds :sup:`1`
    * - pipx
      - ``python:3.11-slim-bookworm``
-     - builds; 11/12 :sup:`1`
-     - builds; 11/12 :sup:`1`
+     - builds :sup:`1`
+     - builds :sup:`1`
    * - npm
      - ``node:20-bookworm-slim``
      - builds; runtime-only (prebuilt binaries)
-     - 21/23 binaries (ngiab + troute not bundled)
+     - builds (ngiab + troute not bundled)
    * - conda
      - ``condaforge/miniforge3:24.11.3-2``
-     - builds; 11/12 :sup:`1`
-     - builds; 11/12 :sup:`1` (single-source conda toolchain)
+     - builds :sup:`1`
+     - builds :sup:`1` (single-source conda toolchain)
    * - source
      - ``python:3.11-slim-bookworm``
-     - builds; 11/12 :sup:`1` (bootstrap stage)
-     - builds; 12/12 (manual stage)
+     - builds :sup:`1` (bootstrap stage)
+     - builds (manual stage)
 
-:sup:`1` The 1-of-12 gap is ``ngen``, which the wrapper marks as failed despite
-the binary being built. This is a known false-negative in published
-symfluence's ``_build.sh`` — fixed on a development branch and landing in the
-next release.
+:sup:`1` ``ngen`` is the one binary the wrapper marks as failed despite the
+binary being built — a known false-negative in published symfluence's
+``_build.sh``, fixed on a development branch and landing in the next release.
+The manual ``source`` stage builds it cleanly.
 
 Build & Run
 -----------
@@ -143,8 +143,8 @@ and considerably longer under QEMU.
 Which One Should I Use?
 -----------------------
 
-- **Most users**: ``pip`` or ``uv``. Both produce 12/12 working binaries on
-  Linux. uv is faster to install.
+- **Most users**: ``pip`` or ``uv``. Both produce the full set of working
+  binaries on Linux. uv is faster to install.
 - **Need pre-compiled binaries** (no host build toolchain): ``npm``. Linux
   x86_64 and macOS ARM64 only.
 - **Developing on the project**: ``source --target manual`` so the venv contains

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -38,7 +38,7 @@ Running the Examples
    .. code-block:: bash
 
       cd examples/02_watershed_modelling/
-      jupyter notebook 02b_basin_semidistributed.ipynb
+      jupyter notebook 02b_basin_semi_distributed.ipynb
 
 3. Run the notebook or script as described inside.
 

--- a/docs/source/models/index.rst
+++ b/docs/source/models/index.rst
@@ -23,7 +23,7 @@ physical models to data-driven machine learning approaches.
 
       Bucket and storage-based hydrological models.
 
-      **FUSE** · **cFUSE** · **jFUSE** · **GR** · **HBV**
+      **FUSE** · **GR** · **HBV**
 
    .. grid-item-card:: Machine Learning
       :link: ml-models
@@ -39,7 +39,7 @@ physical models to data-driven machine learning approaches.
 
       Modular frameworks and domain-specific models.
 
-      **NextGen** · **WMFire**
+      **NextGen**
 
 ----
 
@@ -71,8 +71,6 @@ Simplified representations using storage-based approaches.
    :maxdepth: 1
 
    model_fuse
-   model_cfuse
-   model_jfuse
    model_gr
    model_hbv
 
@@ -104,4 +102,3 @@ Modular frameworks and specialized applications.
    :maxdepth: 1
 
    model_ngen
-   model_wmfire

--- a/docs/source/models/model_gnn.rst
+++ b/docs/source/models/model_gnn.rst
@@ -383,7 +383,7 @@ River network with multiple gauged basins:
 
    # Data split
    CALIBRATION_PERIOD: [2010, 2017]  # Training + validation
-   VALIDATION_PERIOD: [2018, 2020]   # Testing
+   EVALUATION_PERIOD: "2018-01-01,2020-12-31"   # Testing
 
 Run:
 
@@ -453,9 +453,7 @@ Train on one network, apply to another:
 
    HYDROLOGICAL_MODEL: GNN
    GNN_EPOCHS: 300
-
-   # Save model
-   GNN_SAVE_MODEL: true
+   # The trained model is saved automatically under models/GNN/
 
 .. code-block:: yaml
 
@@ -468,7 +466,6 @@ Train on one network, apply to another:
 
    # Load pre-trained model
    GNN_LOAD: true
-   GNN_PRETRAINED_MODEL: ../colorado_river/models/GNN/best_model.pt
 
    # Fine-tune with available data
    GNN_EPOCHS: 50

--- a/docs/source/models/model_gr.rst
+++ b/docs/source/models/model_gr.rst
@@ -406,7 +406,7 @@ Calibrate GR on multiple basins simultaneously:
 
    # Calibrate using multi-site objective
    OPTIMIZATION_ALGORITHM: DDS
-   OPTIMIZATION_METRICS: [KGE, NSE, RMSE]
+   OBJECTIVE_METRICS: [KGE, NSE, RMSE]
 
 Regional GR Application
 -----------------------
@@ -542,7 +542,7 @@ Calibration Tips
    .. code-block:: yaml
 
       OPTIMIZATION_ALGORITHM: NSGA2
-      OPTIMIZATION_METRICS:
+      OBJECTIVE_METRICS:
         - KGE         # Streamflow fit
         - RMSE_snow   # Snow cover fit (if data available)
 

--- a/docs/source/models/model_hbv.rst
+++ b/docs/source/models/model_hbv.rst
@@ -799,7 +799,7 @@ Use ``simulate_ensemble`` for efficient parallel runs:
 
 .. code-block:: python
 
-   from symfluence.models.hbv.model import simulate_ensemble
+   from jhbv.model import simulate_ensemble
 
    # Run 100 parameter sets in parallel
    results = simulate_ensemble(

--- a/docs/source/models/model_hype.rst
+++ b/docs/source/models/model_hype.rst
@@ -555,7 +555,7 @@ Calibration Tips
 
    .. code-block:: yaml
 
-      OPTIMIZATION_METRICS: [NSE, KGE, RMSE_log]
+      OBJECTIVE_METRICS: [NSE, KGE, RMSE_log]
 
 5. **Start simple:**
 

--- a/docs/source/models/model_lstm.rst
+++ b/docs/source/models/model_lstm.rst
@@ -351,7 +351,7 @@ Simple basin-scale LSTM:
 
    # Data split
    CALIBRATION_PERIOD: [2010, 2017]  # 8 years training+val
-   VALIDATION_PERIOD: [2018, 2020]   # 3 years testing
+   EVALUATION_PERIOD: "2018-01-01,2020-12-31"   # 3 years testing
 
 Run:
 
@@ -395,9 +395,7 @@ Train on data-rich basin, transfer to ungauged basin:
    HYDROLOGICAL_MODEL: LSTM
 
    # (standard config...)
-
-   # Train and save model
-   LSTM_SAVE_MODEL: true  # Saves to models/LSTM/donor_basin.pt
+   # The trained model is saved automatically under models/LSTM/
 
 .. code-block:: yaml
 
@@ -408,7 +406,6 @@ Train on data-rich basin, transfer to ungauged basin:
 
    # Load pre-trained model
    LSTM_LOAD: true
-   LSTM_PRETRAINED_MODEL: ../donor_basin/models/LSTM/donor_basin.pt
 
    # Fine-tune (if any observations available)
    LSTM_EPOCHS: 50  # Short fine-tuning
@@ -425,9 +422,6 @@ LSTM on distributed domain:
    POUR_POINT_COORDS: [-115.0, 51.0]
 
    HYDROLOGICAL_MODEL: LSTM
-
-   # Train LSTM per subcatchment
-   LSTM_SPATIAL_MODE: distributed
 
    # Optional: Train through routing
    LSTM_TRAIN_THROUGH_ROUTING: true

--- a/docs/source/models/model_rhessys.rst
+++ b/docs/source/models/model_rhessys.rst
@@ -436,10 +436,6 @@ Full ecohydrological simulation:
    # config.yaml
    HYDROLOGICAL_MODEL: RHESSys
 
-   # Enable carbon and nitrogen cycles
-   RHESSYS_SIMULATE_CARBON: true
-   RHESSYS_SIMULATE_NITROGEN: true
-
    # Detailed vegetation representation
    DISCRETIZATION:
      landclass:
@@ -489,8 +485,7 @@ Multi-decade projections:
    FORCING_DATASET: CMIP6_SSP585
    FORCING_PERIOD: [2040, 2070]
 
-   # RHESSys will simulate vegetation response to changing climate
-   RHESSYS_SIMULATE_CARBON: true  # Dynamic vegetation
+   # RHESSys simulates dynamic vegetation response to changing climate
 
 Calibration Strategies
 ======================
@@ -561,7 +556,7 @@ Calibration Approach
 
    OPTIMIZATION_ALGORITHM: NSGA2
 
-   OPTIMIZATION_METRICS:
+   OBJECTIVE_METRICS:
      - KGE              # Streamflow
      - RMSE_snow        # Snow (if data available)
      - MAE_NPP          # Net Primary Productivity (if data available)

--- a/docs/source/models/model_summa.rst
+++ b/docs/source/models/model_summa.rst
@@ -567,7 +567,7 @@ For comprehensive performance:
 
    OPTIMIZATION_ALGORITHM: NSGA2  # Multi-objective algorithm
 
-   OPTIMIZATION_METRICS:
+   OBJECTIVE_METRICS:
      - KGE
      - NSE_log
      - RMSE

--- a/docs/source/routing/droute.rst
+++ b/docs/source/routing/droute.rst
@@ -178,7 +178,8 @@ Standard Workflow
 
 .. code-block:: python
 
-    from symfluence.models.droute import DRoutePreProcessor, DRouteRunner
+    from droute.preprocessor import DRoutePreProcessor
+    from droute.runner import DRouteRunner
 
     # Preprocessing (reuses mizuRoute topology if available)
     preprocessor = DRoutePreProcessor(config, logger)
@@ -193,7 +194,7 @@ Calibration with Gradients
 
 .. code-block:: python
 
-    from symfluence.models.droute.calibration import DRouteWorker
+    from droute.calibration.worker import DRouteWorker
 
     worker = DRouteWorker(config, logger)
 

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -255,7 +255,7 @@ Integration Test Example
 .. code-block:: python
 
    import pytest
-   from symfluence.models.summa import SUMMAPreProcessor
+   from symfluence.models.summa import SummaPreProcessor
 
    pytestmark = [
        pytest.mark.integration,
@@ -271,7 +271,7 @@ Integration Test Example
        config = bow_test_data['config']
        config['EXPERIMENT_OUTPUT_SUMMA'] = str(tmp_path)
 
-       preprocessor = SUMMAPreProcessor(config, logger=None)
+       preprocessor = SummaPreProcessor(config, logger=None)
        preprocessor.run_preprocessing()
 
        assert (tmp_path / 'forcing').exists()
@@ -641,108 +641,45 @@ Quick Reference
 Contributing via the Agent
 ==========================
 
-SYMFLUENCE includes an AI-powered agent that can assist with code contributions.
-The agent can analyze code, propose modifications, run tests, and create PR proposals.
+SYMFLUENCE does not ship its own AI agent. Instead, ``symfluence agent launch``
+hands off to an installed coding-agent CLI (Claude Code, Codex, Gemini, ...),
+primed with the packaged SYMFLUENCE *skills*. That agent brings its own editing,
+search, test-running, and git tooling — SYMFLUENCE just makes sure it knows how to
+work with this codebase. See :doc:`agent_guide` for the full walkthrough.
 
-Starting the Agent
-------------------
+Launching the Agent
+-------------------
 
 .. code-block:: bash
 
-   # Interactive mode
-   symfluence agent start
+   # Interactive session (run from your project / repo directory)
+   symfluence agent launch
 
-   # Single prompt mode
-   symfluence agent run "Help me fix the bug in the config loader"
+   # One-shot prompt
+   symfluence agent launch "Help me fix the bug in the config loader"
 
-Agent-Assisted Workflow
+Install one supported CLI and set the matching API key (e.g. ``ANTHROPIC_API_KEY``
+for Claude Code); SYMFLUENCE detects the CLI on your ``PATH`` and exposes the skills
+to it. Override detection with ``SYMFLUENCE_AGENT_CLI`` and skip skill
+materialization with ``SYMFLUENCE_NO_SKILLS``.
+
+Skills for Contributors
 -----------------------
 
-The agent provides tools for a complete contribution workflow:
+The packaged skills cover both running and extending SYMFLUENCE — for example,
+``add-data-handler``, ``add-model-handler``, ``add-optimizer``, and
+``debug-calibration``. The agent consults the relevant skill when you ask it to
+work on a task, so it follows the framework's conventions (registration via
+``model_manifest()``, license headers, test layout, etc.).
 
-1. **Analyze Codebase**
-
-   .. code-block:: text
-
-      You: Analyze the codebase structure and find where config validation happens
-
-      Assistant: [Uses analyze_codebase tool]
-      The configuration validation is in src/symfluence/core/config/...
-
-2. **Read and Understand Code**
-
-   .. code-block:: text
-
-      You: Read the config loader implementation
-
-      Assistant: [Uses read_file tool]
-      Here's the config loader...
-
-3. **Propose Code Changes**
-
-   .. code-block:: text
-
-      You: Fix the validation bug by adding a null check
-
-      Assistant: [Uses propose_code_change tool]
-      I'll propose the following change:
-      - File: src/symfluence/core/config/loader.py
-      - Change: Add null check before processing
-      [Shows diff preview]
-
-4. **Run Tests**
-
-   .. code-block:: text
-
-      You: Run tests for the config module
-
-      Assistant: [Uses run_tests tool]
-      Running pytest -v -m "config"...
-      All tests passed!
-
-5. **Create PR Proposal**
-
-   .. code-block:: text
-
-      You: Create a PR for these changes
-
-      Assistant: [Uses create_pr_proposal tool]
-      Created PR proposal:
-      - Title: Fix null check in config loader
-      - Description: Adds validation...
-
-Agent Code Contribution Tools
+Best Practices with the Agent
 -----------------------------
 
-.. list-table::
-   :header-rows: 1
-   :widths: 30 70
-
-   * - Tool
-     - Purpose
-   * - ``read_file``
-     - Read source code with line numbers
-   * - ``list_directory``
-     - Browse repository structure
-   * - ``analyze_codebase``
-     - Analyze codebase structure
-   * - ``propose_code_change``
-     - Propose modifications (validates syntax, shows diff)
-   * - ``show_staged_changes``
-     - Display all staged changes
-   * - ``run_tests``
-     - Run pytest tests
-   * - ``create_pr_proposal``
-     - Create a PR proposal from staged changes
-
-Best Practices with Agent
--------------------------
-
 1. **Be Specific** - Describe the exact change you want
-2. **Review Diffs** - Always review proposed changes before accepting
-3. **Run Tests** - Ask the agent to run tests after changes
+2. **Review Diffs** - Always review the agent's changes before committing
+3. **Run Tests** - Ask the agent to run the relevant test markers after changes
 4. **Iterate** - Refine changes through conversation
-5. **Human Review** - All changes require human approval before committing
+5. **Human Review** - All changes require human review before merging
 
 See Also
 ========

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,7 +250,7 @@ symfluence_noahmp = "symfluence.models.noahmp:register"
 Homepage = "https://symfluence.org"
 Source = "https://github.com/symfluence-org/SYMFLUENCE"
 Issues = "https://github.com/symfluence-org/SYMFLUENCE/issues"
-Documentation = "https://symfluence.org/"
+Documentation = "https://symfluence.readthedocs.io"
 
 [tool.hatch.build.targets.sdist]
 include = [


### PR DESCRIPTION
## Summary

A documentation-accuracy pass: align README, root docs, and the Sphinx docs with the post-1.0-cleanup code, and **remove hardcoded counts that go stale** (point at the live registry / `symfluence list` instead of numbers). Docs-only — no code touched.

### Root docs
- **GOVERNANCE.md**: replaced the stale "27 models / 68 data handlers / 17 optimizers" counts with qualitative phrasing.
- **README.md**: fixed the invalid `project pour-point --definition semidistributed` example (→ `delineate`); `GR4J` → `GR`; added the real top-level packages (`agent/`, `gui/`, `tui/`, `fews/`, `coupling/`); count-free tests badge.
- **CONTRIBUTING.md**: `pip install -r requirements.txt` (no such file) → `pip install -e ".[dev]"`; `feature/` → `feat/`; SPDX header "Foundation" → "Team" (matches code).
- **pyproject.toml**: `[project.urls]` Documentation → readthedocs (canonical).

### Sphinx docs
- Rewrote the **removed `ModelRegistry` decorator API** → `model_manifest()` + the `R` facade (api / architecture / developer_guide).
- Fixed the **SYMFLUENCE facade API** docs: `project.system` (not `core.system`), `run_individual_steps([...])` (not invented per-step methods), `visualize_*` (not `plot_*`), `SYMFLUENCEError`.
- **cli_reference**: added the new `symfluence list`, switched the agent docs to `agent launch` (start/run shown as deprecated aliases), corrected the workflow-step list, added `tui`/`doctor`/`fews`.
- **testing.rst**: replaced the removed bespoke-agent section with the launcher model.
- Removed **fabricated config keys** from configuration/calibration and the model docs (each remaining key verified against the Pydantic schema); fixed external-package imports (`droute`, `jhbv`), broken toctree entries (CFuse/JFuse/WMFire), the example-notebook filename, the docker binary-count contradiction, and `conf.py` `github_user`.

(CLAUDE.md is gitignored/local, so its stale workflow-step references are fixed separately, outside this PR.)

---
Repo and code assistance from [Claude](https://claude.ai) (Anthropic).