### PR TITLE
Release 0.9.1: version bump to main

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symfluence",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "SYnergistic Modelling Framework for Linking and Unifying Earth-system Nexii for Computational Exploration - Pre-compiled hydrological modeling tools",
   "main": "index.js",
   "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       }
     },
     "node_modules/symfluence": {
-      "version": "0.8.1",
+      "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/symfluence/-/symfluence-0.8.1.tgz",
       "cpu": [
         "x64",

--- a/src/symfluence/symfluence_version.py
+++ b/src/symfluence/symfluence_version.py
@@ -8,4 +8,4 @@ Update this when cutting a release.
 # Semantic version (PEP 440-friendly)
 from __future__ import annotations
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/tools/npm/package.json
+++ b/tools/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symfluence",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Structure for Unifying Multiple Modeling Alternatives - Pre-compiled hydrological modeling tools",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Promotes the 0.9.1 version bump (#237) to main so the re-pushed v0.9.1 tag validates and the PyPI + npm publishes succeed. Repo and code assistance from [Claude](https://claude.ai) (Anthropic).